### PR TITLE
Potential bug, can't call getEnv() before doing an eval()

### DIFF
--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/EngineTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/EngineTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import com.oracle.truffle.api.TruffleLanguage.Env;
 import com.oracle.truffle.api.source.Source;
 
 public class EngineTest {
@@ -95,6 +96,14 @@ public class EngineTest {
         AccessArray dupl();
 
         List<? extends Number> get(int index);
+    }
+
+    @Test
+    public void getEnvBeforeDoingAnyEval() {
+        PolyglotEngine vm = createBuilder().build();
+        PolyglotEngine.Language language1 = vm.getLanguages().get("application/x-test-import-export-1");
+        Env env = language1.getEnv(true);
+        assertNotNull(env);
     }
 
     @Test


### PR DESCRIPTION
This is a test case, for something that looks like an issue with initialization order.
The thread-local field for the VM/polyglot engine does not yet seem to be set when calling getEnv(.).