### PR TITLE
provide bailout messages for usages of CompilerAsserts.neverPartOfCompilation()

### DIFF
--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/examples/FunctionCall.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/examples/FunctionCall.java
@@ -106,7 +106,7 @@ public class FunctionCall {
         }
 
         protected final boolean cacheFunctionTarget(Function function) {
-            CompilerAsserts.neverPartOfCompilation();
+            CompilerAsserts.neverPartOfCompilation("do not cache function target in compiled code");
             if (cachedFunctions != null) {
                 for (int i = 0; i < cachedFunctions.length; i++) {
                     Function cachedFunction = cachedFunctions[i];

--- a/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/internal/DSLShare.java
+++ b/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/internal/DSLShare.java
@@ -34,7 +34,7 @@ import java.util.concurrent.Callable;
 public class DSLShare {
 
     public static boolean isExcluded(Node currentNode, DSLMetadata otherMetadata) {
-        CompilerAsserts.neverPartOfCompilation();
+        CompilerAsserts.neverPartOfCompilation("do not call DSLShare.isExcluded from compiled code");
 
         assert otherMetadata.getExcludedBy().length > 0 : "At least one exclude must be defined for isIncluded.";
         Node cur = findRoot(currentNode);
@@ -55,7 +55,7 @@ public class DSLShare {
     }
 
     public static <T extends Node & DSLNode> T rewrite(final Node thisNode, final T newNode, final String message) {
-        CompilerAsserts.neverPartOfCompilation();
+        CompilerAsserts.neverPartOfCompilation("do not call DSLShare.rewrite from compiled code");
 
         return thisNode.atomic(new Callable<T>() {
             public T call() {
@@ -77,7 +77,7 @@ public class DSLShare {
 
     @SuppressWarnings("unchecked")
     public static <T extends Node> T findRoot(T node) {
-        CompilerAsserts.neverPartOfCompilation();
+        CompilerAsserts.neverPartOfCompilation("do not call DSLShare.findRoot from compiled code");
 
         Node prev = node;
         Node cur;
@@ -99,7 +99,7 @@ public class DSLShare {
     }
 
     public static <T extends Node & DSLNode> T rewriteUninitialized(final Node uninitialized, final T newNode) {
-        CompilerAsserts.neverPartOfCompilation();
+        CompilerAsserts.neverPartOfCompilation("do not call DSLShare.rewriteUninitialized from compiled code");
 
         return uninitialized.atomic(new Callable<T>() {
             public T call() {
@@ -117,7 +117,7 @@ public class DSLShare {
 
     public static <T extends Node & DSLNode> T rewriteToPolymorphic(final Node oldNode, final DSLNode uninitializedDSL, final T polymorphic, final DSLNode currentCopy, final DSLNode newNodeDSL,
                     final String message) {
-        CompilerAsserts.neverPartOfCompilation();
+        CompilerAsserts.neverPartOfCompilation("do not call DSLShare.rewriteToPolymorphic from compiled code");
 
         return oldNode.atomic(new Callable<T>() {
             public T call() {

--- a/truffle/com.oracle.truffle.api.interop/src/com/oracle/truffle/api/interop/ForeignAccess.java
+++ b/truffle/com.oracle.truffle.api.interop/src/com/oracle/truffle/api/interop/ForeignAccess.java
@@ -46,7 +46,7 @@ public final class ForeignAccess {
     private ForeignAccess(Factory faf) {
         this.factory = faf;
         this.initThread = Thread.currentThread();
-        CompilerAsserts.neverPartOfCompilation();
+        CompilerAsserts.neverPartOfCompilation("do not create a ForeignAccess object from compiled code");
     }
 
     /**

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/FrameDescriptor.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/FrameDescriptor.java
@@ -61,7 +61,7 @@ public final class FrameDescriptor implements Cloneable {
      * @param defaultValue to be returned from {@link #getDefaultValue()}
      */
     public FrameDescriptor(Object defaultValue) {
-        CompilerAsserts.neverPartOfCompilation();
+        CompilerAsserts.neverPartOfCompilation("do not create a FrameDescriptor from compiled code");
         this.defaultValue = defaultValue;
         slots = new ArrayList<>();
         identifierToSlotMap = new HashMap<>();

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/FrameSlot.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/FrameSlot.java
@@ -60,7 +60,7 @@ public final class FrameSlot implements Cloneable {
 
     /**
      * Identifier of the slot.
-     * 
+     *
      * @return value as specified in {@link FrameDescriptor#addFrameSlot(java.lang.Object)}
      *         parameter
      */
@@ -70,7 +70,7 @@ public final class FrameSlot implements Cloneable {
 
     /**
      * Information about the slot.
-     * 
+     *
      * @return value as specified as second parameter of
      *         {@link FrameDescriptor#addFrameSlot(java.lang.Object, java.lang.Object, com.oracle.truffle.api.frame.FrameSlotKind)}
      */
@@ -80,7 +80,7 @@ public final class FrameSlot implements Cloneable {
 
     /**
      * Index of the slot in the {@link FrameDescriptor}.
-     * 
+     *
      * @return position of the slot computed after
      *         {@link FrameDescriptor#addFrameSlot(java.lang.Object, java.lang.Object, com.oracle.truffle.api.frame.FrameSlotKind)
      *         adding} it.
@@ -94,7 +94,7 @@ public final class FrameSlot implements Cloneable {
      * {@link FrameDescriptor#addFrameSlot(java.lang.Object, com.oracle.truffle.api.frame.FrameSlotKind)
      * creation time} or updated via {@link #setKind(com.oracle.truffle.api.frame.FrameSlotKind)}
      * method.
-     * 
+     *
      * @return current kind of this slot
      */
     public FrameSlotKind getKind() {
@@ -105,7 +105,7 @@ public final class FrameSlot implements Cloneable {
      * Changes the kind of this slot. Change of the slot kind is done on <em>slow path</em> and
      * invalidates assumptions about {@link FrameDescriptor#createVersion() version} of
      * {@link #getFrameDescriptor() associated descriptor}.
-     * 
+     *
      * @param kind new kind of the slot
      */
     public void setKind(final FrameSlotKind kind) {
@@ -118,13 +118,13 @@ public final class FrameSlot implements Cloneable {
 
     @Override
     public String toString() {
-        CompilerAsserts.neverPartOfCompilation();
+        CompilerAsserts.neverPartOfCompilation("do not call FrameSlot.toString from compiled code");
         return "[" + index + "," + identifier + "," + kind + "]";
     }
 
     /**
      * Frame descriptor this slot is associated with.
-     * 
+     *
      * @return instance of descriptor that {@link FrameDescriptor#addFrameSlot(java.lang.Object)
      *         created} the slot
      */

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/Accessor.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/Accessor.java
@@ -278,7 +278,7 @@ public abstract class Accessor {
     @TruffleBoundary
     @SuppressWarnings("unused")
     protected Closeable executionStart(Object vm, int currentDepth, Debugger debugger, Source s) {
-        CompilerAsserts.neverPartOfCompilation();
+        CompilerAsserts.neverPartOfCompilation("do not call Accessor.executionStart from compiled code");
         Objects.requireNonNull(vm);
         final Object prev = CURRENT_VM.get();
         final Closeable debugClose = DEBUG.executionStart(vm, prev == null ? 0 : -1, debugger, s);

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/Node.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/Node.java
@@ -69,7 +69,7 @@ public abstract class Node implements NodeInterface, Cloneable {
     }
 
     protected Node() {
-        CompilerAsserts.neverPartOfCompilation();
+        CompilerAsserts.neverPartOfCompilation("do not create a Node from compiled code");
         this.nodeClass = NodeClass.get(getClass());
         if (TruffleOptions.TraceASTJSON) {
             JSONHelper.dumpNewNode(this);
@@ -129,7 +129,7 @@ public abstract class Node implements NodeInterface, Cloneable {
     /**
      * @deprecated if your node provides source section, override {@link #getSourceSection()} to
      *             return it - this method will be removed
-     * 
+     *
      *             Clears any previously assigned guest language source code from this node.
      */
     @Deprecated
@@ -306,7 +306,7 @@ public abstract class Node implements NodeInterface, Cloneable {
     }
 
     final void replaceHelper(Node newNode, CharSequence reason) {
-        CompilerAsserts.neverPartOfCompilation();
+        CompilerAsserts.neverPartOfCompilation("do not call Node.replaceHelper from compiled code");
         assert inAtomicBlock();
         if (this.getParent() == null) {
             throw new IllegalStateException("This node cannot be replaced, because it does not yet have a parent.");
@@ -399,7 +399,7 @@ public abstract class Node implements NodeInterface, Cloneable {
      * @return the new copy
      */
     public Node copy() {
-        CompilerAsserts.neverPartOfCompilation();
+        CompilerAsserts.neverPartOfCompilation("do not call Node.copy from compiled code");
 
         try {
             return (Node) super.clone();

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/NodeUtil.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/NodeUtil.java
@@ -131,7 +131,7 @@ public final class NodeUtil {
 
     @SuppressWarnings("deprecation")
     static Node deepCopyImpl(Node orig) {
-        CompilerAsserts.neverPartOfCompilation();
+        CompilerAsserts.neverPartOfCompilation("do not call Node.deepCopyImpl from compiled code");
         final Node clone = orig.copy();
         NodeClass nodeClass = clone.getNodeClass();
 
@@ -169,7 +169,7 @@ public final class NodeUtil {
     }
 
     public static List<Node> findNodeChildren(Node node) {
-        CompilerAsserts.neverPartOfCompilation();
+        CompilerAsserts.neverPartOfCompilation("do not call Node.findNodeChildren from compiled code");
         List<Node> nodes = new ArrayList<>();
         NodeClass nodeClass = node.getNodeClass();
 
@@ -204,7 +204,7 @@ public final class NodeUtil {
 
     @SuppressWarnings("deprecation")
     static boolean replaceChild(Node parent, Node oldChild, Node newChild, boolean adopt) {
-        CompilerAsserts.neverPartOfCompilation();
+        CompilerAsserts.neverPartOfCompilation("do not replace Node child from compiled code");
         NodeClass nodeClass = parent.getNodeClass();
 
         for (NodeFieldAccessor nodeField : nodeClass.getChildFields()) {
@@ -315,7 +315,7 @@ public final class NodeUtil {
      * @return {@code true} if all children were visited, {@code false} otherwise
      */
     public static boolean forEachChild(Node parent, NodeVisitor visitor) {
-        CompilerAsserts.neverPartOfCompilation();
+        CompilerAsserts.neverPartOfCompilation("do not iterate over Node children from compiled code");
         Objects.requireNonNull(visitor);
         NodeClass parentNodeClass = parent.getNodeClass();
 

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/RootNode.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/RootNode.java
@@ -108,7 +108,7 @@ public abstract class RootNode extends Node {
      * heuristics can use the loop count to guide compilation and inlining.
      */
     public final void reportLoopCount(int count) {
-        CompilerAsserts.neverPartOfCompilation();
+        CompilerAsserts.neverPartOfCompilation("do not call RootNode.reportLoopCount from compiled code");
         if (getCallTarget() instanceof LoopCountReceiver) {
             ((LoopCountReceiver) getCallTarget()).reportLoopCount(count);
         }
@@ -141,7 +141,7 @@ public abstract class RootNode extends Node {
      * stack) without prior knowledge of the language it has come from.
      *
      * Used for instance to determine the language of a <code>RootNode<code>:
-     *
+     * 
      * <pre>
      * <code>
      * rootNode.getExecutionContext().getLanguageShortName();

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/source/Source.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/source/Source.java
@@ -121,6 +121,8 @@ public abstract class Source {
 
     private static boolean fileCacheEnabled = true;
 
+    private static final String NO_FASTPATH_SUBSOURCE_CREATION_MESSAGE = "do not create sub sources from compiled code";
+
     /**
      * Locates an existing instance by the name under which it was indexed.
      */
@@ -195,7 +197,7 @@ public abstract class Source {
      *             method matches the file name
      */
     public static Source fromFileName(CharSequence chars, String fileName) throws IOException {
-        CompilerAsserts.neverPartOfCompilation();
+        CompilerAsserts.neverPartOfCompilation("do not call Source.fromFileName from compiled code");
         assert chars != null;
 
         final WeakReference<Source> nameRef = nameToSource.get(fileName);
@@ -228,7 +230,7 @@ public abstract class Source {
      * @return a newly created, non-indexed source representation
      */
     public static Source fromText(CharSequence chars, String description) {
-        CompilerAsserts.neverPartOfCompilation();
+        CompilerAsserts.neverPartOfCompilation("do not call Source.fromText from compiled code");
         return new LiteralSource(description, chars.toString());
     }
 
@@ -240,7 +242,7 @@ public abstract class Source {
      * @return a newly created, non-indexed, initially empty, appendable source representation
      */
     public static Source fromAppendableText(String description) {
-        CompilerAsserts.neverPartOfCompilation();
+        CompilerAsserts.neverPartOfCompilation("do not call Source.fromAppendableText from compiled code");
         return new AppendableLiteralSource(description);
     }
 
@@ -254,7 +256,7 @@ public abstract class Source {
      * @return a newly created, source representation
      */
     public static Source fromNamedText(CharSequence chars, String name) {
-        CompilerAsserts.neverPartOfCompilation();
+        CompilerAsserts.neverPartOfCompilation("do not call Source.fromNamedText from compiled code");
         final Source source = new LiteralSource(name, chars.toString());
         nameToSource.put(name, new WeakReference<>(source));
         return source;
@@ -270,7 +272,7 @@ public abstract class Source {
      * @return a newly created, indexed, initially empty, appendable source representation
      */
     public static Source fromNamedAppendableText(String name) {
-        CompilerAsserts.neverPartOfCompilation();
+        CompilerAsserts.neverPartOfCompilation("do not call Source.fromNamedAppendable from compiled code");
         final Source source = new AppendableLiteralSource(name);
         nameToSource.put(name, new WeakReference<>(source));
         return source;
@@ -287,7 +289,7 @@ public abstract class Source {
      * @throws IllegalArgumentException if the specified sub-range is not contained in the base
      */
     public static Source subSource(Source base, int baseCharIndex, int length) {
-        CompilerAsserts.neverPartOfCompilation();
+        CompilerAsserts.neverPartOfCompilation(NO_FASTPATH_SUBSOURCE_CREATION_MESSAGE);
         final SubSource subSource = SubSource.create(base, baseCharIndex, length);
         return subSource;
     }
@@ -302,7 +304,7 @@ public abstract class Source {
      * @throws IllegalArgumentException if the index is out of range
      */
     public static Source subSource(Source base, int baseCharIndex) {
-        CompilerAsserts.neverPartOfCompilation();
+        CompilerAsserts.neverPartOfCompilation(NO_FASTPATH_SUBSOURCE_CREATION_MESSAGE);
 
         return subSource(base, baseCharIndex, base.getLength() - baseCharIndex);
     }
@@ -316,7 +318,7 @@ public abstract class Source {
      * @throws IOException if reading fails
      */
     public static Source fromURL(URL url, String description) throws IOException {
-        CompilerAsserts.neverPartOfCompilation();
+        CompilerAsserts.neverPartOfCompilation("do not call Source.fromURL from compiled code");
         return URLSource.get(url, description);
     }
 
@@ -329,7 +331,7 @@ public abstract class Source {
      * @throws IOException if reading fails
      */
     public static Source fromReader(Reader reader, String description) throws IOException {
-        CompilerAsserts.neverPartOfCompilation();
+        CompilerAsserts.neverPartOfCompilation("do not call Source.fromReader from compiled code");
         return new LiteralSource(description, read(reader));
     }
 
@@ -361,7 +363,7 @@ public abstract class Source {
      * @return a newly created, non-indexed source representation
      */
     public static Source fromBytes(byte[] bytes, int byteIndex, int length, String description, Charset charset) {
-        CompilerAsserts.neverPartOfCompilation();
+        CompilerAsserts.neverPartOfCompilation("do not call Source.fromBytes from compiled code");
         return new BytesSource(description, bytes, byteIndex, length, charset);
     }
 

--- a/truffle/com.oracle.truffle.object/src/com/oracle/truffle/object/ShapeImpl.java
+++ b/truffle/com.oracle.truffle.object/src/com/oracle/truffle/object/ShapeImpl.java
@@ -103,6 +103,8 @@ public abstract class ShapeImpl extends Shape {
     protected final Assumption validAssumption;
     @CompilationFinal protected volatile Assumption leafAssumption;
 
+    public static final String NO_FASTPATH_PROPERTY_ADD_MESSAGE = "don't add object properties in compiled code";
+
     /**
      * Shape transition map; lazily initialized.
      *
@@ -390,7 +392,7 @@ public abstract class ShapeImpl extends Shape {
      * @see #addProperty(Property)
      */
     private ShapeImpl addPropertyInternal(Property prop, boolean ensureValid) {
-        CompilerAsserts.neverPartOfCompilation();
+        CompilerAsserts.neverPartOfCompilation(NO_FASTPATH_PROPERTY_ADD_MESSAGE);
         assert prop.isShadow() || !(this.hasProperty(prop.getKey())) : "duplicate property " + prop.getKey();
 
         AddPropertyTransition addTransition = new AddPropertyTransition(prop);


### PR DESCRIPTION
While debugging a failed compilation, I missed those bailout messages. They would have sped up my debugging process. (I was not able to use e.g. TruffleCompilationExceptionsArePrinted from the binary I used).

IMHO we should even deprecate the option NOT to provide a message, but that's a different story.