### PR TITLE
assert neverPartOfCompilation in FrameSlot.toString

### DIFF
--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/FrameSlot.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/FrameSlot.java
@@ -24,6 +24,7 @@
  */
 package com.oracle.truffle.api.frame;
 
+import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 
@@ -117,6 +118,7 @@ public final class FrameSlot implements Cloneable {
 
     @Override
     public String toString() {
+        CompilerAsserts.neverPartOfCompilation();
         return "[" + index + "," + identifier + "," + kind + "]";
     }
 


### PR DESCRIPTION
Accidentally invoking toString might lead to huge graphs potentially causing the compiler to run OOM. This assertion should help catching such errors upfront.