### PR TITLE
Fix virtual frame abbreviations

### DIFF
--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/ExampleReadNode.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/ExampleReadNode.java
@@ -34,7 +34,7 @@ language = TestTruffleLanguage.class)
 public final class ExampleReadNode extends ExampleReadBaseNode {
 
     @Override
-    protected Object access(VirtualFrame vf,
+    protected Object access(VirtualFrame frame,
                     ExampleTruffleObject receiver,
                     String name) {
         if (ExampleTruffleObject.MEMBER_NAME.equals(name)) {

--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/ExampleWriteNode.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/ExampleWriteNode.java
@@ -30,7 +30,7 @@ import com.oracle.truffle.api.interop.UnknownIdentifierException;
 public final class ExampleWriteNode extends ExampleWriteBaseNode {
 
     @Override
-    protected int access(VirtualFrame vf, ExampleTruffleObject receiver, String name, int value) {
+    protected int access(VirtualFrame frame, ExampleTruffleObject receiver, String name, int value) {
         if (ExampleTruffleObject.MEMBER_NAME.equals(name)) {
             receiver.setValue(value);
             return value;

--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/Execute2.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/Execute2.java
@@ -29,7 +29,7 @@ import com.oracle.truffle.api.interop.AcceptMessage;
 public final class Execute2 extends BaseExecute2 {
     @SuppressWarnings({"static-method", "unused"})
     @ExpectError({"The first argument must be a com.oracle.truffle.api.frame.VirtualFrame- but is java.lang.String"})
-    public Object access(String frame, ValidTruffleObject object, Object[] args) {
+    public Object access(String string, ValidTruffleObject object, Object[] args) {
         return true;
     }
 }

--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/Invoke4.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/Invoke4.java
@@ -30,7 +30,7 @@ public final class Invoke4 extends BaseInvoke4 {
 
     @SuppressWarnings({"static-method", "unused"})
     @ExpectError({"The first argument must be a com.oracle.truffle.api.frame.VirtualFrame- but is java.lang.String"})
-    protected int access(String frame, ValidTruffleObject receiver, Object name, Object[] args) {
+    protected int access(String string, ValidTruffleObject receiver, Object name, Object[] args) {
         return 0;
     }
 }

--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/Invoke4.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/Invoke4.java
@@ -30,7 +30,7 @@ public final class Invoke4 extends BaseInvoke4 {
 
     @SuppressWarnings({"static-method", "unused"})
     @ExpectError({"The first argument must be a com.oracle.truffle.api.frame.VirtualFrame- but is java.lang.String"})
-    protected int access(String vf, ValidTruffleObject receiver, Object name, Object[] args) {
+    protected int access(String frame, ValidTruffleObject receiver, Object name, Object[] args) {
         return 0;
     }
 }

--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/Invoke5.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/Invoke5.java
@@ -28,7 +28,7 @@ import com.oracle.truffle.api.interop.AcceptMessage;
 @AcceptMessage(value = "INVOKE", receiverType = ValidTruffleObject.class, language = TestTruffleLanguage.class)
 public final class Invoke5 extends BaseInvoke5 {
     @Override
-    protected int access(VirtualFrame vf, ValidTruffleObject receiver, String name, Object[] args) {
+    protected int access(VirtualFrame frame, ValidTruffleObject receiver, String name, Object[] args) {
         return 0;
     }
 }

--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/Invoke6.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/Invoke6.java
@@ -28,12 +28,12 @@ import com.oracle.truffle.api.interop.AcceptMessage;
 @AcceptMessage(value = "INVOKE", receiverType = ValidTruffleObject.class, language = TestTruffleLanguage.class)
 public final class Invoke6 extends BaseInvoke6 {
     @Override
-    protected int access(VirtualFrame vf, ValidTruffleObjectB receiver, String name, Object[] args) {
+    protected int access(VirtualFrame frame, ValidTruffleObjectB receiver, String name, Object[] args) {
         return 0;
     }
 
     @Override
-    protected int access(VirtualFrame vf, ValidTruffleObject receiver, String name, Object[] args) {
+    protected int access(VirtualFrame frame, ValidTruffleObject receiver, String name, Object[] args) {
         return 0;
     }
 }

--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/IsBoxed2.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/IsBoxed2.java
@@ -29,7 +29,7 @@ import com.oracle.truffle.api.interop.AcceptMessage;
 public final class IsBoxed2 extends BaseIsBoxed2 {
     @SuppressWarnings({"static-method", "unused"})
     @ExpectError({"The first argument of access must be of type com.oracle.truffle.api.frame.VirtualFrame- but is java.lang.String"})
-    public Object access(String frame, ValidTruffleObject object) {
+    public Object access(String string, ValidTruffleObject object) {
         return true;
     }
 }

--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/New.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/New.java
@@ -28,12 +28,12 @@ import com.oracle.truffle.api.interop.AcceptMessage;
 @AcceptMessage(value = "NEW", receiverType = ValidTruffleObject.class, language = TestTruffleLanguage.class)
 public final class New extends BaseNew {
     @Override
-    protected int access(VirtualFrame vf, ValidTruffleObjectB receiver, Object[] args) {
+    protected int access(VirtualFrame frame, ValidTruffleObjectB receiver, Object[] args) {
         return 0;
     }
 
     @Override
-    protected int access(VirtualFrame vf, ValidTruffleObject receiver, Object[] args) {
+    protected int access(VirtualFrame frame, ValidTruffleObject receiver, Object[] args) {
         return 0;
     }
 }

--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/New1.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/New1.java
@@ -29,7 +29,7 @@ import com.oracle.truffle.api.interop.AcceptMessage;
 public final class New1 extends BaseNew1 {
 
     @Override
-    protected int access(VirtualFrame vf, ValidTruffleObject receiver, Object[] args) {
+    protected int access(VirtualFrame frame, ValidTruffleObject receiver, Object[] args) {
         return 0;
     }
 }

--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/ReadNode2.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/ReadNode2.java
@@ -31,7 +31,7 @@ import com.oracle.truffle.api.interop.AcceptMessage;
 public final class ReadNode2 extends BaseReadNode2 {
 
     @SuppressWarnings({"static-method", "unused"})
-    protected int access(VirtualFrame vf, Object receiver, Object name) {
+    protected int access(VirtualFrame frame, Object receiver, Object name) {
         return 0;
     }
 }

--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/ReadNode4.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/ReadNode4.java
@@ -31,7 +31,7 @@ public final class ReadNode4 extends BaseReadNode4 {
 
     @SuppressWarnings({"static-method", "unused"})
     @ExpectError({"access method has to have 3 arguments"})
-    protected int access(VirtualFrame vf, Object receiver, Object name, int i) {
+    protected int access(VirtualFrame frame, Object receiver, Object name, int i) {
         return 0;
     }
 }

--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/ReadNode5.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/ReadNode5.java
@@ -30,7 +30,7 @@ public final class ReadNode5 extends BaseReadNode5 {
 
     @SuppressWarnings({"static-method", "unused"})
     @ExpectError({"The first argument must be a com.oracle.truffle.api.frame.VirtualFrame- but is java.lang.String"})
-    protected int access(String vf, Object receiver, Object name) {
+    protected int access(String frame, Object receiver, Object name) {
         return 0;
     }
 }

--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/ReadNode5.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/ReadNode5.java
@@ -30,7 +30,7 @@ public final class ReadNode5 extends BaseReadNode5 {
 
     @SuppressWarnings({"static-method", "unused"})
     @ExpectError({"The first argument must be a com.oracle.truffle.api.frame.VirtualFrame- but is java.lang.String"})
-    protected int access(String frame, Object receiver, Object name) {
+    protected int access(String string, Object receiver, Object name) {
         return 0;
     }
 }

--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/ReadNode6.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/ReadNode6.java
@@ -29,7 +29,7 @@ import com.oracle.truffle.api.interop.AcceptMessage;
 public final class ReadNode6 extends BaseReadNode6 {
 
     @Override
-    protected Object access(VirtualFrame vf, Object receiver, Object name) {
+    protected Object access(VirtualFrame frame, Object receiver, Object name) {
         return 0;
     }
 }

--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/ReadNode7.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/ReadNode7.java
@@ -29,17 +29,17 @@ import com.oracle.truffle.api.interop.AcceptMessage;
 public final class ReadNode7 extends BaseReadNode7 {
 
     @Override
-    protected Object access(VirtualFrame vf, ValidTruffleObjectB receiver, Object name) {
+    protected Object access(VirtualFrame frame, ValidTruffleObjectB receiver, Object name) {
         return 0;
     }
 
     @Override
-    protected Object access(VirtualFrame vf, ValidTruffleObject receiver, Object name) {
+    protected Object access(VirtualFrame frame, ValidTruffleObject receiver, Object name) {
         return 0;
     }
 
     @Override
-    protected Object access(VirtualFrame vf, Object receiver, Object name) {
+    protected Object access(VirtualFrame frame, Object receiver, Object name) {
         return 0;
     }
 }

--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/WriteNode.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/WriteNode.java
@@ -30,7 +30,7 @@ public final class WriteNode extends BaseWriteNode {
 
     @SuppressWarnings({"static-method", "unused"})
     @ExpectError({"The first argument must be a com.oracle.truffle.api.frame.VirtualFrame- but is java.lang.String"})
-    protected int access(String frame, Object receiver, Object name, Object value) {
+    protected int access(String string, Object receiver, Object name, Object value) {
         return 0;
     }
 }

--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/WriteNode.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/WriteNode.java
@@ -30,7 +30,7 @@ public final class WriteNode extends BaseWriteNode {
 
     @SuppressWarnings({"static-method", "unused"})
     @ExpectError({"The first argument must be a com.oracle.truffle.api.frame.VirtualFrame- but is java.lang.String"})
-    protected int access(String vf, Object receiver, Object name, Object value) {
+    protected int access(String frame, Object receiver, Object name, Object value) {
         return 0;
     }
 }

--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/WriteNode2.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/WriteNode2.java
@@ -31,7 +31,7 @@ public final class WriteNode2 extends BaseWriteNode2 {
 
     @SuppressWarnings({"static-method", "unused"})
     @ExpectError({"access method has to have 4 arguments"})
-    protected int access(VirtualFrame vf, Object receiver, Object name) {
+    protected int access(VirtualFrame frame, Object receiver, Object name) {
         return 0;
     }
 }

--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/WriteNode3.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/WriteNode3.java
@@ -29,7 +29,7 @@ import com.oracle.truffle.api.interop.AcceptMessage;
 public final class WriteNode3 extends BaseWriteNode3 {
 
     @Override
-    protected int access(VirtualFrame vf, Object receiver, Object name, Object value) {
+    protected int access(VirtualFrame frame, Object receiver, Object name, Object value) {
         return 0;
     }
 }

--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/WriteNode4.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/interop/WriteNode4.java
@@ -29,17 +29,17 @@ import com.oracle.truffle.api.interop.AcceptMessage;
 public final class WriteNode4 extends BaseWriteNode4 {
 
     @Override
-    protected int access(VirtualFrame vf, ValidTruffleObject receiver, Object name, String value) {
+    protected int access(VirtualFrame frame, ValidTruffleObject receiver, Object name, String value) {
         return 0;
     }
 
     @Override
-    protected int access(VirtualFrame vf, ValidTruffleObject receiver, Object name, Object value) {
+    protected int access(VirtualFrame frame, ValidTruffleObject receiver, Object name, Object value) {
         return 0;
     }
 
     @Override
-    protected int access(VirtualFrame vf, Object receiver, Object name, Object value) {
+    protected int access(VirtualFrame frame, Object receiver, Object name, Object value) {
         return 0;
     }
 }

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/instrument/EvalInstrumentTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/instrument/EvalInstrumentTest.java
@@ -96,14 +96,14 @@ public class EvalInstrumentTest {
         final int[] evalCount = {0};
         final Instrument instrument = instrumenter.attach(addNodeProbe[0], source42, new EvalInstrumentListener() {
 
-            public void onExecution(Node node, VirtualFrame vFrame, Object result) {
+            public void onExecution(Node node, VirtualFrame frame, Object result) {
                 evalCount[0] = evalCount[0] + 1;
                 if (result instanceof Integer) {
                     evalResult[0] = (Integer) result;
                 }
             }
 
-            public void onFailure(Node node, VirtualFrame vFrame, Exception ex) {
+            public void onFailure(Node node, VirtualFrame frame, Exception ex) {
                 fail("Eval test evaluates without exception");
 
             }

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/instrument/InstrumentationTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/instrument/InstrumentationTest.java
@@ -275,19 +275,19 @@ public class InstrumentationTest {
         public void attach(Probe probe) {
             instrument = instrumenter.attach(probe, new StandardInstrumentListener() {
 
-                public void onEnter(Probe p, Node node, VirtualFrame vFrame) {
+                public void onEnter(Probe p, Node node, VirtualFrame frame) {
                     enterCount++;
                 }
 
-                public void onReturnVoid(Probe p, Node node, VirtualFrame vFrame) {
+                public void onReturnVoid(Probe p, Node node, VirtualFrame frame) {
                     leaveCount++;
                 }
 
-                public void onReturnValue(Probe p, Node node, VirtualFrame vFrame, Object result) {
+                public void onReturnValue(Probe p, Node node, VirtualFrame frame, Object result) {
                     leaveCount++;
                 }
 
-                public void onReturnExceptional(Probe p, Node node, VirtualFrame vFrame, Throwable exception) {
+                public void onReturnExceptional(Probe p, Node node, VirtualFrame frame, Throwable exception) {
                     leaveCount++;
                 }
             }, "Instrumentation Test Counter");
@@ -354,7 +354,7 @@ public class InstrumentationTest {
         public int counter = 0;
 
         @Override
-        public void onEnter(Probe probe, Node node, VirtualFrame vFrame) {
+        public void onEnter(Probe probe, Node node, VirtualFrame frame) {
             counter++;
         }
     }

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/instrument/InstrumentationTestNodes.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/instrument/InstrumentationTestNodes.java
@@ -35,7 +35,7 @@ import com.oracle.truffle.api.nodes.RootNode;
 class InstrumentationTestNodes {
 
     abstract static class TestLanguageNode extends Node {
-        public abstract Object execute(VirtualFrame vFrame);
+        public abstract Object execute(VirtualFrame frame);
 
     }
 
@@ -70,14 +70,14 @@ class InstrumentationTestNodes {
         }
 
         @Override
-        public Object execute(VirtualFrame vFrame) {
-            eventHandlerNode.enter(child, vFrame);
+        public Object execute(VirtualFrame frame) {
+            eventHandlerNode.enter(child, frame);
             Object result;
             try {
-                result = child.execute(vFrame);
-                eventHandlerNode.returnValue(child, vFrame, result);
+                result = child.execute(frame);
+                eventHandlerNode.returnValue(child, frame, result);
             } catch (Exception e) {
-                eventHandlerNode.returnExceptional(child, vFrame, e);
+                eventHandlerNode.returnExceptional(child, frame, e);
                 throw (e);
             }
             return result;
@@ -95,7 +95,7 @@ class InstrumentationTestNodes {
         }
 
         @Override
-        public Object execute(VirtualFrame vFrame) {
+        public Object execute(VirtualFrame frame) {
             return new Integer(this.value);
         }
     }
@@ -113,8 +113,8 @@ class InstrumentationTestNodes {
         }
 
         @Override
-        public Object execute(VirtualFrame vFrame) {
-            return new Integer(((Integer) leftChild.execute(vFrame)).intValue() + ((Integer) rightChild.execute(vFrame)).intValue());
+        public Object execute(VirtualFrame frame) {
+            return new Integer(((Integer) leftChild.execute(frame)).intValue() + ((Integer) rightChild.execute(frame)).intValue());
         }
     }
 
@@ -137,8 +137,8 @@ class InstrumentationTestNodes {
         }
 
         @Override
-        public Object execute(VirtualFrame vFrame) {
-            return body.execute(vFrame);
+        public Object execute(VirtualFrame frame) {
+            return body.execute(frame);
         }
 
         @Override
@@ -169,8 +169,8 @@ class InstrumentationTestNodes {
         }
 
         @Override
-        public Object execute(VirtualFrame vFrame) {
-            return body.execute(vFrame);
+        public Object execute(VirtualFrame frame) {
+            return body.execute(frame);
         }
 
         @Override

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/debug/Debugger.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/debug/Debugger.java
@@ -404,13 +404,13 @@ public final class Debugger {
             beforeTagInstrument = instrumenter.attach(STEPPING_TAG, new StandardBeforeInstrumentListener() {
                 @TruffleBoundary
                 @Override
-                public void onEnter(Probe probe, Node node, VirtualFrame vFrame) {
+                public void onEnter(Probe probe, Node node, VirtualFrame frame) {
                     // HALT: just before statement
                     --unfinishedStepCount;
                     strategyTrace("HALT BEFORE", "unfinished steps=%d", unfinishedStepCount);
                     // Should run in fast path
                     if (unfinishedStepCount <= 0) {
-                        halt(node, vFrame.materialize(), true);
+                        halt(node, frame.materialize(), true);
                     }
                     strategyTrace("RESUME BEFORE", "");
                 }
@@ -418,16 +418,16 @@ public final class Debugger {
 
             afterTagInstrument = instrumenter.attach(CALL_TAG, new StandardAfterInstrumentListener() {
 
-                public void onReturnVoid(Probe probe, Node node, VirtualFrame vFrame) {
-                    doHalt(node, vFrame.materialize());
+                public void onReturnVoid(Probe probe, Node node, VirtualFrame frame) {
+                    doHalt(node, frame.materialize());
                 }
 
-                public void onReturnValue(Probe probe, Node node, VirtualFrame vFrame, Object result) {
-                    doHalt(node, vFrame.materialize());
+                public void onReturnValue(Probe probe, Node node, VirtualFrame frame, Object result) {
+                    doHalt(node, frame.materialize());
                 }
 
-                public void onReturnExceptional(Probe probe, Node node, VirtualFrame vFrame, Throwable exception) {
-                    doHalt(node, vFrame.materialize());
+                public void onReturnExceptional(Probe probe, Node node, VirtualFrame frame, Throwable exception) {
+                    doHalt(node, frame.materialize());
                 }
 
                 @TruffleBoundary
@@ -476,16 +476,16 @@ public final class Debugger {
 
             afterTagInstrument = instrumenter.attach(CALL_TAG, new StandardAfterInstrumentListener() {
 
-                public void onReturnVoid(Probe probe, Node node, VirtualFrame vFrame) {
-                    doHalt(node, vFrame.materialize());
+                public void onReturnVoid(Probe probe, Node node, VirtualFrame frame) {
+                    doHalt(node, frame.materialize());
                 }
 
-                public void onReturnValue(Probe probe, Node node, VirtualFrame vFrame, Object result) {
-                    doHalt(node, vFrame.materialize());
+                public void onReturnValue(Probe probe, Node node, VirtualFrame frame, Object result) {
+                    doHalt(node, frame.materialize());
                 }
 
-                public void onReturnExceptional(Probe probe, Node node, VirtualFrame vFrame, Throwable exception) {
-                    doHalt(node, vFrame.materialize());
+                public void onReturnExceptional(Probe probe, Node node, VirtualFrame frame, Throwable exception) {
+                    doHalt(node, frame.materialize());
                 }
 
                 @TruffleBoundary
@@ -535,7 +535,7 @@ public final class Debugger {
 
                 @TruffleBoundary
                 @Override
-                public void onEnter(Probe probe, Node node, VirtualFrame vFrame) {
+                public void onEnter(Probe probe, Node node, VirtualFrame frame) {
                     final int currentStackDepth = currentStackDepth();
                     if (currentStackDepth <= stackDepth) {
                         // HALT: stack depth unchanged or smaller; treat like StepInto
@@ -545,7 +545,7 @@ public final class Debugger {
                         }
                         // Test should run in fast path
                         if (unfinishedStepCount <= 0) {
-                            halt(node, vFrame.materialize(), true);
+                            halt(node, frame.materialize(), true);
                         }
                     } else {
                         // CONTINUE: Stack depth increased; don't count as a step
@@ -559,16 +559,16 @@ public final class Debugger {
 
             afterTagInstrument = instrumenter.attach(CALL_TAG, new StandardAfterInstrumentListener() {
 
-                public void onReturnVoid(Probe probe, Node node, VirtualFrame vFrame) {
-                    doHalt(node, vFrame.materialize());
+                public void onReturnVoid(Probe probe, Node node, VirtualFrame frame) {
+                    doHalt(node, frame.materialize());
                 }
 
-                public void onReturnValue(Probe probe, Node node, VirtualFrame vFrame, Object result) {
-                    doHalt(node, vFrame.materialize());
+                public void onReturnValue(Probe probe, Node node, VirtualFrame frame, Object result) {
+                    doHalt(node, frame.materialize());
                 }
 
-                public void onReturnExceptional(Probe probe, Node node, VirtualFrame vFrame, Throwable exception) {
-                    doHalt(node, vFrame.materialize());
+                public void onReturnExceptional(Probe probe, Node node, VirtualFrame frame, Throwable exception) {
+                    doHalt(node, frame.materialize());
                 }
 
                 @TruffleBoundary
@@ -623,14 +623,14 @@ public final class Debugger {
             beforeTagInstrument = instrumenter.attach(STEPPING_TAG, new StandardBeforeInstrumentListener() {
                 @TruffleBoundary
                 @Override
-                public void onEnter(Probe probe, Node node, VirtualFrame vFrame) {
+                public void onEnter(Probe probe, Node node, VirtualFrame frame) {
                     final int currentStackDepth = currentStackDepth();
                     if (currentStackDepth <= startStackDepth) {
                         // At original step depth (or smaller) after being nested
                         --unfinishedStepCount;
                         strategyTrace("HALT AFTER", "unfinished steps=%d stackDepth start=%d current=%d", unfinishedStepCount, stackDepth, currentStackDepth);
                         if (unfinishedStepCount <= 0) {
-                            halt(node, vFrame.materialize(), false);
+                            halt(node, frame.materialize(), false);
                         }
                         // TODO (mlvdv) fixme for multiple steps
                         strategyTrace("RESUME BEFORE", "");

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/debug/LineBreakpointFactory.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/debug/LineBreakpointFactory.java
@@ -405,9 +405,9 @@ final class LineBreakpointFactory {
             setState(after);
         }
 
-        private void doBreak(Node node, VirtualFrame vFrame) {
+        private void doBreak(Node node, VirtualFrame frame) {
             if (incrHitCountCheckIgnore()) {
-                breakpointCallback.haltedAt(node, vFrame.materialize(), BREAKPOINT_NAME);
+                breakpointCallback.haltedAt(node, frame.materialize(), BREAKPOINT_NAME);
             }
         }
 
@@ -416,7 +416,7 @@ final class LineBreakpointFactory {
          * where the breakpoint is set. Designed so that when in the fast path, there is either an
          * unconditional "halt" call to the debugger or nothing.
          */
-        private void nodeEnter(Node astNode, VirtualFrame vFrame) {
+        private void nodeEnter(Node astNode, VirtualFrame frame) {
 
             // Deopt if the global active/inactive flag has changed
             try {
@@ -436,31 +436,31 @@ final class LineBreakpointFactory {
                 if (isOneShot()) {
                     dispose();
                 }
-                LineBreakpointImpl.this.doBreak(astNode, vFrame);
+                LineBreakpointImpl.this.doBreak(astNode, frame);
             }
         }
 
-        public void onExecution(Node node, VirtualFrame vFrame, Object result) {
+        public void onExecution(Node node, VirtualFrame frame, Object result) {
             if (result instanceof Boolean) {
                 final boolean condition = (Boolean) result;
                 if (TRACE) {
                     trace("breakpoint condition = %b  %s", condition, getShortDescription());
                 }
                 if (condition) {
-                    nodeEnter(node, vFrame);
+                    nodeEnter(node, frame);
                 }
             } else {
-                onFailure(node, vFrame, new RuntimeException("breakpint failure = non-boolean condition " + result.toString()));
+                onFailure(node, frame, new RuntimeException("breakpint failure = non-boolean condition " + result.toString()));
             }
         }
 
-        public void onFailure(Node node, VirtualFrame vFrame, Exception ex) {
+        public void onFailure(Node node, VirtualFrame frame, Exception ex) {
             addExceptionWarning(ex);
             if (TRACE) {
                 trace("breakpoint failure = %s  %s", ex, getShortDescription());
             }
             // Take the breakpoint if evaluation fails.
-            nodeEnter(node, vFrame);
+            nodeEnter(node, frame);
         }
 
         @TruffleBoundary
@@ -481,8 +481,8 @@ final class LineBreakpointFactory {
         private final class UnconditionalLineBreakInstrumentListener extends DefaultStandardInstrumentListener {
 
             @Override
-            public void onEnter(Probe probe, Node node, VirtualFrame vFrame) {
-                LineBreakpointImpl.this.nodeEnter(node, vFrame);
+            public void onEnter(Probe probe, Node node, VirtualFrame frame) {
+                LineBreakpointImpl.this.nodeEnter(node, frame);
             }
         }
     }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/debug/TagBreakpointFactory.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/debug/TagBreakpointFactory.java
@@ -366,9 +366,9 @@ final class TagBreakpointFactory {
             setState(after);
         }
 
-        private void doBreak(Node node, VirtualFrame vFrame) {
+        private void doBreak(Node node, VirtualFrame frame) {
             if (incrHitCountCheckIgnore()) {
-                breakpointCallback.haltedAt(node, vFrame.materialize(), BREAKPOINT_NAME);
+                breakpointCallback.haltedAt(node, frame.materialize(), BREAKPOINT_NAME);
             }
         }
 
@@ -377,7 +377,7 @@ final class TagBreakpointFactory {
          * where the breakpoint is set. Designed so that when in the fast path, there is either an
          * unconditional "halt" call to the debugger or nothing.
          */
-        private void nodeEnter(Node astNode, VirtualFrame vFrame) {
+        private void nodeEnter(Node astNode, VirtualFrame frame) {
 
             // Deopt if the global active/inactive flag has changed
             try {
@@ -397,32 +397,32 @@ final class TagBreakpointFactory {
                 if (isOneShot()) {
                     dispose();
                 }
-                TagBreakpointImpl.this.doBreak(astNode, vFrame);
+                TagBreakpointImpl.this.doBreak(astNode, frame);
             }
 
         }
 
-        public void onExecution(Node node, VirtualFrame vFrame, Object result) {
+        public void onExecution(Node node, VirtualFrame frame, Object result) {
             if (result instanceof Boolean) {
                 final boolean condition = (Boolean) result;
                 if (TRACE) {
                     trace("breakpoint condition = %b  %s", condition, getShortDescription());
                 }
                 if (condition) {
-                    nodeEnter(node, vFrame);
+                    nodeEnter(node, frame);
                 }
             } else {
-                onFailure(node, vFrame, new RuntimeException("breakpint failure = non-boolean condition " + result.toString()));
+                onFailure(node, frame, new RuntimeException("breakpint failure = non-boolean condition " + result.toString()));
             }
         }
 
-        public void onFailure(Node node, VirtualFrame vFrame, Exception ex) {
+        public void onFailure(Node node, VirtualFrame frame, Exception ex) {
             addExceptionWarning(ex);
             if (TRACE) {
                 trace("breakpoint failure = %s  %s", ex, getShortDescription());
             }
             // Take the breakpoint if evaluation fails.
-            nodeEnter(node, vFrame);
+            nodeEnter(node, frame);
         }
 
         @TruffleBoundary
@@ -443,8 +443,8 @@ final class TagBreakpointFactory {
         private final class UnconditionalTagBreakInstrumentListener extends DefaultStandardInstrumentListener {
 
             @Override
-            public void onEnter(Probe probe, Node node, VirtualFrame vFrame) {
-                TagBreakpointImpl.this.nodeEnter(node, vFrame);
+            public void onEnter(Probe probe, Node node, VirtualFrame frame) {
+                TagBreakpointImpl.this.nodeEnter(node, frame);
             }
         }
 

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/EvalInstrumentListener.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/EvalInstrumentListener.java
@@ -51,10 +51,10 @@ public interface EvalInstrumentListener {
      * evaluation; annotate with {@link TruffleBoundary} if this should not be permitted.
      *
      * @param node the guest language AST node at which the expression was evaluated
-     * @param vFrame execution frame at the guest-language AST node
+     * @param frame execution frame at the guest-language AST node
      * @param result expression evaluation
      */
-    void onExecution(Node node, VirtualFrame vFrame, Object result);
+    void onExecution(Node node, VirtualFrame frame, Object result);
 
     /**
      * Notifies listener that a client-provided Guest Language expression
@@ -68,9 +68,9 @@ public interface EvalInstrumentListener {
      *
      * @param node the guest-language AST node to which the host Instrument's {@link Probe} is
      *            attached
-     * @param vFrame execution frame at the guest-language AST node
+     * @param frame execution frame at the guest-language AST node
      * @param ex the exception
      */
-    void onFailure(Node node, VirtualFrame vFrame, Exception ex);
+    void onFailure(Node node, VirtualFrame frame, Exception ex);
 
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/EventHandlerNode.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/EventHandlerNode.java
@@ -39,22 +39,22 @@ public abstract class EventHandlerNode extends Node implements InstrumentationNo
     /**
      * An AST node's execute method is about to be called.
      */
-    public abstract void enter(Node node, VirtualFrame vFrame);
+    public abstract void enter(Node node, VirtualFrame frame);
 
     /**
      * An AST Node's {@code void}-valued execute method has just returned.
      */
-    public abstract void returnVoid(Node node, VirtualFrame vFrame);
+    public abstract void returnVoid(Node node, VirtualFrame frame);
 
     /**
      * An AST Node's execute method has just returned a value (boxed if primitive).
      */
-    public abstract void returnValue(Node node, VirtualFrame vFrame, Object result);
+    public abstract void returnValue(Node node, VirtualFrame frame, Object result);
 
     /**
      * An AST Node's execute method has just thrown an exception.
      */
-    public abstract void returnExceptional(Node node, VirtualFrame vFrame, Throwable exception);
+    public abstract void returnExceptional(Node node, VirtualFrame frame, Throwable exception);
 
     /**
      * Gets the {@link Probe} that manages this chain of event handling.

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/ProbeInstrument.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/ProbeInstrument.java
@@ -196,34 +196,34 @@ public abstract class ProbeInstrument extends Instrument {
             }
 
             @Override
-            public void enter(Node node, VirtualFrame vFrame) {
+            public void enter(Node node, VirtualFrame frame) {
                 SimpleInstrument.this.simpleListener.onEnter(SimpleInstrument.this.probe);
                 if (nextInstrumentNode != null) {
-                    nextInstrumentNode.enter(node, vFrame);
+                    nextInstrumentNode.enter(node, frame);
                 }
             }
 
             @Override
-            public void returnVoid(Node node, VirtualFrame vFrame) {
+            public void returnVoid(Node node, VirtualFrame frame) {
                 SimpleInstrument.this.simpleListener.onReturnVoid(SimpleInstrument.this.probe);
                 if (nextInstrumentNode != null) {
-                    nextInstrumentNode.returnVoid(node, vFrame);
+                    nextInstrumentNode.returnVoid(node, frame);
                 }
             }
 
             @Override
-            public void returnValue(Node node, VirtualFrame vFrame, Object result) {
+            public void returnValue(Node node, VirtualFrame frame, Object result) {
                 SimpleInstrument.this.simpleListener.onReturnValue(SimpleInstrument.this.probe, result);
                 if (nextInstrumentNode != null) {
-                    nextInstrumentNode.returnValue(node, vFrame, result);
+                    nextInstrumentNode.returnValue(node, frame, result);
                 }
             }
 
             @Override
-            public void returnExceptional(Node node, VirtualFrame vFrame, Throwable exception) {
+            public void returnExceptional(Node node, VirtualFrame frame, Throwable exception) {
                 SimpleInstrument.this.simpleListener.onReturnExceptional(SimpleInstrument.this.probe, exception);
                 if (nextInstrumentNode != null) {
-                    nextInstrumentNode.returnExceptional(node, vFrame, exception);
+                    nextInstrumentNode.returnExceptional(node, frame, exception);
                 }
             }
 
@@ -288,34 +288,34 @@ public abstract class ProbeInstrument extends Instrument {
             }
 
             @Override
-            public void enter(Node node, VirtualFrame vFrame) {
-                standardListener.onEnter(StandardInstrument.this.probe, node, vFrame);
+            public void enter(Node node, VirtualFrame frame) {
+                standardListener.onEnter(StandardInstrument.this.probe, node, frame);
                 if (nextInstrumentNode != null) {
-                    nextInstrumentNode.enter(node, vFrame);
+                    nextInstrumentNode.enter(node, frame);
                 }
             }
 
             @Override
-            public void returnVoid(Node node, VirtualFrame vFrame) {
-                standardListener.onReturnVoid(StandardInstrument.this.probe, node, vFrame);
+            public void returnVoid(Node node, VirtualFrame frame) {
+                standardListener.onReturnVoid(StandardInstrument.this.probe, node, frame);
                 if (nextInstrumentNode != null) {
-                    nextInstrumentNode.returnVoid(node, vFrame);
+                    nextInstrumentNode.returnVoid(node, frame);
                 }
             }
 
             @Override
-            public void returnValue(Node node, VirtualFrame vFrame, Object result) {
-                standardListener.onReturnValue(StandardInstrument.this.probe, node, vFrame, result);
+            public void returnValue(Node node, VirtualFrame frame, Object result) {
+                standardListener.onReturnValue(StandardInstrument.this.probe, node, frame, result);
                 if (nextInstrumentNode != null) {
-                    nextInstrumentNode.returnValue(node, vFrame, result);
+                    nextInstrumentNode.returnValue(node, frame, result);
                 }
             }
 
             @Override
-            public void returnExceptional(Node node, VirtualFrame vFrame, Throwable exception) {
-                standardListener.onReturnExceptional(StandardInstrument.this.probe, node, vFrame, exception);
+            public void returnExceptional(Node node, VirtualFrame frame, Throwable exception) {
+                standardListener.onReturnExceptional(StandardInstrument.this.probe, node, frame, exception);
                 if (nextInstrumentNode != null) {
-                    nextInstrumentNode.returnExceptional(node, vFrame, exception);
+                    nextInstrumentNode.returnExceptional(node, frame, exception);
                 }
             }
 
@@ -390,7 +390,7 @@ public abstract class ProbeInstrument extends Instrument {
             }
 
             @Override
-            public void enter(Node node, VirtualFrame vFrame) {
+            public void enter(Node node, VirtualFrame frame) {
                 if (callNode == null) {
                     try {
                         final CallTarget callTarget = Instrumenter.ACCESSOR.parse(languageClass, source, node, names);
@@ -402,45 +402,45 @@ public abstract class ProbeInstrument extends Instrument {
                         }
                     } catch (RuntimeException | IOException ex) {
                         if (evalListener != null) {
-                            evalListener.onFailure(node, vFrame, ex);
+                            evalListener.onFailure(node, frame, ex);
                         }
                     }
                 }
                 if (callNode != null) {
                     try {
-                        final Object result = callNode.call(vFrame, params);
+                        final Object result = callNode.call(frame, params);
                         if (evalListener != null) {
-                            evalListener.onExecution(node, vFrame, result);
+                            evalListener.onExecution(node, frame, result);
                         }
                     } catch (RuntimeException ex) {
                         if (evalListener != null) {
-                            evalListener.onFailure(node, vFrame, ex);
+                            evalListener.onFailure(node, frame, ex);
                         }
                     }
                 }
                 if (nextInstrumentNode != null) {
-                    nextInstrumentNode.enter(node, vFrame);
+                    nextInstrumentNode.enter(node, frame);
                 }
             }
 
             @Override
-            public void returnVoid(Node node, VirtualFrame vFrame) {
+            public void returnVoid(Node node, VirtualFrame frame) {
                 if (nextInstrumentNode != null) {
-                    nextInstrumentNode.returnVoid(node, vFrame);
+                    nextInstrumentNode.returnVoid(node, frame);
                 }
             }
 
             @Override
-            public void returnValue(Node node, VirtualFrame vFrame, Object result) {
+            public void returnValue(Node node, VirtualFrame frame, Object result) {
                 if (nextInstrumentNode != null) {
-                    nextInstrumentNode.returnValue(node, vFrame, result);
+                    nextInstrumentNode.returnValue(node, frame, result);
                 }
             }
 
             @Override
-            public void returnExceptional(Node node, VirtualFrame vFrame, Throwable exception) {
+            public void returnExceptional(Node node, VirtualFrame frame, Throwable exception) {
                 if (nextInstrumentNode != null) {
-                    nextInstrumentNode.returnExceptional(node, vFrame, exception);
+                    nextInstrumentNode.returnExceptional(node, frame, exception);
                 }
             }
 
@@ -500,34 +500,34 @@ public abstract class ProbeInstrument extends Instrument {
             }
 
             @Override
-            public void enter(Node node, VirtualFrame vFrame) {
+            public void enter(Node node, VirtualFrame frame) {
                 if (this.isCompiled != CompilerDirectives.inCompiledCode()) {
                     this.isCompiled = CompilerDirectives.inCompiledCode();
                     TruffleOptInstrument.this.toolOptListener.notifyIsCompiled(this.isCompiled);
                 }
                 if (nextInstrumentNode != null) {
-                    nextInstrumentNode.enter(node, vFrame);
+                    nextInstrumentNode.enter(node, frame);
                 }
             }
 
             @Override
-            public void returnVoid(Node node, VirtualFrame vFrame) {
+            public void returnVoid(Node node, VirtualFrame frame) {
                 if (nextInstrumentNode != null) {
-                    nextInstrumentNode.returnVoid(node, vFrame);
+                    nextInstrumentNode.returnVoid(node, frame);
                 }
             }
 
             @Override
-            public void returnValue(Node node, VirtualFrame vFrame, Object result) {
+            public void returnValue(Node node, VirtualFrame frame, Object result) {
                 if (nextInstrumentNode != null) {
-                    nextInstrumentNode.returnValue(node, vFrame, result);
+                    nextInstrumentNode.returnValue(node, frame, result);
                 }
             }
 
             @Override
-            public void returnExceptional(Node node, VirtualFrame vFrame, Throwable exception) {
+            public void returnExceptional(Node node, VirtualFrame frame, Throwable exception) {
                 if (nextInstrumentNode != null) {
-                    nextInstrumentNode.returnExceptional(node, vFrame, exception);
+                    nextInstrumentNode.returnExceptional(node, frame, exception);
                 }
             }
 

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/ProbeNode.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/ProbeNode.java
@@ -74,43 +74,43 @@ final class ProbeNode extends EventHandlerNode {
     }
 
     @Override
-    public void enter(Node node, VirtualFrame vFrame) {
+    public void enter(Node node, VirtualFrame frame) {
         this.probe.checkProbeUnchanged();
         final BeforeTagInstrument beforeTagInstrument = probe.getBeforeTagInstrument();
         if (beforeTagInstrument != null) {
-            beforeTagInstrument.getListener().onEnter(probe, ((WrapperNode) this.getParent()).getChild(), vFrame);
+            beforeTagInstrument.getListener().onEnter(probe, ((WrapperNode) this.getParent()).getChild(), frame);
         }
         if (firstInstrumentNode != null) {
-            firstInstrumentNode.enter(node, vFrame);
+            firstInstrumentNode.enter(node, frame);
         }
     }
 
     @Override
-    public void returnVoid(Node node, VirtualFrame vFrame) {
+    public void returnVoid(Node node, VirtualFrame frame) {
         this.probe.checkProbeUnchanged();
         if (firstInstrumentNode != null) {
-            firstInstrumentNode.returnVoid(node, vFrame);
+            firstInstrumentNode.returnVoid(node, frame);
         }
         final AfterTagInstrument afterTagInstrument = probe.getAfterTagInstrument();
         if (afterTagInstrument != null) {
-            afterTagInstrument.getListener().onReturnVoid(probe, ((WrapperNode) this.getParent()).getChild(), vFrame);
+            afterTagInstrument.getListener().onReturnVoid(probe, ((WrapperNode) this.getParent()).getChild(), frame);
         }
     }
 
     @Override
-    public void returnValue(Node node, VirtualFrame vFrame, Object result) {
+    public void returnValue(Node node, VirtualFrame frame, Object result) {
         this.probe.checkProbeUnchanged();
         if (firstInstrumentNode != null) {
-            firstInstrumentNode.returnValue(node, vFrame, result);
+            firstInstrumentNode.returnValue(node, frame, result);
         }
         final AfterTagInstrument afterTagInstrument = probe.getAfterTagInstrument();
         if (afterTagInstrument != null) {
-            afterTagInstrument.getListener().onReturnValue(probe, ((WrapperNode) this.getParent()).getChild(), vFrame, result);
+            afterTagInstrument.getListener().onReturnValue(probe, ((WrapperNode) this.getParent()).getChild(), frame, result);
         }
     }
 
     @Override
-    public void returnExceptional(Node node, VirtualFrame vFrame, Throwable exception) {
+    public void returnExceptional(Node node, VirtualFrame frame, Throwable exception) {
         if (exception instanceof KillException) {
             throw (KillException) exception;
         }
@@ -119,11 +119,11 @@ final class ProbeNode extends EventHandlerNode {
         }
         this.probe.checkProbeUnchanged();
         if (firstInstrumentNode != null) {
-            firstInstrumentNode.returnExceptional(node, vFrame, exception);
+            firstInstrumentNode.returnExceptional(node, frame, exception);
         }
         final AfterTagInstrument afterTagInstrument = probe.getAfterTagInstrument();
         if (afterTagInstrument != null) {
-            afterTagInstrument.getListener().onReturnExceptional(probe, ((WrapperNode) this.getParent()).getChild(), vFrame, exception);
+            afterTagInstrument.getListener().onReturnExceptional(probe, ((WrapperNode) this.getParent()).getChild(), frame, exception);
         }
     }
 

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/StandardAfterInstrumentListener.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/StandardAfterInstrumentListener.java
@@ -53,7 +53,7 @@ public interface StandardAfterInstrumentListener {
      * <p>
      * <strong>Synchronous</strong>: Truffle execution waits until the call returns.
      */
-    void onReturnVoid(Probe probe, Node node, VirtualFrame vFrame);
+    void onReturnVoid(Probe probe, Node node, VirtualFrame frame);
 
     /**
      * Receive notification that an AST Node's execute method has just returned a value (boxed if
@@ -61,12 +61,12 @@ public interface StandardAfterInstrumentListener {
      * <p>
      * <strong>Synchronous</strong>: Truffle execution waits until the call returns.
      */
-    void onReturnValue(Probe probe, Node node, VirtualFrame vFrame, Object result);
+    void onReturnValue(Probe probe, Node node, VirtualFrame frame, Object result);
 
     /**
      * Receive notification that an AST Node's execute method has just thrown an exception.
      * <p>
      * <strong>Synchronous</strong>: Truffle execution waits until the call returns.
      */
-    void onReturnExceptional(Probe probe, Node node, VirtualFrame vFrame, Throwable exception);
+    void onReturnExceptional(Probe probe, Node node, VirtualFrame frame, Throwable exception);
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/StandardBeforeInstrumentListener.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/StandardBeforeInstrumentListener.java
@@ -53,6 +53,6 @@ public interface StandardBeforeInstrumentListener {
      * <p>
      * <strong>Synchronous</strong>: Truffle execution waits until the call returns.
      */
-    void onEnter(Probe probe, Node node, VirtualFrame vFrame);
+    void onEnter(Probe probe, Node node, VirtualFrame frame);
 
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/StandardInstrumentListener.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/StandardInstrumentListener.java
@@ -52,14 +52,14 @@ public interface StandardInstrumentListener {
      * <p>
      * <strong>Synchronous</strong>: Truffle execution waits until the call returns.
      */
-    void onEnter(Probe probe, Node node, VirtualFrame vFrame);
+    void onEnter(Probe probe, Node node, VirtualFrame frame);
 
     /**
      * Receive notification that an AST Node's {@code void}-valued execute method has just returned.
      * <p>
      * <strong>Synchronous</strong>: Truffle execution waits until the call returns.
      */
-    void onReturnVoid(Probe probe, Node node, VirtualFrame vFrame);
+    void onReturnVoid(Probe probe, Node node, VirtualFrame frame);
 
     /**
      * Receive notification that an AST Node's execute method has just returned a value (boxed if
@@ -67,12 +67,12 @@ public interface StandardInstrumentListener {
      * <p>
      * <strong>Synchronous</strong>: Truffle execution waits until the call returns.
      */
-    void onReturnValue(Probe probe, Node node, VirtualFrame vFrame, Object result);
+    void onReturnValue(Probe probe, Node node, VirtualFrame frame, Object result);
 
     /**
      * Receive notification that an AST Node's execute method has just thrown an exception.
      * <p>
      * <strong>Synchronous</strong>: Truffle execution waits until the call returns.
      */
-    void onReturnExceptional(Probe probe, Node node, VirtualFrame vFrame, Throwable exception);
+    void onReturnExceptional(Probe probe, Node node, VirtualFrame frame, Throwable exception);
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/impl/DefaultStandardInstrumentListener.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/impl/DefaultStandardInstrumentListener.java
@@ -35,15 +35,15 @@ import com.oracle.truffle.api.nodes.Node;
  */
 public class DefaultStandardInstrumentListener implements StandardInstrumentListener {
 
-    public void onEnter(Probe probe, Node node, VirtualFrame vFrame) {
+    public void onEnter(Probe probe, Node node, VirtualFrame frame) {
     }
 
-    public void onReturnVoid(Probe probe, Node node, VirtualFrame vFrame) {
+    public void onReturnVoid(Probe probe, Node node, VirtualFrame frame) {
     }
 
-    public void onReturnValue(Probe probe, Node node, VirtualFrame vFrame, Object result) {
+    public void onReturnValue(Probe probe, Node node, VirtualFrame frame, Object result) {
     }
 
-    public void onReturnExceptional(Probe probe, Node node, VirtualFrame vFrame, Throwable exception) {
+    public void onReturnExceptional(Probe probe, Node node, VirtualFrame frame, Throwable exception) {
     }
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/RootNode.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/RootNode.java
@@ -201,7 +201,7 @@ public abstract class RootNode extends Node {
         }
 
         @Override
-        public Object execute(VirtualFrame vf) {
+        public Object execute(VirtualFrame frame) {
             return value;
         }
     }

--- a/truffle/com.oracle.truffle.sl/src/com/oracle/truffle/sl/nodes/instrument/SLExpressionWrapperNode.java
+++ b/truffle/com.oracle.truffle.sl/src/com/oracle/truffle/sl/nodes/instrument/SLExpressionWrapperNode.java
@@ -98,41 +98,41 @@ public final class SLExpressionWrapperNode extends SLExpressionNode implements W
     }
 
     @Override
-    public Object executeGeneric(VirtualFrame vFrame) {
+    public Object executeGeneric(VirtualFrame frame) {
 
-        eventHandlerNode.enter(child, vFrame);
+        eventHandlerNode.enter(child, frame);
         Object result;
 
         try {
-            result = child.executeGeneric(vFrame);
-            eventHandlerNode.returnValue(child, vFrame, result);
+            result = child.executeGeneric(frame);
+            eventHandlerNode.returnValue(child, frame, result);
         } catch (Exception e) {
-            eventHandlerNode.returnExceptional(child, vFrame, e);
+            eventHandlerNode.returnExceptional(child, frame, e);
             throw (e);
         }
         return result;
     }
 
     @Override
-    public long executeLong(VirtualFrame vFrame) throws UnexpectedResultException {
-        return SLTypesGen.expectLong(executeGeneric(vFrame));
+    public long executeLong(VirtualFrame frame) throws UnexpectedResultException {
+        return SLTypesGen.expectLong(executeGeneric(frame));
     }
 
     @Override
-    public boolean executeBoolean(VirtualFrame vFrame) throws UnexpectedResultException {
-        return SLTypesGen.expectBoolean(executeGeneric(vFrame));
+    public boolean executeBoolean(VirtualFrame frame) throws UnexpectedResultException {
+        return SLTypesGen.expectBoolean(executeGeneric(frame));
     }
 
     @Override
-    public SLFunction executeFunction(VirtualFrame vFrame) throws UnexpectedResultException {
-        eventHandlerNode.enter(child, vFrame);
+    public SLFunction executeFunction(VirtualFrame frame) throws UnexpectedResultException {
+        eventHandlerNode.enter(child, frame);
         SLFunction result;
 
         try {
-            result = child.executeFunction(vFrame);
-            eventHandlerNode.returnValue(child, vFrame, result);
+            result = child.executeFunction(frame);
+            eventHandlerNode.returnValue(child, frame, result);
         } catch (Exception e) {
-            eventHandlerNode.returnExceptional(child, vFrame, e);
+            eventHandlerNode.returnExceptional(child, frame, e);
             throw (e);
         }
         return result;

--- a/truffle/com.oracle.truffle.sl/src/com/oracle/truffle/sl/nodes/instrument/SLStatementWrapperNode.java
+++ b/truffle/com.oracle.truffle.sl/src/com/oracle/truffle/sl/nodes/instrument/SLStatementWrapperNode.java
@@ -93,14 +93,14 @@ public final class SLStatementWrapperNode extends SLStatementNode implements Wra
     }
 
     @Override
-    public void executeVoid(VirtualFrame vFrame) {
-        eventHandlerNode.enter(child, vFrame);
+    public void executeVoid(VirtualFrame frame) {
+        eventHandlerNode.enter(child, frame);
 
         try {
-            child.executeVoid(vFrame);
-            eventHandlerNode.returnVoid(child, vFrame);
+            child.executeVoid(frame);
+            eventHandlerNode.returnVoid(child, frame);
         } catch (Exception e) {
-            eventHandlerNode.returnExceptional(child, vFrame, e);
+            eventHandlerNode.returnExceptional(child, frame, e);
             throw (e);
         }
     }

--- a/truffle/com.oracle.truffle.tools.test/src/com/oracle/truffle/tools/test/ToolTestUtil.java
+++ b/truffle/com.oracle.truffle.tools.test/src/com/oracle/truffle/tools/test/ToolTestUtil.java
@@ -167,7 +167,7 @@ public class ToolTestUtil {
     }
 
     abstract static class ToolTestLangNode extends Node {
-        public abstract Object execute(VirtualFrame vFrame);
+        public abstract Object execute(VirtualFrame frame);
 
         protected ToolTestLangNode(SourceSection ss) {
             super(ss);
@@ -205,14 +205,14 @@ public class ToolTestUtil {
         }
 
         @Override
-        public Object execute(VirtualFrame vFrame) {
-            eventHandlerNode.enter(child, vFrame);
+        public Object execute(VirtualFrame frame) {
+            eventHandlerNode.enter(child, frame);
             Object result;
             try {
-                result = child.execute(vFrame);
-                eventHandlerNode.returnValue(child, vFrame, result);
+                result = child.execute(frame);
+                eventHandlerNode.returnValue(child, frame, result);
             } catch (Exception e) {
-                eventHandlerNode.returnExceptional(child, vFrame, e);
+                eventHandlerNode.returnExceptional(child, frame, e);
                 throw (e);
             }
             return result;
@@ -231,7 +231,7 @@ public class ToolTestUtil {
         }
 
         @Override
-        public Object execute(VirtualFrame vFrame) {
+        public Object execute(VirtualFrame frame) {
             return new Integer(this.value);
         }
     }
@@ -250,8 +250,8 @@ public class ToolTestUtil {
         }
 
         @Override
-        public Object execute(VirtualFrame vFrame) {
-            return new Integer(((Integer) leftChild.execute(vFrame)).intValue() + ((Integer) rightChild.execute(vFrame)).intValue());
+        public Object execute(VirtualFrame frame) {
+            return new Integer(((Integer) leftChild.execute(frame)).intValue() + ((Integer) rightChild.execute(frame)).intValue());
         }
     }
 
@@ -274,8 +274,8 @@ public class ToolTestUtil {
         }
 
         @Override
-        public Object execute(VirtualFrame vFrame) {
-            return body.execute(vFrame);
+        public Object execute(VirtualFrame frame) {
+            return body.execute(frame);
         }
 
         @Override
@@ -307,8 +307,8 @@ public class ToolTestUtil {
         }
 
         @Override
-        public Object execute(VirtualFrame vFrame) {
-            return body.execute(vFrame);
+        public Object execute(VirtualFrame frame) {
+            return body.execute(frame);
         }
 
         @Override

--- a/truffle/com.oracle.truffle.tools/src/com/oracle/truffle/tools/NodeExecCounter.java
+++ b/truffle/com.oracle.truffle.tools/src/com/oracle/truffle/tools/NodeExecCounter.java
@@ -115,7 +115,7 @@ public final class NodeExecCounter extends Instrumenter.Tool {
      */
     private final StandardInstrumentListener instrumentListener = new DefaultStandardInstrumentListener() {
         @Override
-        public void onEnter(Probe probe, Node node, VirtualFrame vFrame) {
+        public void onEnter(Probe probe, Node node, VirtualFrame frame) {
             if (isEnabled()) {
                 final Class<?> nodeClass = node.getClass();
                 /*


### PR DESCRIPTION
`VirtualFrame` parameters seem to be abbreviated in different and inconsistent ways: `vFrame`, `vf` and `frame`. I believe only the last one is good for readability and is also the most used.
One of the obvious place where it looks strange is in the [JavaDoc](http://lafo.ssw.uni-linz.ac.at/javadoc/truffle/latest/com/oracle/truffle/api/interop/AcceptMessage.html).

If this create large conflicts with existing in-flights PR, I'm happy to redo it on top when they are merged.