### PR TITLE
Showing the current approach to pass in language arguments

### DIFF
--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/EngineTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/EngineTest.java
@@ -120,12 +120,18 @@ public class EngineTest {
 
     @Test
     public void passArgumentsToALanguage() throws Exception {
+        final PolyglotEngine.Builder builder = createBuilder(); /*
+        // BEGIN: arguments.pass
+        PolyglotEngine.Builder builder = PolyglotEngine.newBuilder(); // */
+        // prepare array of arguments
         String[] args = {"argsKey", "argsValue"};
-        final PolyglotEngine.Builder builder = createBuilder();
+        // pass them under language specific name
         builder.globalSymbol("args", args);
-        PolyglotEngine tvm = builder.build();
 
-        PolyglotEngine.Language language1 = tvm.getLanguages().get("application/x-test-import-export-1");
+        PolyglotEngine engine = builder.build();
+        // END: arguments.pass
+
+        PolyglotEngine.Language language1 = engine.getLanguages().get("application/x-test-import-export-1");
         language1.eval(Source.fromText("return=args", "get the array")).as(List.class);
         assertEquals("argsKey", args[0]);
         assertEquals("argsValue", args[1]);

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/EngineTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/EngineTest.java
@@ -117,4 +117,17 @@ public class EngineTest {
         assertEquals(2, arr[1].intValue());
         assertEquals(3, arr[2].intValue());
     }
+
+    @Test
+    public void passArgumentsToALanguage() throws Exception {
+        String[] args = {"argsKey", "argsValue"};
+        final PolyglotEngine.Builder builder = createBuilder();
+        builder.globalSymbol("args", args);
+        PolyglotEngine tvm = builder.build();
+
+        PolyglotEngine.Language language1 = tvm.getLanguages().get("application/x-test-import-export-1");
+        language1.eval(Source.fromText("return=args", "get the array")).as(List.class);
+        assertEquals("argsKey", args[0]);
+        assertEquals("argsValue", args[1]);
+    }
 }

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/ImplicitExplicitExportTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/ImplicitExplicitExportTest.java
@@ -48,9 +48,13 @@ import com.oracle.truffle.api.TruffleLanguage.Env;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.instrument.Visualizer;
 import com.oracle.truffle.api.instrument.WrapperNode;
+import com.oracle.truffle.api.interop.TruffleObject;
+import com.oracle.truffle.api.interop.java.JavaInterop;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.source.Source;
+import java.util.List;
+import static org.junit.Assert.assertNotNull;
 
 public class ImplicitExplicitExportTest {
     private static Thread mainThread;
@@ -267,6 +271,21 @@ public class ImplicitExplicitExportTest {
         public static final AbstractExportImportLanguage INSTANCE = new ExportImportLanguage1();
 
         public ExportImportLanguage1() {
+        }
+
+        @Override
+        protected Ctx createContext(Env env) {
+            Ctx ret = super.createContext(env);
+            Object args = env.importSymbol("args");
+            if (args != null) {
+                assertTrue("It is truffle object", args instanceof TruffleObject);
+                List<?> argsList = JavaInterop.asJavaObject(List.class, (TruffleObject) args);
+                assertNotNull(argsList);
+                final String arg0 = (String) argsList.get(0);
+                final String arg1 = (String) argsList.get(1);
+                ret.explicit.put(arg0, arg1);
+            }
+            return ret;
         }
 
         @Override

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/ImplicitExplicitExportTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/ImplicitExplicitExportTest.java
@@ -54,7 +54,6 @@ import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.source.Source;
 import java.util.List;
-import static org.junit.Assert.assertNotNull;
 
 public class ImplicitExplicitExportTest {
     private static Thread mainThread;
@@ -275,12 +274,18 @@ public class ImplicitExplicitExportTest {
 
         @Override
         protected Ctx createContext(Env env) {
-            Ctx ret = super.createContext(env);
+            // BEGIN: arguments.read
             Object args = env.importSymbol("args");
-            if (args != null) {
-                assertTrue("It is truffle object", args instanceof TruffleObject);
-                List<?> argsList = JavaInterop.asJavaObject(List.class, (TruffleObject) args);
-                assertNotNull(argsList);
+            List<?> argsList = null;
+            if (args instanceof TruffleObject) {
+                // convert arguments to list
+                argsList = JavaInterop.asJavaObject(
+                    List.class, (TruffleObject) args
+                );
+            }
+            // END: arguments.read
+            Ctx ret = super.createContext(env);
+            if (argsList != null) {
                 final String arg0 = (String) argsList.get(0);
                 final String arg1 = (String) argsList.get(1);
                 ret.explicit.put(arg0, arg1);


### PR DESCRIPTION
In contrast to https://github.com/graalvm/truffle/pull/10 this kind of arguments access doesn't require any API changes right now and it seems to be straightforward enough (once documented) in Javadoc.