### PR TITLE
Adding check of javadoc broken links into travis pull request run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,6 @@ env:
   - TEST_COMMAND='mx/mx checkoverlap'
   - TEST_COMMAND='mx/mx canonicalizeprojects'
   - TEST_COMMAND='mx/mx checkstyle'
-  
+  - TEST_COMMAND='mx/mx javadoc --unified'  
 
 


### PR DESCRIPTION
Run more tests to ensure documentation doesn't have broken links and missing tags.