### PR TITLE
The actual exception thrown when running on GraalVM-0.9 is java.lang.…

### DIFF
--- a/truffle/com.oracle.truffle.api.profiles/src/com/oracle/truffle/api/profiles/Profile.java
+++ b/truffle/com.oracle.truffle.api.profiles/src/com/oracle/truffle/api/profiles/Profile.java
@@ -95,7 +95,7 @@ public abstract class Profile extends NodeCloneable {
         boolean enabled;
         try {
             enabled = Truffle.getRuntime().isProfilingEnabled();
-        } catch (NoSuchMethodError ex) {
+        } catch (LinkageError ex) {
             // running on old version of Graal
             enabled = true;
         }


### PR DESCRIPTION
…AbstractMethodError - as such we need to catch more than just NoSuchMethodError.

With this fix the simple language with deps on truffle-0.11 (plus this change) can run on GraalVM-0.9 published in Oct 2015.