### PR TITLE
Test case for a potential bug in the polyglot engine.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ## Introduction
 
 Truffle is a framework for implementing languages as simple interpreters.
-Together with the [Graal compiler](http://github.com/OracleLabs/GraalVM),
+Together with the [Graal compiler](https://wiki.openjdk.java.net/display/Graal/Instructions),
 Truffle interpreters are automatically just-in-time compiled and programs
 running on top of them can reach performance of normal Java.
 


### PR DESCRIPTION
This test case fails to access the global object of SL.
It raises `IllegalStateException("Accessor.findLanguage access to vm")`, while it probably shouldn't.