### PR TITLE
Fixed JavaDoc issues in object model docs

### DIFF
--- a/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/Layout.java
+++ b/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/Layout.java
@@ -86,7 +86,6 @@ public abstract class Layout {
      * @param objectType that describes the object instance with this shape.
      * @param sharedData for language-specific use
      * @param id for language-specific use
-     * @return
      */
     public abstract Shape createShape(ObjectType objectType, Object sharedData, int id);
 

--- a/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/Property.java
+++ b/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/Property.java
@@ -35,7 +35,7 @@ public abstract class Property {
     /**
      * Create a new property.
      *
-     * @param flags, for language-specific use
+     * @param flags for language-specific use
      */
     public static Property create(Object key, Location location, int flags) {
         return Layout.getFactory().createProperty(key, location, flags);


### PR DESCRIPTION
These issues cause `mx javadoc --unified` to report errors.