### PR TITLE
better message for UnsupportedSpecializationException: include data types

### DIFF
--- a/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/UnsupportedSpecializationException.java
+++ b/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/UnsupportedSpecializationException.java
@@ -54,7 +54,12 @@ public final class UnsupportedSpecializationException extends RuntimeException {
 
     @Override
     public String getMessage() {
-        return String.format("Unexpected values provided for %s: %s", node, Arrays.toString(suppliedValues));
+        StringBuilder str = new StringBuilder();
+        str.append("Unexpected values provided for ").append(node).append(": ").append(Arrays.toString(suppliedValues)).append(", [");
+        for (int i = 0; i < suppliedValues.length; i++) {
+            str.append(i == 0 ? "" : ",").append(suppliedValues[i] == null ? "null" : suppliedValues[i].getClass().getSimpleName());
+        }
+        return str.append("]").toString();
     }
 
     /**


### PR DESCRIPTION
the actual data types that weren't successfully specialized on are not always visible from the "toString()" of the values - this change adds a list of type names.