### PR TITLE
Source section less node

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,2 +1,12 @@
-Please see http://openjdk.java.net/contribute/ for details of how to contribute
-to OpenJDK projects including GraalVM.
+To submit pull requests for truffle, you need to sign the [Oracle Contributor Agreement][1].
+There is a white-list for contributors who have signed the OCA so please add a comment
+to your first pull request indicating the name you used to sign the OCA if it isn't clear
+from your github profile.
+
+Pull requests can only be merged by committers and a committer cannot merge
+his or her own pull requests.
+
+When creating a pull request, make sure you designate an assignee to ensure
+the request is processed in a timely manner.
+
+[1]: http://www.oracle.com/technetwork/community/oca-486395.html

--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/SourceSectionTest.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/SourceSectionTest.java
@@ -22,13 +22,10 @@
  */
 package com.oracle.truffle.api.dsl.test;
 
-import static com.oracle.truffle.api.dsl.test.TestHelper.createRoot;
+import com.oracle.truffle.api.CompilerDirectives;
 import static com.oracle.truffle.api.dsl.test.TestHelper.createRootPrefix;
 import static com.oracle.truffle.api.dsl.test.TestHelper.executeWith;
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.sameInstance;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
 import org.junit.experimental.theories.DataPoints;
@@ -41,13 +38,15 @@ import com.oracle.truffle.api.dsl.Fallback;
 import com.oracle.truffle.api.dsl.NodeChild;
 import com.oracle.truffle.api.dsl.Specialization;
 import com.oracle.truffle.api.dsl.internal.SpecializationNode;
-import com.oracle.truffle.api.dsl.test.SourceSectionTestFactory.SourceSection0Factory;
-import com.oracle.truffle.api.dsl.test.SourceSectionTestFactory.SourceSection1Factory;
 import com.oracle.truffle.api.dsl.test.TypeSystemTest.ArgumentNode;
 import com.oracle.truffle.api.dsl.test.TypeSystemTest.TestRootNode;
 import com.oracle.truffle.api.dsl.test.TypeSystemTest.ValueNode;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.source.SourceSection;
+import static com.oracle.truffle.api.dsl.test.TestHelper.createRoot;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
 
 @RunWith(Theories.class)
 public class SourceSectionTest {
@@ -56,9 +55,9 @@ public class SourceSectionTest {
 
     @Theory
     public void testSourceSections(int value0, int value1, int value2) {
-        TestRootNode<SourceSection0> root = createRoot(SourceSection0Factory.getInstance());
+        TestRootNode<MutableSourceSectionNode> root = createRoot(SourceSectionTestFactory.MutableSourceSectionNodeFactory.getInstance());
         SourceSection section = SourceSection.createUnavailable("a", "b");
-        root.getNode().assignSourceSection(section);
+        root.getNode().changeSourceSection(section);
         expectSourceSection(root.getNode(), section);
         assertThat((int) executeWith(root, value0), is(value0));
         expectSourceSection(root.getNode(), section);
@@ -81,7 +80,21 @@ public class SourceSectionTest {
     }
 
     @NodeChild("a")
-    static class SourceSection0 extends ValueNode {
+    static class MutableSourceSectionNode extends ValueNode {
+        // BEGIN: source.section.mutable
+        @CompilerDirectives.CompilationFinal private SourceSection section;
+
+        final void changeSourceSection(SourceSection sourceSection) {
+            CompilerDirectives.transferToInterpreterAndInvalidate();
+            this.section = sourceSection;
+        }
+
+        @Override
+        public SourceSection getSourceSection() {
+            return section;
+        }
+
+        // END: source.section.mutable
 
         @Specialization(guards = "a == 1")
         int do1(int a) {
@@ -108,18 +121,27 @@ public class SourceSectionTest {
     public void testCreateCast() {
         SourceSection section = SourceSection.createUnavailable("a", "b");
         assertNull(section.getSource());
-        TestRootNode<SourceSection1> root = createRootPrefix(SourceSection1Factory.getInstance(), true, section);
+        TestRootNode<NodeWithFixedSourceSection> root = createRootPrefix(SourceSectionTestFactory.NodeWithFixedSourceSectionFactory.getInstance(), true, section);
         expectSourceSection(root.getNode(), section);
         assertThat((int) executeWith(root, 1), is(1));
         expectSourceSection(root.getNode(), section);
     }
 
     @NodeChild("a")
-    static class SourceSection1 extends ValueNode {
+    static class NodeWithFixedSourceSection extends ValueNode {
+        // BEGIN: source.section.fixed
+        private final SourceSection section;
 
-        public SourceSection1(SourceSection section) {
-            super(section);
+        public NodeWithFixedSourceSection(SourceSection section) {
+            this.section = section;
         }
+
+        @Override
+        public SourceSection getSourceSection() {
+            return section;
+        }
+
+        // END: source.section.fixed
 
         @CreateCast("a")
         public ValueNode cast(ValueNode node) {

--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/SourceSectionTest.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/SourceSectionTest.java
@@ -81,7 +81,7 @@ public class SourceSectionTest {
 
     @NodeChild("a")
     static class MutableSourceSectionNode extends ValueNode {
-        // BEGIN: source.section.mutable
+        // BEGIN: MutableSourceSectionNode
         @CompilerDirectives.CompilationFinal private SourceSection section;
 
         final void changeSourceSection(SourceSection sourceSection) {
@@ -94,7 +94,7 @@ public class SourceSectionTest {
             return section;
         }
 
-        // END: source.section.mutable
+        // END: MutableSourceSectionNode
 
         @Specialization(guards = "a == 1")
         int do1(int a) {
@@ -129,7 +129,7 @@ public class SourceSectionTest {
 
     @NodeChild("a")
     static class NodeWithFixedSourceSection extends ValueNode {
-        // BEGIN: source.section.fixed
+        // BEGIN: NodeWithFixedSourceSection
         private final SourceSection section;
 
         public NodeWithFixedSourceSection(SourceSection section) {
@@ -141,7 +141,7 @@ public class SourceSectionTest {
             return section;
         }
 
-        // END: source.section.fixed
+        // END: NodeWithFixedSourceSection
 
         @CreateCast("a")
         public ValueNode cast(ValueNode node) {

--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/TypeSystemTest.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/TypeSystemTest.java
@@ -37,7 +37,6 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.nodes.UnexpectedResultException;
-import com.oracle.truffle.api.source.SourceSection;
 
 public class TypeSystemTest {
 
@@ -83,11 +82,6 @@ public class TypeSystemTest {
     public static class ValueNode extends Node {
 
         public ValueNode() {
-            super(null);
-        }
-
-        public ValueNode(SourceSection sourceSection) {
-            super(sourceSection);
         }
 
         public int executeInt(VirtualFrame frame) throws UnexpectedResultException {

--- a/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/internal/DSLShare.java
+++ b/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/internal/DSLShare.java
@@ -146,7 +146,8 @@ public class DSLShare {
 
     private static void updateSourceSection(Node oldNode, Node newNode) {
         if (newNode.getSourceSection() == null) {
-            newNode.assignSourceSection(oldNode.getSourceSection());
+            throw new IllegalArgumentException("Can't update source: " + oldNode);
+            // newNode.assignSourceSection(oldNode.getSourceSection());
         }
     }
 

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/ArgumentsTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/ArgumentsTest.java
@@ -97,7 +97,6 @@ public class ArgumentsTest {
         private final int index;
 
         TestArgumentNode(int index) {
-            super(null);
             this.index = index;
         }
 

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/ChildNodeTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/ChildNodeTest.java
@@ -104,7 +104,6 @@ public class ChildNodeTest {
     class TestChildNode extends Node {
 
         public TestChildNode() {
-            super(null);
         }
 
         public int execute() {

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/ChildrenNodesTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/ChildrenNodesTest.java
@@ -102,7 +102,6 @@ public class ChildrenNodesTest {
     class TestChildNode extends Node {
 
         public TestChildNode() {
-            super(null);
         }
 
         public int execute() {

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/FinalFieldTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/FinalFieldTest.java
@@ -97,7 +97,6 @@ public class FinalFieldTest {
         private final int value;
 
         public TestChildNode(int value) {
-            super(null);
             this.value = value;
         }
 

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/FrameSlotTypeSpecializationTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/FrameSlotTypeSpecializationTest.java
@@ -96,7 +96,6 @@ public class FrameSlotTypeSpecializationTest {
     abstract class TestChildNode extends Node {
 
         protected TestChildNode() {
-            super(null);
         }
 
         abstract Object execute(VirtualFrame frame);

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/FrameTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/FrameTest.java
@@ -125,7 +125,6 @@ public class FrameTest {
     abstract class TestChildNode extends Node {
 
         public TestChildNode() {
-            super(null);
         }
 
         abstract int execute(VirtualFrame frame);

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/InterfaceChildFieldTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/InterfaceChildFieldTest.java
@@ -113,7 +113,6 @@ public class InterfaceChildFieldTest {
 
     class TestLeafNode extends Node implements TestChildInterface {
         public TestLeafNode() {
-            super(null);
         }
 
         public int executeIntf() {
@@ -123,7 +122,6 @@ public class InterfaceChildFieldTest {
 
     class TestLeaf2Node extends Node implements TestChildInterface {
         public TestLeaf2Node() {
-            super(null);
         }
 
         public int executeIntf() {
@@ -137,7 +135,6 @@ public class InterfaceChildFieldTest {
         @Child private TestChildInterface right;
 
         public TestChildNode(TestChildInterface left, TestChildInterface right) {
-            super(null);
             this.left = left;
             this.right = right;
         }
@@ -153,7 +150,6 @@ public class InterfaceChildFieldTest {
         @Children private final TestChildInterface[] children;
 
         public TestChildrenNode(TestChildInterface[] children) {
-            super(null);
             this.children = children;
         }
 

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/ReplaceTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/ReplaceTest.java
@@ -115,7 +115,6 @@ public class ReplaceTest {
     abstract class ValueNode extends Node {
 
         ValueNode() {
-            super(null);
         }
 
         abstract int execute();

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/ReplaceTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/ReplaceTest.java
@@ -115,7 +115,6 @@ public class ReplaceTest {
     abstract class ValueNode extends Node {
 
         public ValueNode() {
-            super(null);
         }
 
         abstract int execute();

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/ReturnTypeSpecializationTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/ReturnTypeSpecializationTest.java
@@ -96,7 +96,6 @@ public class ReturnTypeSpecializationTest {
     abstract class TestChildNode extends Node {
 
         public TestChildNode() {
-            super(null);
         }
 
         abstract Object execute(VirtualFrame frame);

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/ThreadSafetyTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/ThreadSafetyTest.java
@@ -103,7 +103,6 @@ public class ThreadSafetyTest {
     abstract static class ValueNode extends Node {
 
         public ValueNode() {
-            super(null);
         }
 
         abstract int execute(VirtualFrame frame);

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/Accessor.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/Accessor.java
@@ -110,7 +110,7 @@ public abstract class Accessor {
             }
         };
         lng.hashCode();
-        new Node(null) {
+        new Node() {
         }.getRootNode();
 
         try {

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/Node.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/Node.java
@@ -167,7 +167,7 @@ public abstract class Node implements NodeInterface, Cloneable {
      * @return an approximation of the source code represented by this Node
      */
     @ExplodeLoop
-    public final SourceSection getEncapsulatingSourceSection() {
+    public SourceSection getEncapsulatingSourceSection() {
         Node current = this;
         while (current != null) {
             final SourceSection currentSection = current.getSourceSection();

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/Node.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/Node.java
@@ -146,12 +146,12 @@ public abstract class Node implements NodeInterface, Cloneable {
      * To define node with <em>fixed</em> {@link SourceSection} that doesn't change after node
      * construction use:
      *
-     * {@codesnippet source.section.fixed}
+     * {@codesnippet NodeWithFixedSourceSection}
      *
      * To create a node which can associate and change the {@link SourceSection} later at any point
      * of time use:
      *
-     * {@codesnippet source.section.mutable}
+     * {@codesnippet MutableSourceSectionNode}
      *
      * @return the source code represented by this Node
      */

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/Node.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/Node.java
@@ -69,12 +69,7 @@ public abstract class Node implements NodeInterface, Cloneable {
     }
 
     protected Node() {
-        this(null);
-    }
-
-    protected Node(SourceSection sourceSection) {
         CompilerAsserts.neverPartOfCompilation();
-        this.sourceSection = sourceSection;
         this.nodeClass = NodeClass.get(getClass());
         if (TruffleOptions.TraceASTJSON) {
             JSONHelper.dumpNewNode(this);
@@ -82,10 +77,23 @@ public abstract class Node implements NodeInterface, Cloneable {
     }
 
     /**
-     * Assigns a link to a guest language source section to this node.
+     * @deprecated if your node provides source section, override {@link #getSourceSection()} to
+     *             return it - this constructor will be removed
+     * @param sourceSection
+     */
+    @Deprecated
+    protected Node(SourceSection sourceSection) {
+        this();
+        this.sourceSection = sourceSection;
+    }
+
+    /**
+     * @deprecated if your node provides source section, override {@link #getSourceSection()} to
+     *             return it - this method will be removed
      *
      * @param section the object representing a section in guest language source code
      */
+    @Deprecated
     public void assignSourceSection(SourceSection section) {
         if (sourceSection != null) {
             // Patch this test during the transition to constructor-based
@@ -119,14 +127,31 @@ public abstract class Node implements NodeInterface, Cloneable {
     }
 
     /**
-     * Clears any previously assigned guest language source code from this node.
+     * @deprecated if your node provides source section, override {@link #getSourceSection()} to
+     *             return it - this method will be removed
+     * 
+     *             Clears any previously assigned guest language source code from this node.
      */
+    @Deprecated
     public void clearSourceSection() {
         this.sourceSection = null;
     }
 
     /**
-     * Retrieves the segment of guest language source code that is represented by this Node.
+     * Retrieves the segment of guest language source code that is represented by this Node. The
+     * default implementation of this method returns <code>null</code>. If your node represents a
+     * segment of the source code, override this method and return a <code>final</code> or
+     * {@link CompilationFinal} field in your node to the caller.
+     *
+     * To define node with <em>fixed</em> {@link SourceSection} that doesn't change after node
+     * construction use:
+     *
+     * {@codesnippet source.section.fixed}
+     *
+     * To create a node which can associate and change the {@link SourceSection} later at any point
+     * of time use:
+     *
+     * {@codesnippet source.section.mutable}
      *
      * @return the source code represented by this Node
      */
@@ -142,11 +167,12 @@ public abstract class Node implements NodeInterface, Cloneable {
      * @return an approximation of the source code represented by this Node
      */
     @ExplodeLoop
-    public SourceSection getEncapsulatingSourceSection() {
+    public final SourceSection getEncapsulatingSourceSection() {
         Node current = this;
         while (current != null) {
-            if (current.sourceSection != null) {
-                return current.sourceSection;
+            final SourceSection currentSection = current.getSourceSection();
+            if (currentSection != null) {
+                return currentSection;
             }
             current = current.parent;
         }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/RootNode.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/RootNode.java
@@ -66,6 +66,7 @@ public abstract class RootNode extends Node {
         this(language, sourceSection, frameDescriptor, true);
     }
 
+    @SuppressWarnings("deprecation")
     private RootNode(Class<? extends TruffleLanguage> language, SourceSection sourceSection, FrameDescriptor frameDescriptor, boolean checkLanguage) {
         super(sourceSection);
         if (checkLanguage) {

--- a/truffle/com.oracle.truffle.sl.test/src/com/oracle/truffle/sl/test/SLDebugTest.java
+++ b/truffle/com.oracle.truffle.sl.test/src/com/oracle/truffle/sl/test/SLDebugTest.java
@@ -215,7 +215,7 @@ public class SLDebugTest {
         run(null);
     }
 
-    private void assertLine(int line) {
+    void assertLine(int line) {
         assertNotNull(suspendedEvent);
         final SourceSection expLoc = factorial.createSection("Line " + line, line);
         final SourceSection sourceLoc = suspendedEvent.getNode().getEncapsulatingSourceSection();

--- a/truffle/com.oracle.truffle.sl/src/com/oracle/truffle/sl/nodes/SLStatementNode.java
+++ b/truffle/com.oracle.truffle.sl/src/com/oracle/truffle/sl/nodes/SLStatementNode.java
@@ -54,9 +54,15 @@ import com.oracle.truffle.api.source.SourceSection;
  */
 @NodeInfo(language = "Simple Language", description = "The abstract base node for all statements")
 public abstract class SLStatementNode extends Node {
+    private final SourceSection section;
 
     public SLStatementNode(SourceSection src) {
-        super(src);
+        section = src;
+    }
+
+    @Override
+    public SourceSection getSourceSection() {
+        return section;
     }
 
     /**

--- a/truffle/com.oracle.truffle.sl/src/com/oracle/truffle/sl/nodes/controlflow/SLRepeatingNode.java
+++ b/truffle/com.oracle.truffle.sl/src/com/oracle/truffle/sl/nodes/controlflow/SLRepeatingNode.java
@@ -51,7 +51,7 @@ import com.oracle.truffle.sl.nodes.SLExpressionNode;
 import com.oracle.truffle.sl.nodes.SLStatementNode;
 
 public final class SLRepeatingNode extends Node implements RepeatingNode {
-
+    private final SourceSection section;
     /**
      * The condition of the loop. This in a {@link SLExpressionNode} because we require a result
      * value. We do not have a node type that can only return a {@code boolean} value, so
@@ -71,11 +71,17 @@ public final class SLRepeatingNode extends Node implements RepeatingNode {
     private final BranchProfile breakTaken = BranchProfile.create();
 
     public SLRepeatingNode(SourceSection src, SLExpressionNode conditionNode, SLStatementNode bodyNode) {
-        super(src);
+        this.section = src;
         this.conditionNode = conditionNode;
         this.bodyNode = bodyNode;
     }
 
+    @Override
+    public SourceSection getSourceSection() {
+        return section;
+    }
+
+    @Override
     public boolean executeRepeating(VirtualFrame frame) {
         if (evaluateCondition(frame)) {
             try {

--- a/truffle/com.oracle.truffle.tools.test/src/com/oracle/truffle/tools/test/ToolTestUtil.java
+++ b/truffle/com.oracle.truffle.tools.test/src/com/oracle/truffle/tools/test/ToolTestUtil.java
@@ -167,10 +167,17 @@ public class ToolTestUtil {
     }
 
     abstract static class ToolTestLangNode extends Node {
+        private final SourceSection section;
+
         public abstract Object execute(VirtualFrame vFrame);
 
         protected ToolTestLangNode(SourceSection ss) {
-            super(ss);
+            this.section = ss;
+        }
+
+        @Override
+        public SourceSection getSourceSection() {
+            return section;
         }
     }
 


### PR DESCRIPTION
According to discussion in #25 it seems that there is a general consensus that SourceSections should be handled by individual languages and the interface in Truffle API simplified to:

- Node.getSourceSection() that can be implemented by subclasses
- RootNode(SourceSection, ...) constructor accepting SourceSection as majority of RootNode instances have source section

The other methods are deprecated while the functionality is kept. Once the deprecated methods are removed, the Node#sourceSection field will be removed as well. RootNode will then get such field to hold the value provided in constructor.