### PR TITLE
Add Env#getSupportedMimeTypes()

### DIFF
--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/IsMimeTypeSupportedTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/IsMimeTypeSupportedTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.truffle.api.vm;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+import com.oracle.truffle.api.source.Source;
+
+public class IsMimeTypeSupportedTest {
+
+    private static final String MIME_TYPE = "application/x-test-mime-type-supported";
+
+    @Test
+    public void isMimeSupported() throws IOException {
+        PolyglotEngine vm = PolyglotEngine.newBuilder().build();
+        assertEquals(true, vm.eval(Source.fromText(MIME_TYPE, "supported").withMimeType(MIME_TYPE)).as(Boolean.class));
+        assertEquals(false, vm.eval(Source.fromText("application/x-this-language-does-not-exist", "unsupported").withMimeType(MIME_TYPE)).as(Boolean.class));
+    }
+
+}

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/IsMimeTypeSupportedTestLanguage.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/IsMimeTypeSupportedTestLanguage.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.truffle.api.vm;
+
+import java.io.IOException;
+
+import com.oracle.truffle.api.CallTarget;
+import com.oracle.truffle.api.TruffleLanguage;
+import com.oracle.truffle.api.TruffleLanguage.Env;
+import com.oracle.truffle.api.frame.MaterializedFrame;
+import com.oracle.truffle.api.instrument.Visualizer;
+import com.oracle.truffle.api.instrument.WrapperNode;
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.source.Source;
+
+@TruffleLanguage.Registration(name = "Hash", mimeType = "application/x-test-mime-type-supported", version = "1.0")
+public class IsMimeTypeSupportedTestLanguage extends TruffleLanguage<Env> {
+
+    public static final IsMimeTypeSupportedTestLanguage INSTANCE = new IsMimeTypeSupportedTestLanguage();
+
+    @Override
+    protected Env createContext(com.oracle.truffle.api.TruffleLanguage.Env env) {
+        return env;
+    }
+
+    @Override
+    protected CallTarget parse(final Source code, Node context, String... argumentNames) throws IOException {
+        final String mimeType = code.getCode();
+
+        return new CallTarget() {
+
+            public Object call(Object... arguments) {
+                return findContext(createFindContextNode()).isMimeTypeSupported(mimeType);
+            }
+
+        };
+    }
+
+    @Override
+    protected Object findExportedSymbol(Env context, String globalName, boolean onlyExplicit) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected Object getLanguageGlobal(Env context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected boolean isObjectOfLanguage(Object object) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected Visualizer getVisualizer() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected boolean isInstrumentable(Node node) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected WrapperNode createWrapperNode(Node node) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected Object evalInContext(Source source, Node node, MaterializedFrame mFrame) throws IOException {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotEngine.java
+++ b/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotEngine.java
@@ -886,14 +886,6 @@ public class PolyglotEngine {
         return null;
     }
 
-    String[] getSupportedMimeTypes() {
-        final Set<String> mimeTypes = new HashSet<>();
-        for (PolyglotEngine.Language language : langs.values()) {
-            mimeTypes.addAll(language.getMimeTypes());
-        }
-        return mimeTypes.toArray(new String[mimeTypes.size()]);
-    }
-
     TruffleLanguage<?> findLanguage(String mimeType) {
         Language languageDescription = this.langs.get(mimeType);
         if (languageDescription != null) {

--- a/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotEngine.java
+++ b/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotEngine.java
@@ -989,14 +989,14 @@ public class PolyglotEngine {
         }
 
         @Override
-        protected String[] getSupportedMimeTypes(Object obj) {
-            final PolyglotEngine vm = (PolyglotEngine) obj;
-            return vm.getSupportedMimeTypes();
+        protected Class<? extends TruffleLanguage> findLanguage(Probe probe) {
+            return super.findLanguage(probe);
         }
 
         @Override
-        protected Class<? extends TruffleLanguage> findLanguage(Probe probe) {
-            return super.findLanguage(probe);
+        protected boolean isMimeTypeSupported(Object obj, String mimeType) {
+            final PolyglotEngine vm = (PolyglotEngine) obj;
+            return vm.findLanguage(mimeType) != null;
         }
 
         @Override

--- a/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotEngine.java
+++ b/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotEngine.java
@@ -886,6 +886,14 @@ public class PolyglotEngine {
         return null;
     }
 
+    String[] getSupportedMimeTypes() {
+        final Set<String> mimeTypes = new HashSet<>();
+        for (PolyglotEngine.Language language : langs.values()) {
+            mimeTypes.addAll(language.getMimeTypes());
+        }
+        return mimeTypes.toArray(new String[mimeTypes.size()]);
+    }
+
     TruffleLanguage<?> findLanguage(String mimeType) {
         Language languageDescription = this.langs.get(mimeType);
         if (languageDescription != null) {
@@ -978,6 +986,12 @@ public class PolyglotEngine {
         protected Instrumenter getInstrumenter(Object obj) {
             final PolyglotEngine vm = (PolyglotEngine) obj;
             return vm.instrumenter;
+        }
+
+        @Override
+        protected String[] getSupportedMimeTypes(Object obj) {
+            final PolyglotEngine vm = (PolyglotEngine) obj;
+            return vm.getSupportedMimeTypes();
         }
 
         @Override

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
@@ -388,11 +388,11 @@ public abstract class TruffleLanguage<C> {
         }
 
         /**
-         * Allows it to be determined if this {@link PolyglotEngine} can execute code written in a
-         * language with a given MIME type.
+         * Allows it to be determined if this {@link com.oracle.truffle.api.vm.PolyglotEngine} can
+         * execute code written in a language with a given MIME type.
          *
-         * @see Source#withMimeType()
-         * @see #parse()
+         * @see Source#withMimeType(String)
+         * @see #parse(Source, String...)
          *
          * @return a boolean that indicates if the MIME type is supported
          */

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
@@ -232,8 +232,8 @@ public abstract class TruffleLanguage<C> {
     protected abstract Visualizer getVisualizer();
 
     /**
-     * Returns {@code true} for a node can be "instrumented" by {@linkplain Instrumenter#probe(Node)
-     * probing}.
+     * Returns {@code true} for a node can be "instrumented" by
+     * {@linkplain Instrumenter#probe(Node) probing}.
      * <p>
      * <b>Note:</b> instrumentation requires a appropriate {@link WrapperNode}
      *

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
@@ -232,8 +232,8 @@ public abstract class TruffleLanguage<C> {
     protected abstract Visualizer getVisualizer();
 
     /**
-     * Returns {@code true} for a node can be "instrumented" by
-     * {@linkplain Instrumenter#probe(Node) probing}.
+     * Returns {@code true} for a node can be "instrumented" by {@linkplain Instrumenter#probe(Node)
+     * probing}.
      * <p>
      * <b>Note:</b> instrumentation requires a appropriate {@link WrapperNode}
      *
@@ -388,16 +388,16 @@ public abstract class TruffleLanguage<C> {
         }
 
         /**
-         * Produces an array of strings for the MIME types supported by this {@link PolyglotEngine}.
-         * There may be multiple MIME types for a single language. Each MIME type will appear only
-         * once, even if multiple language declare it.
+         * Allows it to be determined if this {@link PolyglotEngine} can execute code written in a
+         * language with a given MIME type.
          *
-         * MIME types from this array can be used in methods such as {@link #parse}.
+         * @see Source#withMimeType()
+         * @see #parse()
          *
-         * @return a non-null array of a string for each supported MIME type
+         * @return a boolean that indicates if the MIME type is supported
          */
-        public String[] getSupportedMimeTypes() {
-            return API.getSupportedMimeTypes(vm);
+        public boolean isMimeTypeSupported(String mimeType) {
+            return API.isMimeTypeSupported(vm, mimeType);
         }
 
         /**
@@ -539,8 +539,8 @@ public abstract class TruffleLanguage<C> {
         }
 
         @Override
-        protected String[] getSupportedMimeTypes(Object obj) {
-            return super.getSupportedMimeTypes(obj);
+        protected boolean isMimeTypeSupported(Object vm, String mimeType) {
+            return super.isMimeTypeSupported(vm, mimeType);
         }
 
         @Override

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
@@ -388,6 +388,19 @@ public abstract class TruffleLanguage<C> {
         }
 
         /**
+         * Produces an array of strings for the MIME types supported by this {@link PolyglotEngine}.
+         * There may be multiple MIME types for a single language. Each MIME type will appear only
+         * once, even if multiple language declare it.
+         *
+         * MIME types from this array can be used in methods such as {@link #parse}.
+         *
+         * @return a non-null array of a string for each supported MIME type
+         */
+        public String[] getSupportedMimeTypes() {
+            return API.getSupportedMimeTypes(vm);
+        }
+
+        /**
          * Evaluates source of (potentially different) language. The {@link Source#getMimeType()
          * MIME type} is used to identify the {@link TruffleLanguage} to use to perform the
          * {@link #parse(com.oracle.truffle.api.source.Source, com.oracle.truffle.api.nodes.Node, java.lang.String...)}
@@ -523,6 +536,11 @@ public abstract class TruffleLanguage<C> {
         @Override
         protected Object findExportedSymbol(TruffleLanguage.Env env, String globalName, boolean onlyExplicit) {
             return env.langCtx.findExportedSymbol(globalName, onlyExplicit);
+        }
+
+        @Override
+        protected String[] getSupportedMimeTypes(Object obj) {
+            return super.getSupportedMimeTypes(obj);
         }
 
         @Override

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/Accessor.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/Accessor.java
@@ -204,6 +204,10 @@ public abstract class Accessor {
         return API.createWrapperNode(node, language);
     }
 
+    protected String[] getSupportedMimeTypes(Object obj) {
+        return SPI.getSupportedMimeTypes(obj);
+    }
+
     @SuppressWarnings("rawtypes")
     protected Class<? extends TruffleLanguage> findLanguage(RootNode n) {
         return NODES.findLanguage(n);

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/Accessor.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/Accessor.java
@@ -204,8 +204,8 @@ public abstract class Accessor {
         return API.createWrapperNode(node, language);
     }
 
-    protected String[] getSupportedMimeTypes(Object obj) {
-        return SPI.getSupportedMimeTypes(obj);
+    protected boolean isMimeTypeSupported(Object vm, String mimeType) {
+        return SPI.isMimeTypeSupported(vm, mimeType);
     }
 
     @SuppressWarnings("rawtypes")


### PR DESCRIPTION
I want to know what languages are supported in a `PolyglotEngine`. The pressing use-case is in JRuby+Truffle where I want to know if I have a JS interpreter available. I'm currently doing this by just trying to eval with `application/javascript` and catching any error as an indication that it isn't available. This patch instead checks what languages are available first.

https://github.com/jruby/jruby/compare/truffle-execjs...truffle-execjs-list-languages#diff-0c9caf96978e9602deec3f1fca2d97a8L68

The workaround before this patch is slow, even if I end up not using the JavaScript interpreter after finding that it is available. This is 3rd party code for the most part so I can't redesign much.

This is a new API, so a 'large' review. @jtulach @chumer @woess