### PR TITLE
use Objects.requireNonNull instead of obj.getClass for null checks

### DIFF
--- a/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotEngine.java
+++ b/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotEngine.java
@@ -36,6 +36,7 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.Executor;
@@ -266,7 +267,7 @@ public class PolyglotEngine {
          * @return instance of this builder
          */
         public Builder onEvent(EventConsumer<?> handler) {
-            handler.getClass();
+            Objects.requireNonNull(handler);
             handlers.add(handler);
             return this;
         }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/Accessor.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/Accessor.java
@@ -51,6 +51,7 @@ import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.source.Source;
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Communication between PolyglotEngine, TruffleLanguage API/SPI, and other services.
@@ -277,8 +278,8 @@ public abstract class Accessor {
     @TruffleBoundary
     @SuppressWarnings("unused")
     protected Closeable executionStart(Object vm, int currentDepth, Debugger debugger, Source s) {
-        vm.getClass();
         CompilerAsserts.neverPartOfCompilation();
+        Objects.requireNonNull(vm);
         final Object prev = CURRENT_VM.get();
         final Closeable debugClose = DEBUG.executionStart(vm, prev == null ? 0 : -1, debugger, s);
         if (!(vm == previousVM.get())) {

--- a/truffle/com.oracle.truffle.tck/src/com/oracle/truffle/tck/BoxedValue.java
+++ b/truffle/com.oracle.truffle.tck/src/com/oracle/truffle/tck/BoxedValue.java
@@ -24,6 +24,8 @@
  */
 package com.oracle.truffle.tck;
 
+import java.util.Objects;
+
 import com.oracle.truffle.tck.impl.TckLanguage;
 import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.Truffle;
@@ -37,8 +39,7 @@ final class BoxedValue implements TruffleObject, ForeignAccess.Factory10 {
     private final Object value;
 
     BoxedValue(Object v) {
-        v.getClass();
-        this.value = v;
+        this.value = Objects.requireNonNull(v);
     }
 
     @Override


### PR DESCRIPTION
Use the preferable self-documenting `Objects.requireNonNull` method instead of `obj.getClass()` to null-check arguments.