### PR TITLE
Enable passing of arguments to the polyglot engine

### DIFF
--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/EngineTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/EngineTest.java
@@ -124,7 +124,6 @@ public class EngineTest {
         assertEquals(3, arr[2].intValue());
     }
 
-
     @Test
     public void engineConfigBasicAccess() throws IOException {
         Builder builder = createBuilder();
@@ -228,6 +227,5 @@ public class EngineTest {
         Ctx ctx2 = language1.getGlobalObject().as(Ctx.class);
         assertNull(ctx2.env.getConfig().get("hello"));
     }
-
 
 }

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/EngineTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/EngineTest.java
@@ -121,7 +121,7 @@ public class EngineTest {
 
     @Test
     public void initializePolyglotEngineWithArguments() throws IOException {
-        PolyglotEngine vm = createBuilder().setArguments("application/x-test-import-export-1", new String[]{"1", "2"}).build();
+        PolyglotEngine vm = createBuilder().config("application/x-test-import-export-1", "cmd-line-args", new String[]{"1", "2"}).build();
         PolyglotEngine.Language language1 = vm.getLanguages().get("application/x-test-import-export-1");
 
         // TODO: remove once initialization issue is solved for
@@ -129,7 +129,7 @@ public class EngineTest {
         language1.eval(Source.fromText("return=arr", "get the array")).as(AccessArray.class);
 
         Env env = language1.getEnv(true);
-        String[] args = (String[]) env.getArguments().get("application/x-test-import-export-1");
+        String[] args = (String[]) env.getConfig().get("application/x-test-import-export-1").get("cmd-line-args");
         assertEquals("1", args[0]);
         assertEquals("2", args[1]);
     }

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/EngineTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/EngineTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 
 import org.junit.Test;
 
+import com.oracle.truffle.api.TruffleLanguage.Env;
 import com.oracle.truffle.api.source.Source;
 
 public class EngineTest {
@@ -116,5 +117,20 @@ public class EngineTest {
         assertEquals(1, arr[0].intValue());
         assertEquals(2, arr[1].intValue());
         assertEquals(3, arr[2].intValue());
+    }
+
+    @Test
+    public void initializePolyglotEngineWithArguments() throws IOException {
+        PolyglotEngine vm = createBuilder().setArguments(new String[]{"1", "2"}).build();
+        PolyglotEngine.Language language1 = vm.getLanguages().get("application/x-test-import-export-1");
+
+        // TODO: remove once initialization issue is solved for
+        // https://github.com/graalvm/truffle/pull/9
+        language1.eval(Source.fromText("return=arr", "get the array")).as(AccessArray.class);
+
+        Env env = language1.getEnv(true);
+        String[] args = env.getArguments();
+        assertEquals("1", args[0]);
+        assertEquals("2", args[1]);
     }
 }

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/EngineTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/EngineTest.java
@@ -33,6 +33,8 @@ import org.junit.Test;
 
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.vm.ImplicitExplicitExportTest.Ctx;
+import static com.oracle.truffle.api.vm.ImplicitExplicitExportTest.L1;
+import static com.oracle.truffle.api.vm.ImplicitExplicitExportTest.L1_ALT;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import com.oracle.truffle.api.vm.PolyglotEngine.Builder;
@@ -129,7 +131,7 @@ public class EngineTest {
         builder.config("application/x-test-import-export-1", "cmd-line-args", new String[]{"1", "2"});
         builder.config("application/x-test-import-export-2", "hello", "world");
         PolyglotEngine vm = builder.build();
-        
+
         PolyglotEngine.Language language1 = vm.getLanguages().get("application/x-test-import-export-1");
 
         assertNotNull("Lang1 found", language1);
@@ -168,4 +170,53 @@ public class EngineTest {
             // OK
         }
     }
+
+    @Test
+    public void secondValueWins() throws IOException {
+        Builder builder = createBuilder();
+        builder.config("application/x-test-import-export-2", "hello", "truffle");
+        builder.config("application/x-test-import-export-2", "hello", "world");
+        PolyglotEngine vm = builder.build();
+
+        PolyglotEngine.Language language2 = vm.getLanguages().get("application/x-test-import-export-2");
+        Ctx ctx2 = language2.getGlobalObject().as(Ctx.class);
+        assertEquals("world", ctx2.env.getConfig().get("hello"));
+    }
+
+    @Test
+    public void secondValueWins2() throws IOException {
+        Builder builder = createBuilder();
+        builder.config("application/x-test-import-export-2", "hello", "world");
+        builder.config("application/x-test-import-export-2", "hello", "truffle");
+        PolyglotEngine vm = builder.build();
+
+        PolyglotEngine.Language language2 = vm.getLanguages().get("application/x-test-import-export-2");
+        Ctx ctx2 = language2.getGlobalObject().as(Ctx.class);
+        assertEquals("truffle", ctx2.env.getConfig().get("hello"));
+    }
+
+    @Test
+    public void altValueWins() throws IOException {
+        Builder builder = createBuilder();
+        builder.config(L1, "hello", "truffle");
+        builder.config(L1_ALT, "hello", "world");
+        PolyglotEngine vm = builder.build();
+
+        PolyglotEngine.Language language1 = vm.getLanguages().get(L1);
+        Ctx ctx2 = language1.getGlobalObject().as(Ctx.class);
+        assertEquals("world", ctx2.env.getConfig().get("hello"));
+    }
+
+    @Test
+    public void altValueWins2() throws IOException {
+        Builder builder = createBuilder();
+        builder.config(L1_ALT, "hello", "truffle");
+        builder.config(L1, "hello", "world");
+        PolyglotEngine vm = builder.build();
+
+        PolyglotEngine.Language language1 = vm.getLanguages().get(L1);
+        Ctx ctx2 = language1.getGlobalObject().as(Ctx.class);
+        assertEquals("world", ctx2.env.getConfig().get("hello"));
+    }
+
 }

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/EngineTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/EngineTest.java
@@ -25,8 +25,6 @@ package com.oracle.truffle.api.vm;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.util.List;
@@ -35,6 +33,8 @@ import org.junit.Test;
 
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.vm.ImplicitExplicitExportTest.Ctx;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
 import com.oracle.truffle.api.vm.PolyglotEngine.Builder;
 
 public class EngineTest {
@@ -122,17 +122,14 @@ public class EngineTest {
         assertEquals(3, arr[2].intValue());
     }
 
-    private PolyglotEngine createEngineWithConfig() {
+
+    @Test
+    public void engineConfigBasicAccess() throws IOException {
         Builder builder = createBuilder();
         builder.config("application/x-test-import-export-1", "cmd-line-args", new String[]{"1", "2"});
         builder.config("application/x-test-import-export-2", "hello", "world");
         PolyglotEngine vm = builder.build();
-        return vm;
-    }
-
-    @Test
-    public void engineConfigBasicAccess() throws IOException {
-        PolyglotEngine vm = createEngineWithConfig();
+        
         PolyglotEngine.Language language1 = vm.getLanguages().get("application/x-test-import-export-1");
 
         assertNotNull("Lang1 found", language1);
@@ -156,7 +153,10 @@ public class EngineTest {
 
     @Test
     public void engineConfigShouldBeReadOnly() throws IOException {
-        PolyglotEngine vm = createEngineWithConfig();
+        Builder builder = createBuilder();
+        builder.config("application/x-test-import-export-1", "cmd-line-args", new String[]{"1", "2"});
+        builder.config("application/x-test-import-export-2", "hello", "world");
+        PolyglotEngine vm = builder.build();
         PolyglotEngine.Language language1 = vm.getLanguages().get("application/x-test-import-export-1");
         Ctx ctx1 = language1.getGlobalObject().as(Ctx.class);
 

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/EngineTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/EngineTest.java
@@ -129,7 +129,7 @@ public class EngineTest {
         language1.eval(Source.fromText("return=arr", "get the array")).as(AccessArray.class);
 
         Env env = language1.getEnv(true);
-        String[] args = env.getArguments().get("application/x-test-import-export-1");
+        String[] args = (String[]) env.getArguments().get("application/x-test-import-export-1");
         assertEquals("1", args[0]);
         assertEquals("2", args[1]);
     }

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/EngineTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/EngineTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 
 import com.oracle.truffle.api.TruffleLanguage.Env;
 import com.oracle.truffle.api.source.Source;
+import com.oracle.truffle.api.vm.ImplicitExplicitExportTest.ExportImportLanguage1;
 
 public class EngineTest {
     protected PolyglotEngine.Builder createBuilder() {
@@ -121,7 +122,7 @@ public class EngineTest {
 
     @Test
     public void initializePolyglotEngineWithArguments() throws IOException {
-        PolyglotEngine vm = createBuilder().setArguments(new String[]{"1", "2"}).build();
+        PolyglotEngine vm = createBuilder().setArguments(ExportImportLanguage1.class, new String[]{"1", "2"}).build();
         PolyglotEngine.Language language1 = vm.getLanguages().get("application/x-test-import-export-1");
 
         // TODO: remove once initialization issue is solved for

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/EngineTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/EngineTest.java
@@ -33,7 +33,6 @@ import org.junit.Test;
 
 import com.oracle.truffle.api.TruffleLanguage.Env;
 import com.oracle.truffle.api.source.Source;
-import com.oracle.truffle.api.vm.ImplicitExplicitExportTest.ExportImportLanguage1;
 
 public class EngineTest {
     protected PolyglotEngine.Builder createBuilder() {
@@ -122,7 +121,7 @@ public class EngineTest {
 
     @Test
     public void initializePolyglotEngineWithArguments() throws IOException {
-        PolyglotEngine vm = createBuilder().setArguments(ExportImportLanguage1.class, new String[]{"1", "2"}).build();
+        PolyglotEngine vm = createBuilder().setArguments("application/x-test-import-export-1", new String[]{"1", "2"}).build();
         PolyglotEngine.Language language1 = vm.getLanguages().get("application/x-test-import-export-1");
 
         // TODO: remove once initialization issue is solved for
@@ -130,7 +129,7 @@ public class EngineTest {
         language1.eval(Source.fromText("return=arr", "get the array")).as(AccessArray.class);
 
         Env env = language1.getEnv(true);
-        String[] args = env.getArguments();
+        String[] args = env.getArguments().get("application/x-test-import-export-1");
         assertEquals("1", args[0]);
         assertEquals("2", args[1]);
     }

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/EngineTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/EngineTest.java
@@ -219,4 +219,15 @@ public class EngineTest {
         assertEquals("world", ctx2.env.getConfig().get("hello"));
     }
 
+    @Test
+    public void configIsNeverNull() throws IOException {
+        Builder builder = createBuilder();
+        PolyglotEngine vm = builder.build();
+
+        PolyglotEngine.Language language1 = vm.getLanguages().get(L1);
+        Ctx ctx2 = language1.getGlobalObject().as(Ctx.class);
+        assertNull(ctx2.env.getConfig().get("hello"));
+    }
+
+
 }

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/EngineTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/EngineTest.java
@@ -38,6 +38,7 @@ import static com.oracle.truffle.api.vm.ImplicitExplicitExportTest.L1_ALT;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import com.oracle.truffle.api.vm.PolyglotEngine.Builder;
+import static org.junit.Assert.assertSame;
 
 public class EngineTest {
     protected PolyglotEngine.Builder createBuilder() {
@@ -228,4 +229,25 @@ public class EngineTest {
         assertNull(ctx2.env.getConfig().get("hello"));
     }
 
+    static class YourLang {
+        public static final String MIME_TYPE = L1;
+    }
+
+    @Test
+    public void exampleOfConfiguration() throws IOException {
+        // @formatter:off
+        // BEGIN: config.specify
+        String[] args = {"--kernel", "Kernel.som", "--instrument", "dyn-metrics"};
+        Builder builder = PolyglotEngine.newBuilder();
+        builder.config(YourLang.MIME_TYPE, "CMD_ARGS", args);
+        PolyglotEngine vm = builder.build();
+        // END: config.specify
+        // @formatter:on
+
+        PolyglotEngine.Language language1 = vm.getLanguages().get(L1);
+        Ctx ctx2 = language1.getGlobalObject().as(Ctx.class);
+        String[] read = (String[]) ctx2.env.getConfig().get("CMD_ARGS");
+
+        assertSame("The same array as specified is returned", args, read);
+    }
 }

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/EngineTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/EngineTest.java
@@ -34,7 +34,6 @@ import java.util.List;
 
 import org.junit.Test;
 
-import com.oracle.truffle.api.TruffleLanguage.Env;
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.vm.ImplicitExplicitExportTest.Ctx;
 

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/ImplicitExplicitExportTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/ImplicitExplicitExportTest.java
@@ -277,6 +277,15 @@ public class ImplicitExplicitExportTest {
         public ExportImportLanguage1() {
         }
 
+        // BEGIN: config.read
+        @Override
+        protected Ctx createContext(Env env) {
+            String[] args = (String[]) env.getConfig().get("CMD_ARGS");
+            // FINISH: config.read
+
+            return super.createContext(env);
+        }
+
         @Override
         protected String toString(Ctx ctx, Object value) {
             if (value instanceof String) {

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/ImplicitExplicitExportTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/ImplicitExplicitExportTest.java
@@ -266,10 +266,11 @@ public class ImplicitExplicitExportTest {
     }
 
     public static final String L1 = "application/x-test-import-export-1";
+    public static final String L1_ALT = "application/alt-test-import-export-1";
     static final String L2 = "application/x-test-import-export-2";
     static final String L3 = "application/x-test-import-export-3";
 
-    @TruffleLanguage.Registration(mimeType = L1, name = "ImportExport1", version = "0")
+    @TruffleLanguage.Registration(mimeType = { L1, L1_ALT }, name = "ImportExport1", version = "0")
     public static final class ExportImportLanguage1 extends AbstractExportImportLanguage {
         public static final AbstractExportImportLanguage INSTANCE = new ExportImportLanguage1();
 

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/ImplicitExplicitExportTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/ImplicitExplicitExportTest.java
@@ -48,6 +48,8 @@ import com.oracle.truffle.api.TruffleLanguage.Env;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.instrument.Visualizer;
 import com.oracle.truffle.api.instrument.WrapperNode;
+import com.oracle.truffle.api.interop.ForeignAccess;
+import com.oracle.truffle.api.interop.TruffleObject;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.source.Source;
@@ -128,7 +130,7 @@ public class ImplicitExplicitExportTest {
         assertEquals("Global symbol is also 43", "43", vm.findGlobalSymbol("ahoj").execute().get());
     }
 
-    static final class Ctx {
+    static final class Ctx implements TruffleObject {
         static final Set<Ctx> disposed = new HashSet<>();
 
         final Map<String, String> explicit = new HashMap<>();
@@ -141,6 +143,11 @@ public class ImplicitExplicitExportTest {
 
         void dispose() {
             disposed.add(this);
+        }
+
+        @Override
+        public ForeignAccess getForeignAccess() {
+            throw new UnsupportedOperationException();
         }
     }
 
@@ -180,7 +187,7 @@ public class ImplicitExplicitExportTest {
 
         @Override
         protected Object getLanguageGlobal(Ctx context) {
-            return null;
+            return context;
         }
 
         @Override

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/ImplicitExplicitExportTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/ImplicitExplicitExportTest.java
@@ -270,7 +270,7 @@ public class ImplicitExplicitExportTest {
     static final String L2 = "application/x-test-import-export-2";
     static final String L3 = "application/x-test-import-export-3";
 
-    @TruffleLanguage.Registration(mimeType = { L1, L1_ALT }, name = "ImportExport1", version = "0")
+    @TruffleLanguage.Registration(mimeType = {L1, L1_ALT}, name = "ImportExport1", version = "0")
     public static final class ExportImportLanguage1 extends AbstractExportImportLanguage {
         public static final AbstractExportImportLanguage INSTANCE = new ExportImportLanguage1();
 

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/ImplicitExplicitExportTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/ImplicitExplicitExportTest.java
@@ -277,6 +277,7 @@ public class ImplicitExplicitExportTest {
         public ExportImportLanguage1() {
         }
 
+        @SuppressWarnings("unused")
         // BEGIN: config.read
         @Override
         protected Ctx createContext(Env env) {

--- a/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotEngine.java
+++ b/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotEngine.java
@@ -842,7 +842,7 @@ public class PolyglotEngine {
 
         private Map<String, Object> getArgumentsForLanguage() {
             if (config == null) {
-                return null;
+                return Collections.emptyMap();
             }
 
             Map<String, Object> forLanguage = new HashMap<>();

--- a/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotEngine.java
+++ b/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotEngine.java
@@ -853,10 +853,10 @@ public class PolyglotEngine {
             for (String mimeType : info.getMimeTypes()) {
                 Map<String, Object> arg = config.get(mimeType);
                 if (arg != null) {
-                    forLanguage.put(mimeType, arg);
+                    forLanguage.put(mimeType, Collections.unmodifiableMap(arg));
                 }
             }
-            return forLanguage;
+            return Collections.unmodifiableMap(forLanguage);
         }
 
         TruffleLanguage.Env getEnv(boolean create) {

--- a/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotEngine.java
+++ b/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotEngine.java
@@ -275,6 +275,8 @@ public class PolyglotEngine {
          * {@link com.oracle.truffle.api.TruffleLanguage#createContext(com.oracle.truffle.api.TruffleLanguage.Env)
          * initial execution state} correctly.
          *
+         * {@codesnippet config.specify}
+         *
          * If the same key is specified multiple times for the same language, the previous values
          * are replaced and just the last one remains.
          *

--- a/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotEngine.java
+++ b/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotEngine.java
@@ -113,7 +113,7 @@ public class PolyglotEngine {
     private final EventConsumer<?>[] handlers;
     private final Map<String, Object> globals;
     private final Instrumenter instrumenter;
-    private final String[] arguments;
+    private final Map<Class<? extends TruffleLanguage>, String[]> arguments;
     private final Debugger debugger;
     private boolean disposed;
 
@@ -137,7 +137,8 @@ public class PolyglotEngine {
     /**
      * Real constructor used from the builder.
      */
-    PolyglotEngine(Executor executor, Map<String, Object> globals, OutputStream out, OutputStream err, InputStream in, EventConsumer<?>[] handlers, String[] arguments) {
+    PolyglotEngine(Executor executor, Map<String, Object> globals, OutputStream out, OutputStream err, InputStream in, EventConsumer<?>[] handlers,
+                    Map<Class<? extends TruffleLanguage>, String[]> arguments) {
         this.executor = executor;
         this.out = out;
         this.err = err;
@@ -214,7 +215,7 @@ public class PolyglotEngine {
         private final List<EventConsumer<?>> handlers = new ArrayList<>();
         private final Map<String, Object> globals = new HashMap<>();
         private Executor executor;
-        private String[] arguments;
+        private Map<Class<? extends TruffleLanguage>, String[]> arguments;
 
         Builder() {
         }
@@ -256,14 +257,18 @@ public class PolyglotEngine {
         }
 
         /**
-         * Provide a set of simple string-based arguments to initialize the {@link PolyglotEngine}.
-         * These arguments can be used by the language to initialize and configure their initial
-         * execution state correctly.
+         * Provide simple string-based arguments to initialize the {@link PolyglotEngine} for a
+         * specific language. These arguments can be used by the language to initialize and
+         * configure their initial execution state correctly.
          *
-         * @param arguments, an array of strings to parameterize initial state
+         * @param lang, the language for which the arguments are
+         * @param arguments, an array of strings to parameterize initial state of a language
          */
-        public Builder setArguments(String[] arguments) {
-            this.arguments = arguments;
+        public Builder setArguments(Class<? extends TruffleLanguage> lang, String[] arguments) {
+            if (this.arguments == null) {
+                this.arguments = new HashMap<>();
+            }
+            this.arguments.put(lang, arguments);
             return this;
         }
 
@@ -915,7 +920,8 @@ public class PolyglotEngine {
         }
 
         @Override
-        protected Env attachEnv(Object obj, TruffleLanguage<?> language, OutputStream stdOut, OutputStream stdErr, InputStream stdIn, Instrumenter instrumenter, String[] arguments) {
+        protected Env attachEnv(Object obj, TruffleLanguage<?> language, OutputStream stdOut, OutputStream stdErr, InputStream stdIn, Instrumenter instrumenter,
+                        Map<Class<? extends TruffleLanguage>, String[]> arguments) {
             PolyglotEngine vm = (PolyglotEngine) obj;
             return super.attachEnv(vm, language, stdOut, stdErr, stdIn, instrumenter, arguments);
         }

--- a/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotEngine.java
+++ b/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotEngine.java
@@ -275,10 +275,12 @@ public class PolyglotEngine {
          * {@link com.oracle.truffle.api.TruffleLanguage#createContext(com.oracle.truffle.api.TruffleLanguage.Env)
          * initial execution state} correctly.
          *
-         * Language implementations that have multiple mimeTypes associated with them will see only
-         * a merged set of configuration values. The merge is done based on the key.
+         * If the same key is specified multiple times for the same language, the previous values
+         * are replaced and just the last one remains.
          *
-         * @param mimeType of the language for which the arguments are
+         * @param mimeType identification of the language for which the arguments are - if the
+         *            language declares multiple MIME types, any of them can be used
+         *
          * @param key to identify a language-specific configuration element
          * @param value to parameterize initial state of a language
          * @return instance of this builder

--- a/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotEngine.java
+++ b/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotEngine.java
@@ -113,7 +113,7 @@ public class PolyglotEngine {
     private final EventConsumer<?>[] handlers;
     private final Map<String, Object> globals;
     private final Instrumenter instrumenter;
-    private final Map<String, String[]> arguments;
+    private final Map<String, Object> arguments;
     private final Debugger debugger;
     private boolean disposed;
 
@@ -137,7 +137,7 @@ public class PolyglotEngine {
     /**
      * Real constructor used from the builder.
      */
-    PolyglotEngine(Executor executor, Map<String, Object> globals, OutputStream out, OutputStream err, InputStream in, EventConsumer<?>[] handlers, Map<String, String[]> arguments) {
+    PolyglotEngine(Executor executor, Map<String, Object> globals, OutputStream out, OutputStream err, InputStream in, EventConsumer<?>[] handlers, Map<String, Object> arguments) {
         this.executor = executor;
         this.out = out;
         this.err = err;
@@ -214,7 +214,7 @@ public class PolyglotEngine {
         private final List<EventConsumer<?>> handlers = new ArrayList<>();
         private final Map<String, Object> globals = new HashMap<>();
         private Executor executor;
-        private Map<String, String[]> arguments;
+        private Map<String, Object> arguments;
 
         Builder() {
         }
@@ -261,9 +261,9 @@ public class PolyglotEngine {
          * configure their initial execution state correctly.
          *
          * @param mimeType of the language for which the arguments are
-         * @param arguments, an array of strings to parameterize initial state of a language
+         * @param arguments, an object to parameterize initial state of a language
          */
-        public Builder setArguments(String mimeType, String[] arguments) {
+        public Builder setArguments(String mimeType, Object arguments) {
             if (this.arguments == null) {
                 this.arguments = new HashMap<>();
             }
@@ -833,7 +833,7 @@ public class PolyglotEngine {
             return impl;
         }
 
-        private Map<String, String[]> getArgumentsForLanguage() {
+        private Map<String, Object> getArgumentsForLanguage() {
             if (arguments == null) {
                 return null;
             }
@@ -842,9 +842,9 @@ public class PolyglotEngine {
                 return null;
             }
 
-            Map<String, String[]> forLanguage = new HashMap<>();
+            Map<String, Object> forLanguage = new HashMap<>();
             for (String mimeType : info.getMimeTypes()) {
-                String[] arg = arguments.get(mimeType);
+                Object arg = arguments.get(mimeType);
                 if (arg != null) {
                     forLanguage.put(mimeType, arg);
                 }
@@ -938,7 +938,7 @@ public class PolyglotEngine {
         }
 
         @Override
-        protected Env attachEnv(Object obj, TruffleLanguage<?> language, OutputStream stdOut, OutputStream stdErr, InputStream stdIn, Instrumenter instrumenter, Map<String, String[]> arguments) {
+        protected Env attachEnv(Object obj, TruffleLanguage<?> language, OutputStream stdOut, OutputStream stdErr, InputStream stdIn, Instrumenter instrumenter, Map<String, Object> arguments) {
             PolyglotEngine vm = (PolyglotEngine) obj;
             return super.attachEnv(vm, language, stdOut, stdErr, stdIn, instrumenter, arguments);
         }

--- a/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotEngine.java
+++ b/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotEngine.java
@@ -113,6 +113,7 @@ public class PolyglotEngine {
     private final EventConsumer<?>[] handlers;
     private final Map<String, Object> globals;
     private final Instrumenter instrumenter;
+    private final String[] arguments;
     private final Debugger debugger;
     private boolean disposed;
 
@@ -130,12 +131,13 @@ public class PolyglotEngine {
         this.executor = null;
         this.instrumenter = null;
         this.debugger = null;
+        this.arguments = null;
     }
 
     /**
      * Real constructor used from the builder.
      */
-    PolyglotEngine(Executor executor, Map<String, Object> globals, OutputStream out, OutputStream err, InputStream in, EventConsumer<?>[] handlers) {
+    PolyglotEngine(Executor executor, Map<String, Object> globals, OutputStream out, OutputStream err, InputStream in, EventConsumer<?>[] handlers, String[] arguments) {
         this.executor = executor;
         this.out = out;
         this.err = err;
@@ -144,6 +146,7 @@ public class PolyglotEngine {
         this.initThread = Thread.currentThread();
         this.globals = new HashMap<>(globals);
         this.instrumenter = SPI.createInstrumenter(this);
+        this.arguments = arguments;
         this.debugger = SPI.createDebugger(this, this.instrumenter);
         Map<String, Language> map = new HashMap<>();
         /* We want to create a language instance but per LanguageCache and not per mime type. */
@@ -211,6 +214,7 @@ public class PolyglotEngine {
         private final List<EventConsumer<?>> handlers = new ArrayList<>();
         private final Map<String, Object> globals = new HashMap<>();
         private Executor executor;
+        private String[] arguments;
 
         Builder() {
         }
@@ -248,6 +252,18 @@ public class PolyglotEngine {
          */
         public Builder setIn(InputStream is) {
             in = is;
+            return this;
+        }
+
+        /**
+         * Provide a set of simple string-based arguments to initialize the {@link PolyglotEngine}.
+         * These arguments can be used by the language to initialize and configure their initial
+         * execution state correctly.
+         *
+         * @param arguments, an array of strings to parameterize initial state
+         */
+        public Builder setArguments(String[] arguments) {
+            this.arguments = arguments;
             return this;
         }
 
@@ -334,7 +350,7 @@ public class PolyglotEngine {
             if (in == null) {
                 in = System.in;
             }
-            return new PolyglotEngine(executor, globals, out, err, in, handlers.toArray(new EventConsumer[0]));
+            return new PolyglotEngine(executor, globals, out, err, in, handlers.toArray(new EventConsumer[0]), arguments);
         }
     }
 
@@ -815,7 +831,7 @@ public class PolyglotEngine {
 
         TruffleLanguage.Env getEnv(boolean create) {
             if (env == null && create) {
-                env = SPI.attachEnv(PolyglotEngine.this, info.getImpl(true), out, err, in, instrumenter);
+                env = SPI.attachEnv(PolyglotEngine.this, info.getImpl(true), out, err, in, instrumenter, arguments);
             }
             return env;
         }
@@ -899,9 +915,9 @@ public class PolyglotEngine {
         }
 
         @Override
-        protected Env attachEnv(Object obj, TruffleLanguage<?> language, OutputStream stdOut, OutputStream stdErr, InputStream stdIn, Instrumenter instrumenter) {
+        protected Env attachEnv(Object obj, TruffleLanguage<?> language, OutputStream stdOut, OutputStream stdErr, InputStream stdIn, Instrumenter instrumenter, String[] arguments) {
             PolyglotEngine vm = (PolyglotEngine) obj;
-            return super.attachEnv(vm, language, stdOut, stdErr, stdIn, instrumenter);
+            return super.attachEnv(vm, language, stdOut, stdErr, stdIn, instrumenter, arguments);
         }
 
         @Override

--- a/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotEngine.java
+++ b/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotEngine.java
@@ -270,12 +270,15 @@ public class PolyglotEngine {
 
         /**
          * Provide configuration data to initialize the {@link PolyglotEngine} for a specific
-         * language. These arguments can be used by languages to initialize and configure their
-         * initial execution state.
+         * language. These arguments {@link com.oracle.truffle.api.TruffleLanguage.Env#getConfig()
+         * can be used by the language} to initialize and configure their
+         * {@link com.oracle.truffle.api.TruffleLanguage#createContext(com.oracle.truffle.api.TruffleLanguage.Env)
+         * initial execution state} correctly.
          *
          * @param mimeType of the language for which the arguments are
          * @param key to identify a language-specific configuration element
-         * @param value an object to parameterize initial state of a language
+         * @param value to parameterize initial state of a language
+         * @return instance of this builder
          */
         public Builder config(String mimeType, String key, Object value) {
             if (arguments == null) {

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
@@ -361,14 +361,16 @@ public abstract class TruffleLanguage<C> {
         private final OutputStream err;
         private final OutputStream out;
         private final Instrumenter instrumenter;
+        private final String[] arguments;
 
-        Env(Object vm, TruffleLanguage<?> lang, OutputStream out, OutputStream err, InputStream in, Instrumenter instrumenter) {
+        Env(Object vm, TruffleLanguage<?> lang, OutputStream out, OutputStream err, InputStream in, Instrumenter instrumenter, String[] arguments) {
             this.vm = vm;
             this.in = in;
             this.err = err;
             this.out = out;
             this.lang = lang;
             this.instrumenter = instrumenter;
+            this.arguments = arguments;
             this.langCtx = new LangCtx<>(lang, this);
         }
 
@@ -437,6 +439,13 @@ public abstract class TruffleLanguage<C> {
         public Instrumenter instrumenter() {
             return instrumenter;
         }
+
+        /**
+         * @return arguments used to create the polyglot engine
+         */
+        public String[] getArguments() {
+            return arguments;
+        }
     }
 
     private static final AccessAPI API = new AccessAPI();
@@ -444,8 +453,8 @@ public abstract class TruffleLanguage<C> {
     @SuppressWarnings("rawtypes")
     private static final class AccessAPI extends Accessor {
         @Override
-        protected Env attachEnv(Object vm, TruffleLanguage<?> language, OutputStream stdOut, OutputStream stdErr, InputStream stdIn, Instrumenter instrumenter) {
-            Env env = new Env(vm, language, stdOut, stdErr, stdIn, instrumenter);
+        protected Env attachEnv(Object vm, TruffleLanguage<?> language, OutputStream stdOut, OutputStream stdErr, InputStream stdIn, Instrumenter instrumenter, String[] arguments) {
+            Env env = new Env(vm, language, stdOut, stdErr, stdIn, instrumenter, arguments);
             return env;
         }
 

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
@@ -441,7 +441,11 @@ public abstract class TruffleLanguage<C> {
         }
 
         /**
-         * @return arguments used to create the polyglot engine
+         * Configuration arguments for this language. Arguments set
+         * {@link com.oracle.truffle.api.vm.PolyglotEngine.Builder#config when constructing the
+         * engine} are accessible via this map.
+         *
+         * @return read-only view of configuration options for this language
          */
         public Map<String, Map<String, Object>> getConfig() {
             return config;

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
@@ -361,9 +361,9 @@ public abstract class TruffleLanguage<C> {
         private final OutputStream err;
         private final OutputStream out;
         private final Instrumenter instrumenter;
-        private final String[] arguments;
+        private final Map<String, String[]> arguments;
 
-        Env(Object vm, TruffleLanguage<?> lang, OutputStream out, OutputStream err, InputStream in, Instrumenter instrumenter, String[] arguments) {
+        Env(Object vm, TruffleLanguage<?> lang, OutputStream out, OutputStream err, InputStream in, Instrumenter instrumenter, Map<String, String[]> arguments) {
             this.vm = vm;
             this.in = in;
             this.err = err;
@@ -443,7 +443,7 @@ public abstract class TruffleLanguage<C> {
         /**
          * @return arguments used to create the polyglot engine
          */
-        public String[] getArguments() {
+        public Map<String, String[]> getArguments() {
             return arguments;
         }
     }
@@ -453,10 +453,8 @@ public abstract class TruffleLanguage<C> {
     @SuppressWarnings("rawtypes")
     private static final class AccessAPI extends Accessor {
         @Override
-        protected Env attachEnv(Object vm, TruffleLanguage<?> language, OutputStream stdOut, OutputStream stdErr, InputStream stdIn, Instrumenter instrumenter,
-                        Map<Class<? extends TruffleLanguage>, String[]> arguments) {
-            String[] args = (arguments != null) ? arguments.get(language.getClass()) : null;
-            Env env = new Env(vm, language, stdOut, stdErr, stdIn, instrumenter, args);
+        protected Env attachEnv(Object vm, TruffleLanguage<?> language, OutputStream stdOut, OutputStream stdErr, InputStream stdIn, Instrumenter instrumenter, Map<String, String[]> arguments) {
+            Env env = new Env(vm, language, stdOut, stdErr, stdIn, instrumenter, arguments);
             return env;
         }
 

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
@@ -445,6 +445,25 @@ public abstract class TruffleLanguage<C> {
          * {@link com.oracle.truffle.api.vm.PolyglotEngine.Builder#config when constructing the
          * engine} are accessible via this map.
          *
+         * This method (in combination with
+         * {@link com.oracle.truffle.api.vm.PolyglotEngine.Builder#config}) provides a
+         * straight-forward way to pass implementation-level arguments, as typically specified on a
+         * command line, to the languages.
+         *
+         * {@codesnippet config.specify}
+         *
+         * In contrast to {@link com.oracle.truffle.api.vm.PolyglotEngine.Builder#globalSymbol
+         * global symbols} the provided values are passed in exactly as specified, because these
+         * configuration arguments are strictly at the implementation level and not language-level
+         * objects.
+         *
+         * These configuration arguments are available when
+         * {@link #createContext(com.oracle.truffle.api.TruffleLanguage.Env) creating the language
+         * context} to make it possible to take them into account before the language gets ready for
+         * execution. This is the most common way to access them:
+         *
+         * {@codesnippet config.read}
+         *
          * @return read-only view of configuration options for this language
          */
         public Map<String, Object> getConfig() {

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
@@ -361,9 +361,9 @@ public abstract class TruffleLanguage<C> {
         private final OutputStream err;
         private final OutputStream out;
         private final Instrumenter instrumenter;
-        private final Map<String, Map<String, Object>> config;
+        private final Map<String, Object> config;
 
-        Env(Object vm, TruffleLanguage<?> lang, OutputStream out, OutputStream err, InputStream in, Instrumenter instrumenter, Map<String, Map<String, Object>> config) {
+        Env(Object vm, TruffleLanguage<?> lang, OutputStream out, OutputStream err, InputStream in, Instrumenter instrumenter, Map<String, Object> config) {
             this.vm = vm;
             this.in = in;
             this.err = err;
@@ -447,7 +447,7 @@ public abstract class TruffleLanguage<C> {
          *
          * @return read-only view of configuration options for this language
          */
-        public Map<String, Map<String, Object>> getConfig() {
+        public Map<String, Object> getConfig() {
             return config;
         }
     }
@@ -457,7 +457,7 @@ public abstract class TruffleLanguage<C> {
     @SuppressWarnings("rawtypes")
     private static final class AccessAPI extends Accessor {
         @Override
-        protected Env attachEnv(Object vm, TruffleLanguage<?> language, OutputStream stdOut, OutputStream stdErr, InputStream stdIn, Instrumenter instrumenter, Map<String, Map<String, Object>> config) {
+        protected Env attachEnv(Object vm, TruffleLanguage<?> language, OutputStream stdOut, OutputStream stdErr, InputStream stdIn, Instrumenter instrumenter, Map<String, Object> config) {
             Env env = new Env(vm, language, stdOut, stdErr, stdIn, instrumenter, config);
             return env;
         }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
@@ -361,16 +361,16 @@ public abstract class TruffleLanguage<C> {
         private final OutputStream err;
         private final OutputStream out;
         private final Instrumenter instrumenter;
-        private final Map<String, Object> arguments;
+        private final Map<String, Map<String, Object>> config;
 
-        Env(Object vm, TruffleLanguage<?> lang, OutputStream out, OutputStream err, InputStream in, Instrumenter instrumenter, Map<String, Object> arguments) {
+        Env(Object vm, TruffleLanguage<?> lang, OutputStream out, OutputStream err, InputStream in, Instrumenter instrumenter, Map<String, Map<String, Object>> config) {
             this.vm = vm;
             this.in = in;
             this.err = err;
             this.out = out;
             this.lang = lang;
             this.instrumenter = instrumenter;
-            this.arguments = arguments;
+            this.config = config;
             this.langCtx = new LangCtx<>(lang, this);
         }
 
@@ -443,8 +443,8 @@ public abstract class TruffleLanguage<C> {
         /**
          * @return arguments used to create the polyglot engine
          */
-        public Map<String, Object> getArguments() {
-            return arguments;
+        public Map<String, Map<String, Object>> getConfig() {
+            return config;
         }
     }
 
@@ -453,8 +453,8 @@ public abstract class TruffleLanguage<C> {
     @SuppressWarnings("rawtypes")
     private static final class AccessAPI extends Accessor {
         @Override
-        protected Env attachEnv(Object vm, TruffleLanguage<?> language, OutputStream stdOut, OutputStream stdErr, InputStream stdIn, Instrumenter instrumenter, Map<String, Object> arguments) {
-            Env env = new Env(vm, language, stdOut, stdErr, stdIn, instrumenter, arguments);
+        protected Env attachEnv(Object vm, TruffleLanguage<?> language, OutputStream stdOut, OutputStream stdErr, InputStream stdIn, Instrumenter instrumenter, Map<String, Map<String, Object>> config) {
+            Env env = new Env(vm, language, stdOut, stdErr, stdIn, instrumenter, config);
             return env;
         }
 

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
@@ -361,9 +361,9 @@ public abstract class TruffleLanguage<C> {
         private final OutputStream err;
         private final OutputStream out;
         private final Instrumenter instrumenter;
-        private final Map<String, String[]> arguments;
+        private final Map<String, Object> arguments;
 
-        Env(Object vm, TruffleLanguage<?> lang, OutputStream out, OutputStream err, InputStream in, Instrumenter instrumenter, Map<String, String[]> arguments) {
+        Env(Object vm, TruffleLanguage<?> lang, OutputStream out, OutputStream err, InputStream in, Instrumenter instrumenter, Map<String, Object> arguments) {
             this.vm = vm;
             this.in = in;
             this.err = err;
@@ -443,7 +443,7 @@ public abstract class TruffleLanguage<C> {
         /**
          * @return arguments used to create the polyglot engine
          */
-        public Map<String, String[]> getArguments() {
+        public Map<String, Object> getArguments() {
             return arguments;
         }
     }
@@ -453,7 +453,7 @@ public abstract class TruffleLanguage<C> {
     @SuppressWarnings("rawtypes")
     private static final class AccessAPI extends Accessor {
         @Override
-        protected Env attachEnv(Object vm, TruffleLanguage<?> language, OutputStream stdOut, OutputStream stdErr, InputStream stdIn, Instrumenter instrumenter, Map<String, String[]> arguments) {
+        protected Env attachEnv(Object vm, TruffleLanguage<?> language, OutputStream stdOut, OutputStream stdErr, InputStream stdIn, Instrumenter instrumenter, Map<String, Object> arguments) {
             Env env = new Env(vm, language, stdOut, stdErr, stdIn, instrumenter, arguments);
             return env;
         }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
@@ -453,8 +453,10 @@ public abstract class TruffleLanguage<C> {
     @SuppressWarnings("rawtypes")
     private static final class AccessAPI extends Accessor {
         @Override
-        protected Env attachEnv(Object vm, TruffleLanguage<?> language, OutputStream stdOut, OutputStream stdErr, InputStream stdIn, Instrumenter instrumenter, String[] arguments) {
-            Env env = new Env(vm, language, stdOut, stdErr, stdIn, instrumenter, arguments);
+        protected Env attachEnv(Object vm, TruffleLanguage<?> language, OutputStream stdOut, OutputStream stdErr, InputStream stdIn, Instrumenter instrumenter,
+                        Map<Class<? extends TruffleLanguage>, String[]> arguments) {
+            String[] args = (arguments != null) ? arguments.get(language.getClass()) : null;
+            Env env = new Env(vm, language, stdOut, stdErr, stdIn, instrumenter, args);
             return env;
         }
 

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/Accessor.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/Accessor.java
@@ -149,8 +149,8 @@ public abstract class Accessor {
         }
     }
 
-    protected Env attachEnv(Object vm, TruffleLanguage<?> language, OutputStream stdOut, OutputStream stdErr, InputStream stdIn, Instrumenter instrumenter) {
-        return API.attachEnv(vm, language, stdOut, stdErr, stdIn, instrumenter);
+    protected Env attachEnv(Object vm, TruffleLanguage<?> language, OutputStream stdOut, OutputStream stdErr, InputStream stdIn, Instrumenter instrumenter, String[] arguments) {
+        return API.attachEnv(vm, language, stdOut, stdErr, stdIn, instrumenter, arguments);
     }
 
     protected Object eval(TruffleLanguage<?> l, Source s, Map<Source, CallTarget> cache) throws IOException {

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/Accessor.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/Accessor.java
@@ -150,8 +150,8 @@ public abstract class Accessor {
         }
     }
 
-    protected Env attachEnv(Object vm, TruffleLanguage<?> language, OutputStream stdOut, OutputStream stdErr, InputStream stdIn, Instrumenter instrumenter, Map<String, Object> arguments) {
-        return API.attachEnv(vm, language, stdOut, stdErr, stdIn, instrumenter, arguments);
+    protected Env attachEnv(Object vm, TruffleLanguage<?> language, OutputStream stdOut, OutputStream stdErr, InputStream stdIn, Instrumenter instrumenter, Map<String, Map<String, Object>> config) {
+        return API.attachEnv(vm, language, stdOut, stdErr, stdIn, instrumenter, config);
     }
 
     protected Object eval(TruffleLanguage<?> l, Source s, Map<Source, CallTarget> cache) throws IOException {

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/Accessor.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/Accessor.java
@@ -48,6 +48,7 @@ import com.oracle.truffle.api.instrument.WrapperNode;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.source.Source;
+
 import java.util.Map;
 
 /**
@@ -149,7 +150,8 @@ public abstract class Accessor {
         }
     }
 
-    protected Env attachEnv(Object vm, TruffleLanguage<?> language, OutputStream stdOut, OutputStream stdErr, InputStream stdIn, Instrumenter instrumenter, String[] arguments) {
+    protected Env attachEnv(Object vm, TruffleLanguage<?> language, OutputStream stdOut, OutputStream stdErr, InputStream stdIn, Instrumenter instrumenter,
+                    Map<Class<? extends TruffleLanguage>, String[]> arguments) {
         return API.attachEnv(vm, language, stdOut, stdErr, stdIn, instrumenter, arguments);
     }
 

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/Accessor.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/Accessor.java
@@ -150,8 +150,7 @@ public abstract class Accessor {
         }
     }
 
-    protected Env attachEnv(Object vm, TruffleLanguage<?> language, OutputStream stdOut, OutputStream stdErr, InputStream stdIn, Instrumenter instrumenter,
-                    Map<Class<? extends TruffleLanguage>, String[]> arguments) {
+    protected Env attachEnv(Object vm, TruffleLanguage<?> language, OutputStream stdOut, OutputStream stdErr, InputStream stdIn, Instrumenter instrumenter, Map<String, String[]> arguments) {
         return API.attachEnv(vm, language, stdOut, stdErr, stdIn, instrumenter, arguments);
     }
 

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/Accessor.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/Accessor.java
@@ -150,7 +150,7 @@ public abstract class Accessor {
         }
     }
 
-    protected Env attachEnv(Object vm, TruffleLanguage<?> language, OutputStream stdOut, OutputStream stdErr, InputStream stdIn, Instrumenter instrumenter, Map<String, Map<String, Object>> config) {
+    protected Env attachEnv(Object vm, TruffleLanguage<?> language, OutputStream stdOut, OutputStream stdErr, InputStream stdIn, Instrumenter instrumenter, Map<String, Object> config) {
         return API.attachEnv(vm, language, stdOut, stdErr, stdIn, instrumenter, config);
     }
 

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/Accessor.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/Accessor.java
@@ -150,7 +150,7 @@ public abstract class Accessor {
         }
     }
 
-    protected Env attachEnv(Object vm, TruffleLanguage<?> language, OutputStream stdOut, OutputStream stdErr, InputStream stdIn, Instrumenter instrumenter, Map<String, String[]> arguments) {
+    protected Env attachEnv(Object vm, TruffleLanguage<?> language, OutputStream stdOut, OutputStream stdErr, InputStream stdIn, Instrumenter instrumenter, Map<String, Object> arguments) {
         return API.attachEnv(vm, language, stdOut, stdErr, stdIn, instrumenter, arguments);
     }
 


### PR DESCRIPTION
This change allows to pass an array of strings to the polyglot engine and retrieve it in the environment object.

The goal is to provide a straight-forward way to pass implementation-level arguments, as the typically come from the command line to the `PolyglotEngine` and the languages.

At the moment, we need to jump through many many hoops.
To realize the same effect, in a language-specific way, it seems we need to do roughly the following:

1. we need some wrapper class to be able to get to the value later on in the language:

  ```Java
  public static class CmdArgWrapper<T> implements TruffleObject {
    private final T obj;
    public CmdArgWrapper(final T obj) {
      this.obj = obj;
    }

    public T getObject() {
      return obj;
    }

    @Override
    public ForeignAccess getForeignAccess() {
      throw new UnsupportedOperationException();
    }
  }
  ```

2. we need to pass the arguments to the engine. In the case of SOM, I need these arguments when creating the language context, because the context contains the object system, which depends on the source to be used. And, might also have instruments that need to be configured from the very start.

  ```Java
  String[] args = new String[] {"--kernel", "Kernel.som", "--instrument", "dyn-metrics"};
  Builder builder = PolyglotEngine.newBuilder();
  builder.globalSymbol("CMD_ARGS", new CmdArgWrapper<String[]>(args));
  PolyglotEngine vm = builder.build();
  ```

  I believe, the whole notion of global TruffleObjects does not apply here because these arguments are strictly at the implementation level and not language-level objects. But even if there are arguments that become visible to the language, it is the languages job to figure that out and do the necessary wrapping.

3. in the `TruffleLanguage.createContext(...)` method, I need to do this:

```Java
protected VM createContext(final Env env) {
    Object argsObj = env.importSymbol("CMD_ARGS");
    String[] args = null;
    if (argsObj instanceof CmdArgWrapper<?>) {
      @SuppressWarnings("unchecked")
      CmdArgWrapper<String[]> argsWrapper = (CmdArgWrapper<String[]>) argsObj;
      args = argsWrapper.getObject();
    }
    assert args != null;
  // ...
```

All this is non-trivial for a very basic use case that any practical language would want to support: take some parameters to control its initialization process/startup.

With the provided patch, all this shrinks to:

```Java
String[] args = new String[] {"--kernel", "Kernel.som", "--instrument", "dyn-metrics"};
Builder builder = PolyglotEngine.newBuilder();
builder.setArguments(args);
PolyglotEngine vm = builder.build();

protected VM createContext(final Env env) {
    String[] args = env.getArguments();
// ...
```

I hope this is compelling enough for inclusion. I know the API should be minimal, but this is a super basic use case, and while there might be static-state solutions that are shorter than this, I believe we should provide an API that allows users to do 'the right thing' easily.

I am not entirely sure about my patch thought. The whole code based involved here is extremely complex and rather hard to comprehend. I mean, it adds about 40 lines of code for something very very trivial: another field + getter. I did not expect that much change for this simple feature.