### PR TITLE
Fix checkstyle issue with redundant public keyword

### DIFF
--- a/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/internal/DSLOptions.java
+++ b/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/internal/DSLOptions.java
@@ -51,7 +51,7 @@ public @interface DSLOptions {
     /** Not yet implemented. */
     boolean useDisjunctiveMethodGuardOptimization() default true;
 
-    public enum ImplicitCastOptimization {
+    enum ImplicitCastOptimization {
 
         /** Perform no informed optimization for implicit casts. */
         NONE,
@@ -78,7 +78,7 @@ public @interface DSLOptions {
         }
     }
 
-    public enum TypeBoxingOptimization {
+    enum TypeBoxingOptimization {
         /** Perform the optimization for all types. */
         ALWAYS,
         /** Perform the optimization just for primitive types. */
@@ -117,7 +117,7 @@ public @interface DSLOptions {
      */
     TypeBoxingOptimization voidBoxingOptimization() default TypeBoxingOptimization.PRIMITIVE;
 
-    public enum FallbackOptimization {
+    enum FallbackOptimization {
         /** Always generate an optimized fallback specialization. */
         ALWAYS,
 

--- a/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/internal/SlowPathEvent.java
+++ b/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/internal/SlowPathEvent.java
@@ -98,7 +98,7 @@ abstract class SlowPathEvent implements CharSequence {
 
         private static final Object[] EMPTY = new Object[0];
 
-        public SlowPathEvent0(SpecializationNode source, String reason, Frame frame) {
+        SlowPathEvent0(SpecializationNode source, String reason, Frame frame) {
             super(source, reason, frame);
         }
 
@@ -113,7 +113,7 @@ abstract class SlowPathEvent implements CharSequence {
 
         protected final Object o1;
 
-        public SlowPathEvent1(SpecializationNode source, String reason, Frame frame, Object o1) {
+        SlowPathEvent1(SpecializationNode source, String reason, Frame frame, Object o1) {
             super(source, reason, frame);
             this.o1 = o1;
         }
@@ -130,7 +130,7 @@ abstract class SlowPathEvent implements CharSequence {
         protected final Object o1;
         protected final Object o2;
 
-        public SlowPathEvent2(SpecializationNode source, String reason, Frame frame, Object o1, Object o2) {
+        SlowPathEvent2(SpecializationNode source, String reason, Frame frame, Object o1, Object o2) {
             super(source, reason, frame);
             this.o1 = o1;
             this.o2 = o2;
@@ -149,7 +149,7 @@ abstract class SlowPathEvent implements CharSequence {
         protected final Object o2;
         protected final Object o3;
 
-        public SlowPathEvent3(SpecializationNode source, String reason, Frame frame, Object o1, Object o2, Object o3) {
+        SlowPathEvent3(SpecializationNode source, String reason, Frame frame, Object o1, Object o2, Object o3) {
             super(source, reason, frame);
             this.o1 = o1;
             this.o2 = o2;
@@ -170,7 +170,7 @@ abstract class SlowPathEvent implements CharSequence {
         protected final Object o3;
         protected final Object o4;
 
-        public SlowPathEvent4(SpecializationNode source, String reason, Frame frame, Object o1, Object o2, Object o3, Object o4) {
+        SlowPathEvent4(SpecializationNode source, String reason, Frame frame, Object o1, Object o2, Object o3, Object o4) {
             super(source, reason, frame);
             this.o1 = o1;
             this.o2 = o2;
@@ -193,7 +193,7 @@ abstract class SlowPathEvent implements CharSequence {
         protected final Object o4;
         protected final Object o5;
 
-        public SlowPathEvent5(SpecializationNode source, String reason, Frame frame, Object o1, Object o2, Object o3, Object o4, Object o5) {
+        SlowPathEvent5(SpecializationNode source, String reason, Frame frame, Object o1, Object o2, Object o3, Object o4, Object o5) {
             super(source, reason, frame);
             this.o1 = o1;
             this.o2 = o2;
@@ -213,7 +213,7 @@ abstract class SlowPathEvent implements CharSequence {
 
         protected final Object[] args;
 
-        public SlowPathEventN(SpecializationNode source, String reason, Frame frame, Object... args) {
+        SlowPathEventN(SpecializationNode source, String reason, Frame frame, Object... args) {
             super(source, reason, frame);
             this.args = args;
         }

--- a/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/internal/SpecializationNode.java
+++ b/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/internal/SpecializationNode.java
@@ -622,7 +622,7 @@ public abstract class SpecializationNode extends Node {
 
     private static final class InsertionEvent0 extends SlowPathEvent0 implements Callable<SpecializationNode> {
 
-        public InsertionEvent0(SpecializationNode source, String reason, Frame frame) {
+        InsertionEvent0(SpecializationNode source, String reason, Frame frame) {
             super(source, reason, frame);
         }
 
@@ -646,7 +646,7 @@ public abstract class SpecializationNode extends Node {
 
     private static final class InsertionEvent1 extends SlowPathEvent1 implements Callable<SpecializationNode> {
 
-        public InsertionEvent1(SpecializationNode source, String reason, Frame frame, Object o1) {
+        InsertionEvent1(SpecializationNode source, String reason, Frame frame, Object o1) {
             super(source, reason, frame, o1);
         }
 
@@ -670,7 +670,7 @@ public abstract class SpecializationNode extends Node {
 
     private static final class InsertionEvent2 extends SlowPathEvent2 implements Callable<SpecializationNode> {
 
-        public InsertionEvent2(SpecializationNode source, String reason, Frame frame, Object o1, Object o2) {
+        InsertionEvent2(SpecializationNode source, String reason, Frame frame, Object o1, Object o2) {
             super(source, reason, frame, o1, o2);
         }
 
@@ -694,7 +694,7 @@ public abstract class SpecializationNode extends Node {
 
     private static final class InsertionEvent3 extends SlowPathEvent3 implements Callable<SpecializationNode> {
 
-        public InsertionEvent3(SpecializationNode source, String reason, Frame frame, Object o1, Object o2, Object o3) {
+        InsertionEvent3(SpecializationNode source, String reason, Frame frame, Object o1, Object o2, Object o3) {
             super(source, reason, frame, o1, o2, o3);
         }
 
@@ -718,7 +718,7 @@ public abstract class SpecializationNode extends Node {
 
     private static final class InsertionEvent4 extends SlowPathEvent4 implements Callable<SpecializationNode> {
 
-        public InsertionEvent4(SpecializationNode source, String reason, Frame frame, Object o1, Object o2, Object o3, Object o4) {
+        InsertionEvent4(SpecializationNode source, String reason, Frame frame, Object o1, Object o2, Object o3, Object o4) {
             super(source, reason, frame, o1, o2, o3, o4);
         }
 
@@ -742,7 +742,7 @@ public abstract class SpecializationNode extends Node {
 
     private static final class InsertionEvent5 extends SlowPathEvent5 implements Callable<SpecializationNode> {
 
-        public InsertionEvent5(SpecializationNode source, String reason, Frame frame, Object o1, Object o2, Object o3, Object o4, Object o5) {
+        InsertionEvent5(SpecializationNode source, String reason, Frame frame, Object o1, Object o2, Object o3, Object o4, Object o5) {
             super(source, reason, frame, o1, o2, o3, o4, o5);
         }
 
@@ -766,7 +766,7 @@ public abstract class SpecializationNode extends Node {
 
     private static final class InsertionEventN extends SlowPathEventN implements Callable<SpecializationNode> {
 
-        public InsertionEventN(SpecializationNode source, String reason, Frame frame, Object[] args) {
+        InsertionEventN(SpecializationNode source, String reason, Frame frame, Object[] args) {
             super(source, reason, frame, args);
         }
 
@@ -789,7 +789,7 @@ public abstract class SpecializationNode extends Node {
 
     private static final class RemoveEvent0 extends SlowPathEvent0 implements Callable<SpecializationNode> {
 
-        public RemoveEvent0(SpecializationNode source, String reason, Frame frame) {
+        RemoveEvent0(SpecializationNode source, String reason, Frame frame) {
             super(source, reason, frame);
         }
 
@@ -801,7 +801,7 @@ public abstract class SpecializationNode extends Node {
 
     private static final class RemoveEvent1 extends SlowPathEvent1 implements Callable<SpecializationNode> {
 
-        public RemoveEvent1(SpecializationNode source, String reason, Frame frame, Object o1) {
+        RemoveEvent1(SpecializationNode source, String reason, Frame frame, Object o1) {
             super(source, reason, frame, o1);
         }
 
@@ -813,7 +813,7 @@ public abstract class SpecializationNode extends Node {
 
     private static final class RemoveEvent2 extends SlowPathEvent2 implements Callable<SpecializationNode> {
 
-        public RemoveEvent2(SpecializationNode source, String reason, Frame frame, Object o1, Object o2) {
+        RemoveEvent2(SpecializationNode source, String reason, Frame frame, Object o1, Object o2) {
             super(source, reason, frame, o1, o2);
         }
 
@@ -825,7 +825,7 @@ public abstract class SpecializationNode extends Node {
 
     private static final class RemoveEvent3 extends SlowPathEvent3 implements Callable<SpecializationNode> {
 
-        public RemoveEvent3(SpecializationNode source, String reason, Frame frame, Object o1, Object o2, Object o3) {
+        RemoveEvent3(SpecializationNode source, String reason, Frame frame, Object o1, Object o2, Object o3) {
             super(source, reason, frame, o1, o2, o3);
         }
 
@@ -837,7 +837,7 @@ public abstract class SpecializationNode extends Node {
 
     private static final class RemoveEvent4 extends SlowPathEvent4 implements Callable<SpecializationNode> {
 
-        public RemoveEvent4(SpecializationNode source, String reason, Frame frame, Object o1, Object o2, Object o3, Object o4) {
+        RemoveEvent4(SpecializationNode source, String reason, Frame frame, Object o1, Object o2, Object o3, Object o4) {
             super(source, reason, frame, o1, o2, o3, o4);
         }
 
@@ -849,7 +849,7 @@ public abstract class SpecializationNode extends Node {
 
     private static final class RemoveEvent5 extends SlowPathEvent5 implements Callable<SpecializationNode> {
 
-        public RemoveEvent5(SpecializationNode source, String reason, Frame frame, Object o1, Object o2, Object o3, Object o4, Object o5) {
+        RemoveEvent5(SpecializationNode source, String reason, Frame frame, Object o1, Object o2, Object o3, Object o4, Object o5) {
             super(source, reason, frame, o1, o2, o3, o4, o5);
         }
 
@@ -861,7 +861,7 @@ public abstract class SpecializationNode extends Node {
 
     private static final class RemoveEventN extends SlowPathEventN implements Callable<SpecializationNode> {
 
-        public RemoveEventN(SpecializationNode source, String reason, Frame frame, Object[] args) {
+        RemoveEventN(SpecializationNode source, String reason, Frame frame, Object[] args) {
             super(source, reason, frame, args);
         }
 

--- a/truffle/com.oracle.truffle.api.interop.java/src/com/oracle/truffle/api/interop/java/JavaInterop.java
+++ b/truffle/com.oracle.truffle.api.interop.java/src/com/oracle/truffle/api/interop/java/JavaInterop.java
@@ -298,7 +298,7 @@ public final class JavaInterop {
         private final TruffleObject symbol;
         private CallTarget target;
 
-        public SingleHandler(TruffleObject obj) {
+        SingleHandler(TruffleObject obj) {
             this.symbol = obj;
         }
 
@@ -318,7 +318,7 @@ public final class JavaInterop {
     private static final class TruffleHandler implements InvocationHandler {
         private final TruffleObject obj;
 
-        public TruffleHandler(TruffleObject obj) {
+        TruffleHandler(TruffleObject obj) {
             this.obj = obj;
         }
 
@@ -502,7 +502,7 @@ public final class JavaInterop {
         private final TruffleObject function;
 
         @SuppressWarnings("rawtypes")
-        public TemporaryRoot(Class<? extends TruffleLanguage> lang, Node foreignAccess, TruffleObject function) {
+        TemporaryRoot(Class<? extends TruffleLanguage> lang, Node foreignAccess, TruffleObject function) {
             super(lang, null, null);
             this.foreignAccess = foreignAccess;
             this.function = function;
@@ -519,7 +519,7 @@ public final class JavaInterop {
         final Method method;
         final Object obj;
 
-        public JavaFunctionObject(Method method, Object obj) {
+        JavaFunctionObject(Method method, Object obj) {
             this.method = method;
             this.obj = obj;
         }
@@ -537,7 +537,7 @@ public final class JavaInterop {
         final Object obj;
         final Class<?> clazz;
 
-        public JavaObject(Object obj, Class<?> clazz) {
+        JavaObject(Object obj, Class<?> clazz) {
             this.obj = obj;
             this.clazz = clazz;
         }

--- a/truffle/com.oracle.truffle.api.interop.java/src/com/oracle/truffle/api/interop/java/ReadArgNode.java
+++ b/truffle/com.oracle.truffle.api.interop.java/src/com/oracle/truffle/api/interop/java/ReadArgNode.java
@@ -31,7 +31,7 @@ import com.oracle.truffle.api.nodes.Node;
 class ReadArgNode extends Node {
     private final int argIndex;
 
-    public ReadArgNode(int argIndex) {
+    ReadArgNode(int argIndex) {
         this.argIndex = argIndex;
     }
 

--- a/truffle/com.oracle.truffle.api.interop.java/src/com/oracle/truffle/api/interop/java/WriteFieldNode.java
+++ b/truffle/com.oracle.truffle.api.interop.java/src/com/oracle/truffle/api/interop/java/WriteFieldNode.java
@@ -32,7 +32,7 @@ import java.lang.reflect.Array;
 
 class WriteFieldNode extends RootNode {
 
-    public WriteFieldNode() {
+    WriteFieldNode() {
         super(JavaInteropLanguage.class, null, null);
     }
 

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/CallTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/CallTest.java
@@ -87,7 +87,7 @@ public class CallTest {
 
         private final int value;
 
-        public ConstantRootNode(int value) {
+        ConstantRootNode(int value) {
             super(TestingLanguage.class, null, null);
             this.value = value;
         }

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/ChildNodeTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/ChildNodeTest.java
@@ -89,7 +89,7 @@ public class ChildNodeTest {
         @Child private TestChildNode left;
         @Child private TestChildNode right;
 
-        public TestRootNode(TestChildNode left, TestChildNode right) {
+        TestRootNode(TestChildNode left, TestChildNode right) {
             super(TestingLanguage.class, null, null);
             this.left = left;
             this.right = right;
@@ -103,7 +103,7 @@ public class ChildNodeTest {
 
     class TestChildNode extends Node {
 
-        public TestChildNode() {
+        TestChildNode() {
             super(null);
         }
 

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/ChildrenNodesTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/ChildrenNodesTest.java
@@ -84,7 +84,7 @@ public class ChildrenNodesTest {
 
         @Children private final TestChildNode[] children;
 
-        public TestRootNode(TestChildNode[] children) {
+        TestRootNode(TestChildNode[] children) {
             super(TestingLanguage.class, null, null);
             this.children = children;
         }
@@ -101,7 +101,7 @@ public class ChildrenNodesTest {
 
     class TestChildNode extends Node {
 
-        public TestChildNode() {
+        TestChildNode() {
             super(null);
         }
 
@@ -137,7 +137,7 @@ public class ChildrenNodesTest {
         @Children private final TestChildNode[] children1;
         @Children private final TestChildNode[] children2;
 
-        public TestRoot2Node(TestChildNode[] children1, TestChildNode[] children2) {
+        TestRoot2Node(TestChildNode[] children1, TestChildNode[] children2) {
             super(new TestChildNode[0]);
             this.children1 = children1;
             this.children2 = children2;

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/FinalFieldTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/FinalFieldTest.java
@@ -77,7 +77,7 @@ public class FinalFieldTest {
 
         @Children private final TestChildNode[] children;
 
-        public TestRootNode(TestChildNode[] children) {
+        TestRootNode(TestChildNode[] children) {
             super(TestingLanguage.class, null, null);
             this.children = children;
         }
@@ -96,7 +96,7 @@ public class FinalFieldTest {
 
         private final int value;
 
-        public TestChildNode(int value) {
+        TestChildNode(int value) {
             super(null);
             this.value = value;
         }

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/FrameSlotTypeSpecializationTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/FrameSlotTypeSpecializationTest.java
@@ -80,7 +80,7 @@ public class FrameSlotTypeSpecializationTest {
         @Child TestChildNode left;
         @Child TestChildNode right;
 
-        public TestRootNode(FrameDescriptor descriptor, TestChildNode left, TestChildNode right) {
+        TestRootNode(FrameDescriptor descriptor, TestChildNode left, TestChildNode right) {
             super(TestingLanguage.class, null, descriptor);
             this.left = left;
             this.right = right;
@@ -106,7 +106,7 @@ public class FrameSlotTypeSpecializationTest {
 
         protected final FrameSlot slot;
 
-        public FrameSlotNode(FrameSlot slot) {
+        FrameSlotNode(FrameSlot slot) {
             this.slot = slot;
         }
     }

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/FrameTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/FrameTest.java
@@ -110,7 +110,7 @@ public class FrameTest {
         @Child TestChildNode left;
         @Child TestChildNode right;
 
-        public TestRootNode(FrameDescriptor descriptor, TestChildNode left, TestChildNode right) {
+        TestRootNode(FrameDescriptor descriptor, TestChildNode left, TestChildNode right) {
             super(TestingLanguage.class, null, descriptor);
             this.left = left;
             this.right = right;
@@ -124,7 +124,7 @@ public class FrameTest {
 
     abstract class TestChildNode extends Node {
 
-        public TestChildNode() {
+        TestChildNode() {
             super(null);
         }
 
@@ -135,7 +135,7 @@ public class FrameTest {
 
         protected final FrameSlot slot;
 
-        public FrameSlotNode(FrameSlot slot) {
+        FrameSlotNode(FrameSlot slot) {
             this.slot = slot;
         }
     }
@@ -175,7 +175,7 @@ public class FrameTest {
 
         class FrameRootNode extends RootNode {
 
-            public FrameRootNode() {
+            FrameRootNode() {
                 super(TestingLanguage.class, null, null);
             }
 

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/InterfaceChildFieldTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/InterfaceChildFieldTest.java
@@ -96,7 +96,7 @@ public class InterfaceChildFieldTest {
 
         @Child private TestChildInterface child;
 
-        public TestRootNode(TestChildInterface child) {
+        TestRootNode(TestChildInterface child) {
             super(TestingLanguage.class, null, null);
             this.child = child;
         }
@@ -112,7 +112,7 @@ public class InterfaceChildFieldTest {
     }
 
     class TestLeafNode extends Node implements TestChildInterface {
-        public TestLeafNode() {
+        TestLeafNode() {
             super(null);
         }
 
@@ -122,7 +122,7 @@ public class InterfaceChildFieldTest {
     }
 
     class TestLeaf2Node extends Node implements TestChildInterface {
-        public TestLeaf2Node() {
+        TestLeaf2Node() {
             super(null);
         }
 
@@ -136,7 +136,7 @@ public class InterfaceChildFieldTest {
         @Child private TestChildInterface left;
         @Child private TestChildInterface right;
 
-        public TestChildNode(TestChildInterface left, TestChildInterface right) {
+        TestChildNode(TestChildInterface left, TestChildInterface right) {
             super(null);
             this.left = left;
             this.right = right;
@@ -152,7 +152,7 @@ public class InterfaceChildFieldTest {
 
         @Children private final TestChildInterface[] children;
 
-        public TestChildrenNode(TestChildInterface[] children) {
+        TestChildrenNode(TestChildInterface[] children) {
             super(null);
             this.children = children;
         }

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/ReplaceTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/ReplaceTest.java
@@ -97,7 +97,7 @@ public class ReplaceTest {
 
         @Children private final ValueNode[] children;
 
-        public TestRootNode(ValueNode[] children) {
+        TestRootNode(ValueNode[] children) {
             super(TestingLanguage.class, null, null);
             this.children = children;
         }
@@ -114,7 +114,7 @@ public class ReplaceTest {
 
     abstract class ValueNode extends Node {
 
-        public ValueNode() {
+        ValueNode() {
             super(null);
         }
 
@@ -125,7 +125,7 @@ public class ReplaceTest {
 
         private final String value;
 
-        public UnresolvedNode(String value) {
+        UnresolvedNode(String value) {
             this.value = value;
         }
 

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/ReturnTypeSpecializationTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/ReturnTypeSpecializationTest.java
@@ -80,7 +80,7 @@ public class ReturnTypeSpecializationTest {
         @Child TestChildNode left;
         @Child TestChildNode right;
 
-        public TestRootNode(FrameDescriptor descriptor, TestChildNode left, TestChildNode right) {
+        TestRootNode(FrameDescriptor descriptor, TestChildNode left, TestChildNode right) {
             super(TestingLanguage.class, null, descriptor);
             this.left = left;
             this.right = right;
@@ -95,7 +95,7 @@ public class ReturnTypeSpecializationTest {
 
     abstract class TestChildNode extends Node {
 
-        public TestChildNode() {
+        TestChildNode() {
             super(null);
         }
 
@@ -114,7 +114,7 @@ public class ReturnTypeSpecializationTest {
 
         protected final FrameSlot slot;
 
-        public FrameSlotNode(FrameSlot slot) {
+        FrameSlotNode(FrameSlot slot) {
             this.slot = slot;
         }
     }

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/RootNodeTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/RootNodeTest.java
@@ -71,7 +71,7 @@ public class RootNodeTest {
 
     class TestRootNode extends RootNode {
 
-        public TestRootNode() {
+        TestRootNode() {
             super(TestingLanguage.class, null, null);
         }
 

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/ThreadSafetyTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/ThreadSafetyTest.java
@@ -89,7 +89,7 @@ public class ThreadSafetyTest {
 
         @Child private ValueNode child;
 
-        public TestRootNode(ValueNode child) {
+        TestRootNode(ValueNode child) {
             super(TestingLanguage.class, null, null);
             this.child = child;
         }
@@ -102,7 +102,7 @@ public class ThreadSafetyTest {
 
     abstract static class ValueNode extends Node {
 
-        public ValueNode() {
+        ValueNode() {
             super(null);
         }
 
@@ -114,11 +114,11 @@ public class ThreadSafetyTest {
         @Child private ValueNode child;
         private final Random random;
 
-        public RewritingNode(ValueNode child) {
+        RewritingNode(ValueNode child) {
             this(child, new Random());
         }
 
-        public RewritingNode(ValueNode child, Random random) {
+        RewritingNode(ValueNode child, Random random) {
             this.child = child;
             this.random = random;
         }
@@ -139,7 +139,7 @@ public class ThreadSafetyTest {
         @Child private ValueNode child;
         private final Random random;
 
-        public OtherRewritingNode(ValueNode child, Random random) {
+        OtherRewritingNode(ValueNode child, Random random) {
             this.child = child;
             this.random = random;
         }

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/instrument/InstrumentationTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/instrument/InstrumentationTest.java
@@ -205,7 +205,7 @@ public class InstrumentationTest {
         public Instrumenter instrumenter;
         private ProbeInstrument instrument;
 
-        public TestSimpleInstrumentCounter(Instrumenter instrumenter) {
+        TestSimpleInstrumentCounter(Instrumenter instrumenter) {
             this.instrumenter = instrumenter;
         }
 
@@ -257,7 +257,7 @@ public class InstrumentationTest {
         public final Instrumenter instrumenter;
         public ProbeInstrument instrument;
 
-        public TestStandardInstrumentCounter(Instrumenter instrumenter) {
+        TestStandardInstrumentCounter(Instrumenter instrumenter) {
             this.instrumenter = instrumenter;
         }
 

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/instrument/InstrumentationTestNodes.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/instrument/InstrumentationTestNodes.java
@@ -44,7 +44,7 @@ class InstrumentationTestNodes {
         @Child private TestLanguageNode child;
         @Child private EventHandlerNode eventHandlerNode;
 
-        public TestLanguageWrapperNode(TestLanguageNode child) {
+        TestLanguageWrapperNode(TestLanguageNode child) {
             assert !(child instanceof TestLanguageWrapperNode);
             this.child = child;
         }
@@ -90,7 +90,7 @@ class InstrumentationTestNodes {
     static class TestValueNode extends TestLanguageNode {
         private final int value;
 
-        public TestValueNode(int value) {
+        TestValueNode(int value) {
             this.value = value;
         }
 
@@ -107,7 +107,7 @@ class InstrumentationTestNodes {
         @Child private TestLanguageNode leftChild;
         @Child private TestLanguageNode rightChild;
 
-        public TestAdditionNode(TestValueNode leftChild, TestValueNode rightChild) {
+        TestAdditionNode(TestValueNode leftChild, TestValueNode rightChild) {
             this.leftChild = insert(leftChild);
             this.rightChild = insert(rightChild);
         }
@@ -131,7 +131,7 @@ class InstrumentationTestNodes {
          * newly created AST. Global registry is not used, since that would interfere with other
          * tests run in the same environment.
          */
-        public InstrumentationTestRootNode(TestLanguageNode body) {
+        InstrumentationTestRootNode(TestLanguageNode body) {
             super(InstrumentationTestingLanguage.class, null, null);
             this.body = body;
         }
@@ -162,7 +162,7 @@ class InstrumentationTestNodes {
          * newly created AST. Global registry is not used, since that would interfere with other
          * tests run in the same environment.
          */
-        public TestRootNode(TestLanguageNode body, Instrumenter instrumenter) {
+        TestRootNode(TestLanguageNode body, Instrumenter instrumenter) {
             super(InstrumentationTestingLanguage.class, null, null);
             this.instrumenter = instrumenter;
             this.body = body;

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/instrument/InstrumentationTestingLanguage.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/instrument/InstrumentationTestingLanguage.java
@@ -66,7 +66,7 @@ public final class InstrumentationTestingLanguage extends TruffleLanguage<Object
         private final String name;
         private final String description;
 
-        private InstrumentTestTag(String name, String description) {
+        InstrumentTestTag(String name, String description) {
             this.name = name;
             this.description = description;
         }

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/instrument/InstrumentationTestingLanguage.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/instrument/InstrumentationTestingLanguage.java
@@ -57,7 +57,7 @@ public final class InstrumentationTestingLanguage extends TruffleLanguage<Object
         return Source.fromText(CONSTANT_SOURCE_TEXT, testName).withMimeType("text/x-instTest");
     }
 
-    static enum InstrumentTestTag implements SyntaxTag {
+    enum InstrumentTestTag implements SyntaxTag {
 
         ADD_TAG("addition", "test language addition node"),
 

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/interop/ForeignAccessToStringTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/interop/ForeignAccessToStringTest.java
@@ -42,7 +42,7 @@ public class ForeignAccessToStringTest {
     }
 
     private static class SimpleTestingFactory implements ForeignAccess.Factory {
-        public SimpleTestingFactory() {
+        SimpleTestingFactory() {
         }
 
         @Override

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/nodes/NodeUtilTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/nodes/NodeUtilTest.java
@@ -73,7 +73,7 @@ public class NodeUtilTest {
 
         private int visited;
 
-        public TestNode() {
+        TestNode() {
         }
 
     }
@@ -84,7 +84,7 @@ public class NodeUtilTest {
 
         private int visited;
 
-        public TestRootNode() {
+        TestRootNode() {
             super(TestingLanguage.class, null, null);
         }
 

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/nodes/SafeReplaceTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/nodes/SafeReplaceTest.java
@@ -83,7 +83,7 @@ public class SafeReplaceTest {
 
         private int executed;
 
-        public TestRootNode() {
+        TestRootNode() {
             super(TestingLanguage.class, null, null);
         }
 

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/profiles/SeparateClassloaderTestRunner.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/profiles/SeparateClassloaderTestRunner.java
@@ -47,7 +47,7 @@ public final class SeparateClassloaderTestRunner extends BlockJUnit4ClassRunner 
     }
 
     private static class TestClassLoader extends URLClassLoader {
-        public TestClassLoader() {
+        TestClassLoader() {
             super(((URLClassLoader) getSystemClassLoader()).getURLs());
         }
 

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/ArrayTruffleObject.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/ArrayTruffleObject.java
@@ -126,7 +126,7 @@ final class ArrayTruffleObject implements TruffleObject, ForeignAccess.Factory10
     }
 
     private final class IndexNode extends RootNode {
-        public IndexNode() {
+        IndexNode() {
             super(TruffleLanguage.class, null, null);
         }
 
@@ -142,7 +142,7 @@ final class ArrayTruffleObject implements TruffleObject, ForeignAccess.Factory10
     }
 
     private final class InvokeNode extends RootNode {
-        public InvokeNode() {
+        InvokeNode() {
             super(TruffleLanguage.class, null, null);
         }
 
@@ -162,7 +162,7 @@ final class ArrayTruffleObject implements TruffleObject, ForeignAccess.Factory10
     }
 
     private final class DuplNode extends RootNode {
-        public DuplNode() {
+        DuplNode() {
             super(TruffleLanguage.class, null, null);
         }
 

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/HashLanguage.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/HashLanguage.java
@@ -92,7 +92,7 @@ public class HashLanguage extends TruffleLanguage<Env> {
         private final Source code;
         private final int id;
 
-        public HashNode(HashLanguage hash, Source code) {
+        HashNode(HashLanguage hash, Source code) {
             super(hash.getClass(), null, null);
             this.code = code;
             id = ++counter;

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/ImplicitExplicitExportTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/ImplicitExplicitExportTest.java
@@ -137,7 +137,7 @@ public class ImplicitExplicitExportTest {
         final Map<String, String> implicit = new HashMap<>();
         final Env env;
 
-        public Ctx(Env env) {
+        Ctx(Env env) {
             this.env = env;
         }
 

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/InitializationTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/InitializationTest.java
@@ -128,7 +128,7 @@ public class InitializationTest {
     private static class ANode extends Node {
         private final int constant;
 
-        public ANode(int constant) {
+        ANode(int constant) {
             this.constant = constant;
         }
 

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
@@ -322,7 +322,7 @@ public abstract class TruffleLanguage<C> {
         final TruffleLanguage<C> lang;
         final C ctx;
 
-        public LangCtx(TruffleLanguage<C> lang, Env env) {
+        LangCtx(TruffleLanguage<C> lang, Env env) {
             this.lang = lang;
             // following call verifies that Accessor.CURRENT_VM is provided
             assert API.findLanguage(null, null) == null;

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/debug/LineBreakpointFactory.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/debug/LineBreakpointFactory.java
@@ -288,7 +288,7 @@ final class LineBreakpointFactory {
          */
         private List<ProbeInstrument> instruments = new ArrayList<>();
 
-        public LineBreakpointImpl(int ignoreCount, LineLocation lineLocation, boolean oneShot) {
+        LineBreakpointImpl(int ignoreCount, LineLocation lineLocation, boolean oneShot) {
             super(ENABLED_UNRESOLVED, ignoreCount, oneShot);
             this.lineLocation = lineLocation;
 

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/debug/LineToProbesMap.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/debug/LineToProbesMap.java
@@ -63,7 +63,7 @@ final class LineToProbesMap extends Instrumenter.Tool {
      * Create a map of {@link Probe}s that collects information on all probes added to subsequently
      * created ASTs (once installed).
      */
-    public LineToProbesMap() {
+    LineToProbesMap() {
         this.probeListener = new LineToProbesListener();
     }
 

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/FrameInstance.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/FrameInstance.java
@@ -29,7 +29,7 @@ import com.oracle.truffle.api.nodes.Node;
 
 public interface FrameInstance {
 
-    public static enum FrameAccess {
+    enum FrameAccess {
         NONE,
         READ_ONLY,
         READ_WRITE,

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/FrameSlotKind.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/FrameSlotKind.java
@@ -36,7 +36,7 @@ public enum FrameSlotKind {
 
     public final byte tag;
 
-    private FrameSlotKind() {
+    FrameSlotKind() {
         this.tag = (byte) ordinal();
     }
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/ProbeFailure.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/ProbeFailure.java
@@ -62,7 +62,7 @@ public final class ProbeFailure {
 
         final String message;
 
-        private Reason(String message) {
+        Reason(String message) {
             this.message = message;
         }
 

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/StandardSyntaxTag.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/StandardSyntaxTag.java
@@ -75,7 +75,7 @@ public enum StandardSyntaxTag implements SyntaxTag {
     private final String name;
     private final String description;
 
-    private StandardSyntaxTag(String name, String description) {
+    StandardSyntaxTag(String name, String description) {
         this.name = name;
         this.description = description;
     }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/GraphPrintVisitor.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/GraphPrintVisitor.java
@@ -75,7 +75,7 @@ public class GraphPrintVisitor implements Closeable {
         private final int id;
         private final Map<String, Object> properties;
 
-        public NodeElement(int id) {
+        NodeElement(int id) {
             super();
             this.id = id;
             this.properties = new LinkedHashMap<>();
@@ -96,7 +96,7 @@ public class GraphPrintVisitor implements Closeable {
         private final int index;
         private final String label;
 
-        public EdgeElement(NodeElement from, NodeElement to, int index, String label) {
+        EdgeElement(NodeElement from, NodeElement to, int index, String label) {
             this.from = from;
             this.to = to;
             this.index = index;

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/NodeFieldAccessor.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/NodeFieldAccessor.java
@@ -36,7 +36,7 @@ import com.oracle.truffle.api.nodes.Node.Children;
  */
 public abstract class NodeFieldAccessor {
 
-    public static enum NodeFieldKind {
+    public enum NodeFieldKind {
         /** The reference to the {@link NodeClass}. */
         NODE_CLASS,
         /** The single {@link Node#getParent() parent} field. */

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/NodeUtil.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/NodeUtil.java
@@ -63,7 +63,7 @@ public final class NodeUtil {
     private static final class RecursiveNodeIterator implements Iterator<Node> {
         private final List<Iterator<Node>> iteratorStack = new ArrayList<>();
 
-        public RecursiveNodeIterator(final Node node) {
+        RecursiveNodeIterator(final Node node) {
             iteratorStack.add(new Iterator<Node>() {
 
                 private boolean visited;
@@ -834,7 +834,7 @@ public final class NodeUtil {
         public int count;
         private final NodeCountFilter filter;
 
-        public NodeCounter(NodeCountFilter filter) {
+        NodeCounter(NodeCountFilter filter) {
             this.filter = filter;
         }
 

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/RootNode.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/RootNode.java
@@ -140,7 +140,7 @@ public abstract class RootNode extends Node {
      * stack) without prior knowledge of the language it has come from.
      *
      * Used for instance to determine the language of a <code>RootNode<code>:
-     * 
+     *
      * <pre>
      * <code>
      * rootNode.getExecutionContext().getLanguageShortName();
@@ -195,7 +195,7 @@ public abstract class RootNode extends Node {
 
         private final Object value;
 
-        public Constant(Object value) {
+        Constant(Object value) {
             super(TruffleLanguage.class, null, null);
             this.value = value;
         }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/source/Source.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/source/Source.java
@@ -706,7 +706,7 @@ public abstract class Source {
         private final String description;
         private final String code;
 
-        public LiteralSource(String description, String code) {
+        LiteralSource(String description, String code) {
             this.description = description;
             this.code = code;
         }
@@ -770,7 +770,7 @@ public abstract class Source {
         private final String description;
         final List<CharSequence> codeList = new ArrayList<>();
 
-        public AppendableLiteralSource(String description) {
+        AppendableLiteralSource(String description) {
             this.description = description;
         }
 
@@ -833,7 +833,7 @@ public abstract class Source {
 
         private String code = null;  // A cache of the file's contents
 
-        public FileSource(File file, String name, String path) {
+        FileSource(File file, String name, String path) {
             this.file = file.getAbsoluteFile();
             this.name = name;
             this.path = path;
@@ -938,7 +938,7 @@ public abstract class Source {
         private final String path;  // Normalized path description of an actual file
         private String code;  // The file's contents, as provided by the client
 
-        public ClientManagedFileSource(File file, String name, String path, CharSequence chars) {
+        ClientManagedFileSource(File file, String name, String path, CharSequence chars) {
             this.file = file.getAbsoluteFile();
             this.name = name;
             this.path = path;
@@ -1035,7 +1035,7 @@ public abstract class Source {
         private final String name;
         private String code;  // A cache of the source contents
 
-        public URLSource(URL url, String name) throws IOException {
+        URLSource(URL url, String name) throws IOException {
             this.url = url;
             this.name = name;
             URLConnection c = url.openConnection();
@@ -1143,7 +1143,7 @@ public abstract class Source {
         private final int length;
         private final CharsetDecoder decoder;
 
-        public BytesSource(String name, byte[] bytes, int byteIndex, int length, Charset decoder) {
+        BytesSource(String name, byte[] bytes, int byteIndex, int length, Charset decoder) {
             this.name = name;
             this.bytes = bytes;
             this.byteIndex = byteIndex;
@@ -1256,7 +1256,7 @@ public abstract class Source {
         // Is the final text character a newline?
         final boolean finalNL;
 
-        public TextMap(int[] nlOffsets, int textLength, boolean finalNL) {
+        TextMap(int[] nlOffsets, int textLength, boolean finalNL) {
             this.nlOffsets = nlOffsets;
             this.textLength = textLength;
             this.finalNL = finalNL;

--- a/truffle/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/AnnotationProcessor.java
+++ b/truffle/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/AnnotationProcessor.java
@@ -45,7 +45,7 @@ class AnnotationProcessor<M extends Template> {
 
     private final Set<String> processedElements = new HashSet<>();
 
-    public AnnotationProcessor(AbstractParser<M> parser, CodeTypeElementFactory<M> factory) {
+    AnnotationProcessor(AbstractParser<M> parser, CodeTypeElementFactory<M> factory) {
         this.parser = parser;
         this.factory = factory;
     }

--- a/truffle/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/InteropProcessor.java
+++ b/truffle/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/InteropProcessor.java
@@ -718,7 +718,7 @@ public final class InteropProcessor extends AbstractProcessor {
 
         private final Map<Message, String> messageHandlers;
 
-        public FactoryGenerator(String packageName, String className, String receiverTypeClass, JavaFileObject factoryFile) {
+        FactoryGenerator(String packageName, String className, String receiverTypeClass, JavaFileObject factoryFile) {
             this.receiverTypeClass = receiverTypeClass;
             this.className = className;
             this.packageName = packageName;

--- a/truffle/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/generator/NodeFactoryFactory.java
+++ b/truffle/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/generator/NodeFactoryFactory.java
@@ -52,7 +52,7 @@ class NodeFactoryFactory {
     private final NodeData node;
     private final CodeTypeElement createdFactoryElement;
 
-    public NodeFactoryFactory(ProcessorContext context, NodeData node, CodeTypeElement createdClass) {
+    NodeFactoryFactory(ProcessorContext context, NodeData node, CodeTypeElement createdClass) {
         this.context = context;
         this.node = node;
         this.createdFactoryElement = createdClass;

--- a/truffle/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/generator/NodeGenFactory.java
+++ b/truffle/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/generator/NodeGenFactory.java
@@ -3110,7 +3110,7 @@ public class NodeGenFactory {
         private final boolean fastPath;
         private final boolean needsCastedValues;
 
-        public SpecializationBody(boolean fastPath, boolean needsCastedValues) {
+        SpecializationBody(boolean fastPath, boolean needsCastedValues) {
             this.fastPath = fastPath;
             this.needsCastedValues = needsCastedValues;
         }

--- a/truffle/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/generator/TypeSystemCodeGenerator.java
+++ b/truffle/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/generator/TypeSystemCodeGenerator.java
@@ -238,7 +238,7 @@ public class TypeSystemCodeGenerator extends CodeTypeElementFactory<TypeSystemDa
         private final ProcessorContext context;
         private final TypeSystemData typeSystem;
 
-        public TypeClassFactory(ProcessorContext context, TypeSystemData typeSystem) {
+        TypeClassFactory(ProcessorContext context, TypeSystemData typeSystem) {
             this.context = context;
             this.typeSystem = typeSystem;
         }

--- a/truffle/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/java/model/CodeElement.java
+++ b/truffle/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/java/model/CodeElement.java
@@ -174,7 +174,7 @@ public abstract class CodeElement<E extends Element> implements Element, Generat
 
     private static class StringBuilderCodeWriter extends AbstractCodeWriter {
 
-        public StringBuilderCodeWriter() {
+        StringBuilderCodeWriter() {
             this.writer = new CharArrayWriter();
         }
 
@@ -194,7 +194,7 @@ public abstract class CodeElement<E extends Element> implements Element, Generat
         private final Element parent;
         private final List<T> delegate;
 
-        public ParentableList(Element parent, List<T> delegate) {
+        ParentableList(Element parent, List<T> delegate) {
             this.parent = parent;
             this.delegate = delegate;
         }

--- a/truffle/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/java/model/CodeNames.java
+++ b/truffle/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/java/model/CodeNames.java
@@ -43,7 +43,7 @@ public abstract class CodeNames {
 
         private final String name;
 
-        public NameImpl(String name) {
+        NameImpl(String name) {
             this.name = name;
         }
 

--- a/truffle/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/java/model/CodeTreeBuilder.java
+++ b/truffle/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/java/model/CodeTreeBuilder.java
@@ -738,7 +738,7 @@ public class CodeTreeBuilder {
         private EndCallback atEndListener;
         private CodeTreeKind removeLast;
 
-        public BuilderCodeTree(CodeTree parent, CodeTreeKind kind, TypeMirror type, String string) {
+        BuilderCodeTree(CodeTree parent, CodeTreeKind kind, TypeMirror type, String string) {
             super(parent, kind, type, string);
         }
 
@@ -766,7 +766,7 @@ public class CodeTreeBuilder {
             private final EndCallback callback1;
             private final EndCallback callback2;
 
-            public CompoundCallback(EndCallback callback1, EndCallback callback2) {
+            CompoundCallback(EndCallback callback1, EndCallback callback2) {
                 this.callback1 = callback1;
                 this.callback2 = callback2;
             }

--- a/truffle/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/java/transform/AbstractCodeWriter.java
+++ b/truffle/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/java/transform/AbstractCodeWriter.java
@@ -372,7 +372,7 @@ public abstract class AbstractCodeWriter extends CodeElementScanner<Void, Void> 
 
         private final Element enclosedElement;
 
-        public AnnotationValueWriterVisitor(Element enclosedElement) {
+        AnnotationValueWriterVisitor(Element enclosedElement) {
             this.enclosedElement = enclosedElement;
         }
 
@@ -741,7 +741,7 @@ public abstract class AbstractCodeWriter extends CodeElementScanner<Void, Void> 
         private final Writer delegate;
         private final StringBuilder buffer = new StringBuilder();
 
-        public TrimTrailingSpaceWriter(Writer delegate) {
+        TrimTrailingSpaceWriter(Writer delegate) {
             this.delegate = delegate;
         }
 

--- a/truffle/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/java/transform/OrganizedImports.java
+++ b/truffle/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/java/transform/OrganizedImports.java
@@ -303,7 +303,7 @@ public final class OrganizedImports {
 
             private final Element enclosingElement;
 
-            public AnnotationValueReferenceVisitor(Element enclosedElement) {
+            AnnotationValueReferenceVisitor(Element enclosedElement) {
                 this.enclosingElement = enclosedElement;
             }
 

--- a/truffle/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/parser/TypeCastParser.java
+++ b/truffle/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/parser/TypeCastParser.java
@@ -37,7 +37,7 @@ import javax.lang.model.type.TypeMirror;
 
 class TypeCastParser extends TypeSystemMethodParser<TypeCastData> {
 
-    public TypeCastParser(ProcessorContext context, TypeSystemData typeSystem) {
+    TypeCastParser(ProcessorContext context, TypeSystemData typeSystem) {
         super(context, typeSystem);
     }
 

--- a/truffle/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/parser/TypeCheckParser.java
+++ b/truffle/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/parser/TypeCheckParser.java
@@ -36,7 +36,7 @@ import javax.lang.model.type.TypeMirror;
 
 class TypeCheckParser extends TypeSystemMethodParser<TypeCheckData> {
 
-    public TypeCheckParser(ProcessorContext context, TypeSystemData typeSystem) {
+    TypeCheckParser(ProcessorContext context, TypeSystemData typeSystem) {
         super(context, typeSystem);
     }
 

--- a/truffle/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/parser/TypeSystemMethodParser.java
+++ b/truffle/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/parser/TypeSystemMethodParser.java
@@ -32,7 +32,7 @@ import javax.lang.model.type.TypeMirror;
 
 abstract class TypeSystemMethodParser<E extends TemplateMethod> extends TemplateMethodParser<TypeSystemData, E> {
 
-    public TypeSystemMethodParser(ProcessorContext context, TypeSystemData typeSystem) {
+    TypeSystemMethodParser(ProcessorContext context, TypeSystemData typeSystem) {
         super(context, typeSystem);
     }
 

--- a/truffle/com.oracle.truffle.object/src/com/oracle/truffle/object/ConsListPropertyMap.java
+++ b/truffle/com.oracle.truffle.object/src/com/oracle/truffle/object/ConsListPropertyMap.java
@@ -284,7 +284,7 @@ final class ConsListPropertyMap extends PropertyMap {
     private static final class MapEntryImpl implements Map.Entry<Object, Property> {
         private final Property backingProperty;
 
-        public MapEntryImpl(Property backingProperty) {
+        MapEntryImpl(Property backingProperty) {
             this.backingProperty = backingProperty;
         }
 

--- a/truffle/com.oracle.truffle.object/src/com/oracle/truffle/object/debug/ShapeProfiler.java
+++ b/truffle/com.oracle.truffle.object/src/com/oracle/truffle/object/debug/ShapeProfiler.java
@@ -107,7 +107,7 @@ public class ShapeProfiler {
         private long pas;
         private long pfs;
 
-        public ShapeStats(String label) {
+        ShapeStats(String label) {
             this.label = label;
         }
 

--- a/truffle/com.oracle.truffle.sl/src/com/oracle/truffle/sl/parser/SLNodeFactory.java
+++ b/truffle/com.oracle.truffle.sl/src/com/oracle/truffle/sl/parser/SLNodeFactory.java
@@ -105,7 +105,7 @@ public class SLNodeFactory {
         protected final LexicalScope outer;
         protected final Map<String, FrameSlot> locals;
 
-        public LexicalScope(LexicalScope outer) {
+        LexicalScope(LexicalScope outer) {
             this.outer = outer;
             this.locals = new HashMap<>();
             if (outer != null) {

--- a/truffle/com.oracle.truffle.sl/src/com/oracle/truffle/sl/runtime/SLFunctionForeignAccess.java
+++ b/truffle/com.oracle.truffle.sl/src/com/oracle/truffle/sl/runtime/SLFunctionForeignAccess.java
@@ -90,7 +90,7 @@ final class SLFunctionForeignAccess implements ForeignAccess.Factory {
     private static class SLForeignCallerRootNode extends RootNode {
         @Child private SLDispatchNode dispatch = SLDispatchNodeGen.create();
 
-        public SLForeignCallerRootNode() {
+        SLForeignCallerRootNode() {
             super(SLLanguage.class, null, null);
         }
 
@@ -108,7 +108,7 @@ final class SLFunctionForeignAccess implements ForeignAccess.Factory {
     }
 
     private static class SLForeignNullCheckNode extends RootNode {
-        public SLForeignNullCheckNode() {
+        SLForeignNullCheckNode() {
             super(SLLanguage.class, null, null);
         }
 
@@ -120,7 +120,7 @@ final class SLFunctionForeignAccess implements ForeignAccess.Factory {
     }
 
     private static class SLForeignExecutableCheckNode extends RootNode {
-        public SLForeignExecutableCheckNode() {
+        SLForeignExecutableCheckNode() {
             super(SLLanguage.class, null, null);
         }
 


### PR DESCRIPTION
The latest Eclipse Checkstyle plugin (version 6.14) flagged `public` and `private` keywords as redundant on inner classes that are declared for instance as private.

It also flagged redundant static keywords for enum, because they are implicitly static.

Note, this is a rather crosscutting change that touches quite a bit of code. This should probably be carefully considered before merging.

Since there are quite a few places also in Graal that have these issues, it might not be desirable to change it all at once (Eclipse has a quick fix feature, but it didn't work for me). Here the patch to mx, that worked for me (note, no 6.14.1 jar on lafo yet.

```patch
diff --git a/mx.mx/suite.py b/mx.mx/suite.py
index 528c414..8e3640b 100644
--- a/mx.mx/suite.py
+++ b/mx.mx/suite.py
@@ -59,15 +59,15 @@ suite = {
 
     "CHECKSTYLE" : {
       "urls" : [
-        "https://lafo.ssw.uni-linz.ac.at/pub/graal-external-deps/checkstyle-6.0-all.jar",
-        "jar:http://sourceforge.net/projects/checkstyle/files/checkstyle/6.0/checkstyle-6.0-bin.zip/download!/checkstyle-6.0/checkstyle-6.0-all.jar",
+        "https://lafo.ssw.uni-linz.ac.at/pub/graal-external-deps/checkstyle-6.14.1-all.jar",
+        "jar:http://sourceforge.net/projects/checkstyle/files/checkstyle/6.14.1/checkstyle-6.14.1-bin.zip/download!/checkstyle-6.14.1/checkstyle-6.14.1-all.jar",
       ],
-      "sha1" : "2bedc7feded58b5fd65595323bfaf7b9bb6a3c7a",
+      "sha1" : "8e2c3a2bcef100c084e6ea80cc426b3443632d8c",
       "licence" : "LGPLv21",
       "maven" : {
         "groupId" : "com.puppycrawl.tools",
         "artifactId" : "checkstyle",
-        "version" : "6.0",
+        "version" : "6.14.1",
       }
     },
 
```