### PR TITLE
Temporary fix for SourceSectionFilterTest execution for running inside graal classloaders

### DIFF
--- a/truffle/com.oracle.truffle.api.instrumentation.test/src/com/oracle/truffle/api/instrumentation/SourceSectionFilterTest.java
+++ b/truffle/com.oracle.truffle.api.instrumentation.test/src/com/oracle/truffle/api/instrumentation/SourceSectionFilterTest.java
@@ -96,55 +96,55 @@ public class SourceSectionFilterTest {
     @Test
     public void testLineIn() {
         Source sampleSource = Source.fromText("line1\nline2\nline3\nline4", null);
-        Assert.assertTrue(//
+        Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 1).build(),
                                         sampleSource.createSection(null, 6, 5, tags())));
 
-        Assert.assertTrue(//
+        Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().lineIn(1, 2).build(),
                                         sampleSource.createSection(null, 2, 1, tags())));
 
-        Assert.assertFalse(//
+        Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().lineIn(1, 1).build(),
                                         sampleSource.createSection(null, 6, 5, tags())));
 
-        Assert.assertFalse(//
+        Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 2).build(),
                                         sampleSource.createSection(null, 3 * LINE_LENGTH, 1, tags())));
 
-        Assert.assertTrue(//
+        Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 2).build(),
                                         sampleSource.createSection(null, 3 * LINE_LENGTH - 1, 1, tags())));
 
-        Assert.assertTrue(//
+        Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 2).build(),
                                         sampleSource.createSection(null, 3 * LINE_LENGTH - 2, 5, tags())));
 
-        Assert.assertFalse(//
+        Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 2).build(),
                                         sampleSource.createSection(null, 0, LINE_LENGTH, tags())));
 
-        Assert.assertTrue(//
+        Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 2).build(),
                                         sampleSource.createSection(null, 0, LINE_LENGTH + 1, tags())));
 
-        Assert.assertTrue(//
+        Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 2).build(),
                                         sampleSource.createSection(null, 1 * LINE_LENGTH - 2, 5, tags())));
 
-        Assert.assertTrue(//
+        Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 2).build(),
                                         sampleSource.createSection(null, 1 * LINE_LENGTH, 1, tags())));
 
-        Assert.assertTrue(//
+        Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 2).build(),
                                         sampleSource.createSection(null, 1 * LINE_LENGTH - 2, 5, tags())));
 
-        Assert.assertFalse(//
+        Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().lineIn(1, 1).build(),
                                         SourceSection.createUnavailable(null, null)));
 
-        Assert.assertTrue(//
+        Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().lineIs(1).build(),
                                         sampleSource.createSection(null, 0, LINE_LENGTH, tags())));
 
@@ -164,27 +164,27 @@ public class SourceSectionFilterTest {
     @Test
     public void testMimeType() {
         Source sampleSource = Source.fromText("line1\nline2\nline3\nline4", null);
-        Assert.assertFalse(//
+        Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().mimeTypeIs().build(),
                                         sampleSource.withMimeType("mime3").createSection(null, 0, 5, tags())));
 
-        Assert.assertTrue(//
+        Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().mimeTypeIs("mime1").build(),
                                         sampleSource.withMimeType("mime1").createSection(null, 0, 5, tags())));
 
-        Assert.assertFalse(//
+        Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().mimeTypeIs("mime1").build(),
                                         sampleSource.withMimeType("mime2").createSection(null, 0, 5, tags())));
 
-        Assert.assertTrue(//
+        Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().mimeTypeIs("mime1", "mime2").build(),
                                         sampleSource.withMimeType("mime2").createSection(null, 0, 5, tags())));
 
-        Assert.assertFalse(//
+        Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().mimeTypeIs("mime1", "mime2").build(),
                                         sampleSource.withMimeType("mime3").createSection(null, 0, 5, tags())));
 
-        Assert.assertFalse(//
+        Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().mimeTypeIs("mime1", "mime2").build(),
                                         sampleSource.withMimeType(null).createSection(null, 0, 5, tags())));
 
@@ -194,51 +194,51 @@ public class SourceSectionFilterTest {
     @Test
     public void testIndexIn() {
         Source sampleSource = Source.fromText("line1\nline2\nline3\nline4", null);
-        Assert.assertFalse(//
+        Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().indexIn(0, 0).build(),
                                         sampleSource.createSection(null, 0, 5, tags())));
 
-        Assert.assertTrue(//
+        Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().indexIn(0, 1).build(),
                                         sampleSource.createSection(null, 0, 5, tags())));
 
-        Assert.assertTrue(//
+        Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
                                         sampleSource.createSection(null, 5, 5, tags())));
 
-        Assert.assertFalse(//
+        Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
                                         sampleSource.createSection(null, 0, 4, tags())));
 
-        Assert.assertTrue(//
+        Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
                                         sampleSource.createSection(null, 0, 5, tags())));
 
-        Assert.assertTrue(//
+        Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
                                         sampleSource.createSection(null, 4, 5, tags())));
 
-        Assert.assertTrue(//
+        Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
                                         sampleSource.createSection(null, 4, 6, tags())));
 
-        Assert.assertTrue(//
+        Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
                                         sampleSource.createSection(null, 5, 5, tags())));
 
-        Assert.assertFalse(//
+        Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
                                         sampleSource.createSection(null, 10, 1, tags())));
 
-        Assert.assertTrue(//
+        Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
                                         sampleSource.createSection(null, 9, 1, tags())));
 
-        Assert.assertTrue(//
+        Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
                                         sampleSource.createSection(null, 9, 5, tags())));
 
-        Assert.assertFalse(//
+        Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
                                         SourceSection.createUnavailable(null, null)));
 
@@ -262,27 +262,27 @@ public class SourceSectionFilterTest {
         Source sampleSource2 = Source.fromText("line1\nline2\nline3\nline4", null);
         Source sampleSource3 = Source.fromText("line1\nline2\nline3\nline4", null);
 
-        Assert.assertTrue(//
+        Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().sourceIs(sampleSource1).build(),
                                         sampleSource1.createSection(null, 0, 5, tags())));
 
-        Assert.assertFalse(//
+        Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().sourceIs(sampleSource1).build(),
                                         SourceSection.createUnavailable(null, null)));
 
-        Assert.assertFalse(//
+        Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().sourceIs(sampleSource1).build(),
                                         sampleSource2.createSection(null, 0, 5, tags())));
 
-        Assert.assertTrue(//
+        Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().sourceIs(sampleSource1, sampleSource2).build(),
                                         sampleSource2.createSection(null, 0, 5, tags())));
 
-        Assert.assertTrue(//
+        Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().sourceIs(sampleSource1, sampleSource2).build(),
                                         sampleSource1.createSection(null, 0, 5, tags())));
 
-        Assert.assertFalse(//
+        Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().sourceIs(sampleSource1, sampleSource2).build(),
                                         sampleSource3.createSection(null, 0, 5, tags())));
 
@@ -294,35 +294,35 @@ public class SourceSectionFilterTest {
         Source sampleSource1 = Source.fromText("line1\nline2\nline3\nline4", null);
         Source sampleSource2 = Source.fromText("line1\nline2\nline3\nline4", null);
 
-        Assert.assertTrue(//
+        Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().sourceSectionEquals(sampleSource1.createSection(null, 1, 6)).build(),
                                         sampleSource1.createSection(null, 1, 6, tags())));
 
-        Assert.assertTrue(//
+        Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().sourceSectionEquals(sampleSource1.createSection(null, 1, 6)).build(),
                                         sampleSource2.createSection(null, 1, 6, tags())));
 
-        Assert.assertFalse(//
+        Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().sourceSectionEquals(sampleSource1.createSection(null, 1, 7)).build(),
                                         sampleSource1.createSection(null, 1, 6, tags())));
 
-        Assert.assertFalse(//
+        Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().sourceSectionEquals(sampleSource1.createSection(null, 2, 6)).build(),
                                         sampleSource1.createSection(null, 1, 6, tags())));
 
-        Assert.assertTrue(//
+        Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().sourceSectionEquals(sampleSource1.createSection(null, 2, 6), sampleSource1.createSection(null, 2, 7)).build(),
                                         sampleSource1.createSection(null, 2, 7, tags())));
 
-        Assert.assertFalse(//
+        Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().sourceSectionEquals(sampleSource1.createSection(null, 2, 6), sampleSource1.createSection(null, 2, 7)).build(),
                                         sampleSource1.createSection(null, 2, 8, tags())));
 
-        Assert.assertFalse(//
+        Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().sourceSectionEquals(sampleSource1.createSection(null, 2, 6), sampleSource1.createSection(null, 2, 7)).build(),
                                         SourceSection.createUnavailable(null, null)));
 
-        Assert.assertFalse(//
+        Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().sourceSectionEquals(sampleSource1.createSection(null, 2, 6), sampleSource1.createSection(null, 2, 7)).build(),
                                         null));
 
@@ -335,32 +335,32 @@ public class SourceSectionFilterTest {
 
     @Test
     public void testTagsIn() {
-        Assert.assertFalse(//
+        Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().tagIs().build(), source()));
 
-        Assert.assertFalse(//
+        Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().tagIs().build(), source(InstrumentationTestLanguage.STATEMENT)));
 
-        Assert.assertTrue(//
+        Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().tagIs(InstrumentationTestLanguage.STATEMENT).build(), source(InstrumentationTestLanguage.STATEMENT)));
 
-        Assert.assertTrue(//
+        Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().tagIs(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT).build(),
                                         source(InstrumentationTestLanguage.STATEMENT)));
 
-        Assert.assertFalse(//
+        Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().tagIs(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT).build(),
                                         source(InstrumentationTestLanguage.ROOT)));
 
-        Assert.assertFalse(//
+        Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().tagIs(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT).build(),
                                         source()));
 
-        Assert.assertTrue(//
+        Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().tagIs(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT).build(),
                                         source(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT)));
 
-        Assert.assertTrue(//
+        Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().tagIs(InstrumentationTestLanguage.STATEMENT).build(),
                                         source(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT)));
 
@@ -369,35 +369,35 @@ public class SourceSectionFilterTest {
 
     @Test
     public void testTagsNotIn() {
-        Assert.assertTrue(//
+        Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().tagIsNot().build(),
                                         source()));
 
-        Assert.assertTrue(//
+        Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().tagIsNot().build(),
                                         source(InstrumentationTestLanguage.STATEMENT)));
 
-        Assert.assertFalse(//
+        Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().tagIsNot(InstrumentationTestLanguage.STATEMENT).build(),
                                         source(InstrumentationTestLanguage.STATEMENT)));
 
-        Assert.assertFalse(//
+        Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().tagIsNot(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT).build(),
                                         source(InstrumentationTestLanguage.STATEMENT)));
 
-        Assert.assertTrue(//
+        Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().tagIsNot(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT).build(),
                                         source(InstrumentationTestLanguage.ROOT)));
 
-        Assert.assertTrue(//
+        Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().tagIsNot(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT).build(),
                                         source()));
 
-        Assert.assertFalse(//
+        Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().tagIsNot(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT).build(),
                                         source(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT)));
 
-        Assert.assertFalse(//
+        Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().tagIsNot(InstrumentationTestLanguage.STATEMENT).build(),
                                         source(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT)));
 

--- a/truffle/com.oracle.truffle.api.instrumentation.test/src/com/oracle/truffle/api/instrumentation/SourceSectionFilterTest.java
+++ b/truffle/com.oracle.truffle.api.instrumentation.test/src/com/oracle/truffle/api/instrumentation/SourceSectionFilterTest.java
@@ -24,6 +24,8 @@
  */
 package com.oracle.truffle.api.instrumentation;
 
+import java.lang.reflect.Method;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -34,94 +36,117 @@ public class SourceSectionFilterTest {
 
     private static final int LINE_LENGTH = 6;
 
-    SourceSection unavailable = SourceSection.createUnavailable(null, null);
-    Source sampleSource = Source.fromText("line1\nline2\nline3\nline4", null);
+    private static boolean isInstrumentedNode(SourceSectionFilter filter, SourceSection section) {
+        return invokeAccessible(filter, "isInstrumentedNode", section);
+    }
+
+    private static boolean isInstrumented(SourceSectionFilter filter, SourceSection section) {
+        return invokeAccessible(filter, "isInstrumented", section);
+    }
+
+    private static boolean isInstrumentedRoot(SourceSectionFilter filter, SourceSection section) {
+        return invokeAccessible(filter, "isInstrumentedRoot", section);
+    }
+
+    private static boolean invokeAccessible(SourceSectionFilter filter, String methodName, SourceSection section) {
+        try {
+            Method m = filter.getClass().getDeclaredMethod(methodName, SourceSection.class);
+            m.setAccessible(true);
+            return (boolean) m.invoke(filter, section);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
 
     @Test
     public void testEmpty() {
+        Source sampleSource = Source.fromText("line1\nline2\nline3\nline4", null);
+        SourceSection unavailable = SourceSection.createUnavailable(null, null);
         SourceSectionFilter filter = SourceSectionFilter.newBuilder().build();
         SourceSection sampleSection = sampleSource.createSection(null, 2);
 
-        Assert.assertTrue(filter.isInstrumentedNode(source()));
-        Assert.assertTrue(filter.isInstrumentedNode(unavailable));
-        Assert.assertTrue(filter.isInstrumentedNode(sampleSection));
+        Assert.assertTrue(isInstrumentedNode(filter, source()));
+        Assert.assertTrue(isInstrumentedNode(filter, unavailable));
+        Assert.assertTrue(isInstrumentedNode(filter, sampleSection));
 
-        Assert.assertTrue(filter.isInstrumentedRoot(null));
-        Assert.assertTrue(filter.isInstrumentedRoot(unavailable));
-        Assert.assertTrue(filter.isInstrumentedRoot(sampleSection));
+        Assert.assertTrue(isInstrumentedRoot(filter, null));
+        Assert.assertTrue(isInstrumentedRoot(filter, unavailable));
+        Assert.assertTrue(isInstrumentedRoot(filter, sampleSection));
 
-        Assert.assertTrue(filter.isInstrumented(source()));
-        Assert.assertTrue(filter.isInstrumented(unavailable));
-        Assert.assertTrue(filter.isInstrumented(sampleSection));
+        Assert.assertTrue(isInstrumented(filter, source()));
+        Assert.assertTrue(isInstrumented(filter, unavailable));
+        Assert.assertTrue(isInstrumented(filter, sampleSection));
 
         String prevTag = null;
         for (String tag : InstrumentationTestLanguage.TAGS) {
-            Assert.assertTrue(filter.isInstrumented(source(tag)));
-            Assert.assertTrue(filter.isInstrumented(unavailable));
-            Assert.assertTrue(filter.isInstrumented(sampleSource.createSection(null, 0, 4, tag)));
+            Assert.assertTrue(isInstrumented(filter, source(tag)));
+            Assert.assertTrue(isInstrumented(filter, unavailable));
+            Assert.assertTrue(isInstrumented(filter, sampleSource.createSection(null, 0, 4, tag)));
             if (prevTag != null) {
-                Assert.assertTrue(filter.isInstrumented(source(tag)));
-                Assert.assertTrue(filter.isInstrumented(unavailable));
-                Assert.assertTrue(filter.isInstrumented(sampleSource.createSection(null, 0, 4, tag, prevTag)));
+                Assert.assertTrue(isInstrumented(filter, source(tag)));
+                Assert.assertTrue(isInstrumented(filter, unavailable));
+                Assert.assertTrue(isInstrumented(filter, sampleSource.createSection(null, 0, 4, tag, prevTag)));
             }
             prevTag = tag;
         }
         Assert.assertNotNull(filter.toString());
+
     }
 
     @Test
     public void testLineIn() {
+        Source sampleSource = Source.fromText("line1\nline2\nline3\nline4", null);
         Assert.assertTrue(//
-        SourceSectionFilter.newBuilder().lineIn(2, 1).build().//
-        isInstrumented(sampleSource.createSection(null, 6, 5, tags())));
+                        isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 1).build(),
+                                        sampleSource.createSection(null, 6, 5, tags())));
 
         Assert.assertTrue(//
-        SourceSectionFilter.newBuilder().lineIn(1, 2).build().//
-        isInstrumented(sampleSource.createSection(null, 2, 1, tags())));
+                        isInstrumented(SourceSectionFilter.newBuilder().lineIn(1, 2).build(),
+                                        sampleSource.createSection(null, 2, 1, tags())));
 
         Assert.assertFalse(//
-        SourceSectionFilter.newBuilder().lineIn(1, 1).build().//
-        isInstrumented(sampleSource.createSection(null, 6, 5, tags())));
+                        isInstrumented(SourceSectionFilter.newBuilder().lineIn(1, 1).build(),
+                                        sampleSource.createSection(null, 6, 5, tags())));
 
         Assert.assertFalse(//
-        SourceSectionFilter.newBuilder().lineIn(2, 2).build().//
-        isInstrumented(sampleSource.createSection(null, 3 * LINE_LENGTH, 1, tags())));
+                        isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 2).build(),
+                                        sampleSource.createSection(null, 3 * LINE_LENGTH, 1, tags())));
 
         Assert.assertTrue(//
-        SourceSectionFilter.newBuilder().lineIn(2, 2).build().//
-        isInstrumented(sampleSource.createSection(null, 3 * LINE_LENGTH - 1, 1, tags())));
+                        isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 2).build(),
+                                        sampleSource.createSection(null, 3 * LINE_LENGTH - 1, 1, tags())));
 
         Assert.assertTrue(//
-        SourceSectionFilter.newBuilder().lineIn(2, 2).build().//
-        isInstrumented(sampleSource.createSection(null, 3 * LINE_LENGTH - 2, 5, tags())));
+                        isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 2).build(),
+                                        sampleSource.createSection(null, 3 * LINE_LENGTH - 2, 5, tags())));
 
         Assert.assertFalse(//
-        SourceSectionFilter.newBuilder().lineIn(2, 2).build().//
-        isInstrumented(sampleSource.createSection(null, 0, LINE_LENGTH, tags())));
+                        isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 2).build(),
+                                        sampleSource.createSection(null, 0, LINE_LENGTH, tags())));
 
         Assert.assertTrue(//
-        SourceSectionFilter.newBuilder().lineIn(2, 2).build().//
-        isInstrumented(sampleSource.createSection(null, 0, LINE_LENGTH + 1, tags())));
+                        isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 2).build(),
+                                        sampleSource.createSection(null, 0, LINE_LENGTH + 1, tags())));
 
         Assert.assertTrue(//
-        SourceSectionFilter.newBuilder().lineIn(2, 2).build().//
-        isInstrumented(sampleSource.createSection(null, 1 * LINE_LENGTH - 2, 5, tags())));
+                        isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 2).build(),
+                                        sampleSource.createSection(null, 1 * LINE_LENGTH - 2, 5, tags())));
 
         Assert.assertTrue(//
-        SourceSectionFilter.newBuilder().lineIn(2, 2).build().//
-        isInstrumented(sampleSource.createSection(null, 1 * LINE_LENGTH, 1, tags())));
+                        isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 2).build(),
+                                        sampleSource.createSection(null, 1 * LINE_LENGTH, 1, tags())));
 
         Assert.assertTrue(//
-        SourceSectionFilter.newBuilder().lineIn(2, 2).build().//
-        isInstrumented(sampleSource.createSection(null, 1 * LINE_LENGTH - 2, 5, tags())));
+                        isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 2).build(),
+                                        sampleSource.createSection(null, 1 * LINE_LENGTH - 2, 5, tags())));
 
         Assert.assertFalse(//
-        SourceSectionFilter.newBuilder().lineIn(1, 1).build().//
-        isInstrumented(SourceSection.createUnavailable(null, null)));
+                        isInstrumented(SourceSectionFilter.newBuilder().lineIn(1, 1).build(),
+                                        SourceSection.createUnavailable(null, null)));
 
         Assert.assertTrue(//
-        SourceSectionFilter.newBuilder().lineIs(1).build().//
-        isInstrumented(sampleSource.createSection(null, 0, LINE_LENGTH, tags())));
+                        isInstrumented(SourceSectionFilter.newBuilder().lineIs(1).build(),
+                                        sampleSource.createSection(null, 0, LINE_LENGTH, tags())));
 
         Assert.assertNotNull(SourceSectionFilter.newBuilder().lineIn(2, 2).build().toString());
     }
@@ -138,82 +163,84 @@ public class SourceSectionFilterTest {
 
     @Test
     public void testMimeType() {
+        Source sampleSource = Source.fromText("line1\nline2\nline3\nline4", null);
         Assert.assertFalse(//
-        SourceSectionFilter.newBuilder().mimeTypeIs().build().//
-        isInstrumented(sampleSource.withMimeType("mime3").createSection(null, 0, 5, tags())));
+                        isInstrumented(SourceSectionFilter.newBuilder().mimeTypeIs().build(),
+                                        sampleSource.withMimeType("mime3").createSection(null, 0, 5, tags())));
 
         Assert.assertTrue(//
-        SourceSectionFilter.newBuilder().mimeTypeIs("mime1").build().//
-        isInstrumented(sampleSource.withMimeType("mime1").createSection(null, 0, 5, tags())));
+                        isInstrumented(SourceSectionFilter.newBuilder().mimeTypeIs("mime1").build(),
+                                        sampleSource.withMimeType("mime1").createSection(null, 0, 5, tags())));
 
         Assert.assertFalse(//
-        SourceSectionFilter.newBuilder().mimeTypeIs("mime1").build().//
-        isInstrumented(sampleSource.withMimeType("mime2").createSection(null, 0, 5, tags())));
+                        isInstrumented(SourceSectionFilter.newBuilder().mimeTypeIs("mime1").build(),
+                                        sampleSource.withMimeType("mime2").createSection(null, 0, 5, tags())));
 
         Assert.assertTrue(//
-        SourceSectionFilter.newBuilder().mimeTypeIs("mime1", "mime2").build().//
-        isInstrumented(sampleSource.withMimeType("mime2").createSection(null, 0, 5, tags())));
+                        isInstrumented(SourceSectionFilter.newBuilder().mimeTypeIs("mime1", "mime2").build(),
+                                        sampleSource.withMimeType("mime2").createSection(null, 0, 5, tags())));
 
         Assert.assertFalse(//
-        SourceSectionFilter.newBuilder().mimeTypeIs("mime1", "mime2").build().//
-        isInstrumented(sampleSource.withMimeType("mime3").createSection(null, 0, 5, tags())));
+                        isInstrumented(SourceSectionFilter.newBuilder().mimeTypeIs("mime1", "mime2").build(),
+                                        sampleSource.withMimeType("mime3").createSection(null, 0, 5, tags())));
 
         Assert.assertFalse(//
-        SourceSectionFilter.newBuilder().mimeTypeIs("mime1", "mime2").build().//
-        isInstrumented(sampleSource.withMimeType(null).createSection(null, 0, 5, tags())));
+                        isInstrumented(SourceSectionFilter.newBuilder().mimeTypeIs("mime1", "mime2").build(),
+                                        sampleSource.withMimeType(null).createSection(null, 0, 5, tags())));
 
         Assert.assertNotNull(SourceSectionFilter.newBuilder().mimeTypeIs("mime1", "mime2").build().toString());
     }
 
     @Test
     public void testIndexIn() {
+        Source sampleSource = Source.fromText("line1\nline2\nline3\nline4", null);
         Assert.assertFalse(//
-        SourceSectionFilter.newBuilder().indexIn(0, 0).build().//
-        isInstrumented(sampleSource.createSection(null, 0, 5, tags())));
+                        isInstrumented(SourceSectionFilter.newBuilder().indexIn(0, 0).build(),
+                                        sampleSource.createSection(null, 0, 5, tags())));
 
         Assert.assertTrue(//
-        SourceSectionFilter.newBuilder().indexIn(0, 1).build().//
-        isInstrumented(sampleSource.createSection(null, 0, 5, tags())));
+                        isInstrumented(SourceSectionFilter.newBuilder().indexIn(0, 1).build(),
+                                        sampleSource.createSection(null, 0, 5, tags())));
 
         Assert.assertTrue(//
-        SourceSectionFilter.newBuilder().indexIn(5, 5).build().//
-        isInstrumented(sampleSource.createSection(null, 5, 5, tags())));
-
-        Assert.assertFalse(//
-        SourceSectionFilter.newBuilder().indexIn(5, 5).build().//
-        isInstrumented(sampleSource.createSection(null, 0, 4, tags())));
-
-        Assert.assertTrue(//
-        SourceSectionFilter.newBuilder().indexIn(5, 5).build().//
-        isInstrumented(sampleSource.createSection(null, 0, 5, tags())));
-
-        Assert.assertTrue(//
-        SourceSectionFilter.newBuilder().indexIn(5, 5).build().//
-        isInstrumented(sampleSource.createSection(null, 4, 5, tags())));
-
-        Assert.assertTrue(//
-        SourceSectionFilter.newBuilder().indexIn(5, 5).build().//
-        isInstrumented(sampleSource.createSection(null, 4, 6, tags())));
-
-        Assert.assertTrue(//
-        SourceSectionFilter.newBuilder().indexIn(5, 5).build().//
-        isInstrumented(sampleSource.createSection(null, 5, 5, tags())));
+                        isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
+                                        sampleSource.createSection(null, 5, 5, tags())));
 
         Assert.assertFalse(//
-        SourceSectionFilter.newBuilder().indexIn(5, 5).build().//
-        isInstrumented(sampleSource.createSection(null, 10, 1, tags())));
+                        isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
+                                        sampleSource.createSection(null, 0, 4, tags())));
 
         Assert.assertTrue(//
-        SourceSectionFilter.newBuilder().indexIn(5, 5).build().//
-        isInstrumented(sampleSource.createSection(null, 9, 1, tags())));
+                        isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
+                                        sampleSource.createSection(null, 0, 5, tags())));
 
         Assert.assertTrue(//
-        SourceSectionFilter.newBuilder().indexIn(5, 5).build().//
-        isInstrumented(sampleSource.createSection(null, 9, 5, tags())));
+                        isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
+                                        sampleSource.createSection(null, 4, 5, tags())));
+
+        Assert.assertTrue(//
+                        isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
+                                        sampleSource.createSection(null, 4, 6, tags())));
+
+        Assert.assertTrue(//
+                        isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
+                                        sampleSource.createSection(null, 5, 5, tags())));
 
         Assert.assertFalse(//
-        SourceSectionFilter.newBuilder().indexIn(5, 5).build().//
-        isInstrumented(SourceSection.createUnavailable(null, null)));
+                        isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
+                                        sampleSource.createSection(null, 10, 1, tags())));
+
+        Assert.assertTrue(//
+                        isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
+                                        sampleSource.createSection(null, 9, 1, tags())));
+
+        Assert.assertTrue(//
+                        isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
+                                        sampleSource.createSection(null, 9, 5, tags())));
+
+        Assert.assertFalse(//
+                        isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
+                                        SourceSection.createUnavailable(null, null)));
 
         Assert.assertNotNull(SourceSectionFilter.newBuilder().indexIn(5, 5).build().toString());
 
@@ -236,28 +263,28 @@ public class SourceSectionFilterTest {
         Source sampleSource3 = Source.fromText("line1\nline2\nline3\nline4", null);
 
         Assert.assertTrue(//
-        SourceSectionFilter.newBuilder().sourceIs(sampleSource1).build().//
-        isInstrumented(sampleSource1.createSection(null, 0, 5, tags())));
+                        isInstrumented(SourceSectionFilter.newBuilder().sourceIs(sampleSource1).build(),
+                                        sampleSource1.createSection(null, 0, 5, tags())));
 
         Assert.assertFalse(//
-        SourceSectionFilter.newBuilder().sourceIs(sampleSource1).build().//
-        isInstrumented(SourceSection.createUnavailable(null, null)));
+                        isInstrumented(SourceSectionFilter.newBuilder().sourceIs(sampleSource1).build(),
+                                        SourceSection.createUnavailable(null, null)));
 
         Assert.assertFalse(//
-        SourceSectionFilter.newBuilder().sourceIs(sampleSource1).build().//
-        isInstrumented(sampleSource2.createSection(null, 0, 5, tags())));
+                        isInstrumented(SourceSectionFilter.newBuilder().sourceIs(sampleSource1).build(),
+                                        sampleSource2.createSection(null, 0, 5, tags())));
 
         Assert.assertTrue(//
-        SourceSectionFilter.newBuilder().sourceIs(sampleSource1, sampleSource2).build().//
-        isInstrumented(sampleSource2.createSection(null, 0, 5, tags())));
+                        isInstrumented(SourceSectionFilter.newBuilder().sourceIs(sampleSource1, sampleSource2).build(),
+                                        sampleSource2.createSection(null, 0, 5, tags())));
 
         Assert.assertTrue(//
-        SourceSectionFilter.newBuilder().sourceIs(sampleSource1, sampleSource2).build().//
-        isInstrumented(sampleSource1.createSection(null, 0, 5, tags())));
+                        isInstrumented(SourceSectionFilter.newBuilder().sourceIs(sampleSource1, sampleSource2).build(),
+                                        sampleSource1.createSection(null, 0, 5, tags())));
 
         Assert.assertFalse(//
-        SourceSectionFilter.newBuilder().sourceIs(sampleSource1, sampleSource2).build().//
-        isInstrumented(sampleSource3.createSection(null, 0, 5, tags())));
+                        isInstrumented(SourceSectionFilter.newBuilder().sourceIs(sampleSource1, sampleSource2).build(),
+                                        sampleSource3.createSection(null, 0, 5, tags())));
 
         Assert.assertNotNull(SourceSectionFilter.newBuilder().sourceIs(sampleSource1, sampleSource2).build().toString());
     }
@@ -268,36 +295,36 @@ public class SourceSectionFilterTest {
         Source sampleSource2 = Source.fromText("line1\nline2\nline3\nline4", null);
 
         Assert.assertTrue(//
-        SourceSectionFilter.newBuilder().sourceSectionEquals(sampleSource1.createSection(null, 1, 6)).build().//
-        isInstrumented(sampleSource1.createSection(null, 1, 6, tags())));
+                        isInstrumented(SourceSectionFilter.newBuilder().sourceSectionEquals(sampleSource1.createSection(null, 1, 6)).build(),
+                                        sampleSource1.createSection(null, 1, 6, tags())));
 
         Assert.assertTrue(//
-        SourceSectionFilter.newBuilder().sourceSectionEquals(sampleSource1.createSection(null, 1, 6)).build().//
-        isInstrumented(sampleSource2.createSection(null, 1, 6, tags())));
+                        isInstrumented(SourceSectionFilter.newBuilder().sourceSectionEquals(sampleSource1.createSection(null, 1, 6)).build(),
+                                        sampleSource2.createSection(null, 1, 6, tags())));
 
         Assert.assertFalse(//
-        SourceSectionFilter.newBuilder().sourceSectionEquals(sampleSource1.createSection(null, 1, 7)).build().//
-        isInstrumented(sampleSource1.createSection(null, 1, 6, tags())));
+                        isInstrumented(SourceSectionFilter.newBuilder().sourceSectionEquals(sampleSource1.createSection(null, 1, 7)).build(),
+                                        sampleSource1.createSection(null, 1, 6, tags())));
 
         Assert.assertFalse(//
-        SourceSectionFilter.newBuilder().sourceSectionEquals(sampleSource1.createSection(null, 2, 6)).build().//
-        isInstrumented(sampleSource1.createSection(null, 1, 6, tags())));
+                        isInstrumented(SourceSectionFilter.newBuilder().sourceSectionEquals(sampleSource1.createSection(null, 2, 6)).build(),
+                                        sampleSource1.createSection(null, 1, 6, tags())));
 
         Assert.assertTrue(//
-        SourceSectionFilter.newBuilder().sourceSectionEquals(sampleSource1.createSection(null, 2, 6), sampleSource1.createSection(null, 2, 7)).build().//
-        isInstrumented(sampleSource1.createSection(null, 2, 7, tags())));
+                        isInstrumented(SourceSectionFilter.newBuilder().sourceSectionEquals(sampleSource1.createSection(null, 2, 6), sampleSource1.createSection(null, 2, 7)).build(),
+                                        sampleSource1.createSection(null, 2, 7, tags())));
 
         Assert.assertFalse(//
-        SourceSectionFilter.newBuilder().sourceSectionEquals(sampleSource1.createSection(null, 2, 6), sampleSource1.createSection(null, 2, 7)).build().//
-        isInstrumented(sampleSource1.createSection(null, 2, 8, tags())));
+                        isInstrumented(SourceSectionFilter.newBuilder().sourceSectionEquals(sampleSource1.createSection(null, 2, 6), sampleSource1.createSection(null, 2, 7)).build(),
+                                        sampleSource1.createSection(null, 2, 8, tags())));
 
         Assert.assertFalse(//
-        SourceSectionFilter.newBuilder().sourceSectionEquals(sampleSource1.createSection(null, 2, 6), sampleSource1.createSection(null, 2, 7)).build().//
-        isInstrumented(SourceSection.createUnavailable(null, null)));
+                        isInstrumented(SourceSectionFilter.newBuilder().sourceSectionEquals(sampleSource1.createSection(null, 2, 6), sampleSource1.createSection(null, 2, 7)).build(),
+                                        SourceSection.createUnavailable(null, null)));
 
         Assert.assertFalse(//
-        SourceSectionFilter.newBuilder().sourceSectionEquals(sampleSource1.createSection(null, 2, 6), sampleSource1.createSection(null, 2, 7)).build().//
-        isInstrumented(null));
+                        isInstrumented(SourceSectionFilter.newBuilder().sourceSectionEquals(sampleSource1.createSection(null, 2, 6), sampleSource1.createSection(null, 2, 7)).build(),
+                                        null));
 
         Assert.assertNotNull(SourceSectionFilter.newBuilder().sourceSectionEquals(sampleSource1.createSection(null, 1, 6)).build().toString());
     }
@@ -309,36 +336,33 @@ public class SourceSectionFilterTest {
     @Test
     public void testTagsIn() {
         Assert.assertFalse(//
-        SourceSectionFilter.newBuilder().tagIs().build().//
-        isInstrumented(source()));
+                        isInstrumented(SourceSectionFilter.newBuilder().tagIs().build(), source()));
 
         Assert.assertFalse(//
-        SourceSectionFilter.newBuilder().tagIs().build().//
-        isInstrumented(source(InstrumentationTestLanguage.STATEMENT)));
+                        isInstrumented(SourceSectionFilter.newBuilder().tagIs().build(), source(InstrumentationTestLanguage.STATEMENT)));
 
         Assert.assertTrue(//
-        SourceSectionFilter.newBuilder().tagIs(InstrumentationTestLanguage.STATEMENT).build().//
-        isInstrumented(source(InstrumentationTestLanguage.STATEMENT)));
+                        isInstrumented(SourceSectionFilter.newBuilder().tagIs(InstrumentationTestLanguage.STATEMENT).build(), source(InstrumentationTestLanguage.STATEMENT)));
 
         Assert.assertTrue(//
-        SourceSectionFilter.newBuilder().tagIs(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT).build().//
-        isInstrumented(source(InstrumentationTestLanguage.STATEMENT)));
+                        isInstrumented(SourceSectionFilter.newBuilder().tagIs(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT).build(),
+                                        source(InstrumentationTestLanguage.STATEMENT)));
 
         Assert.assertFalse(//
-        SourceSectionFilter.newBuilder().tagIs(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT).build().//
-        isInstrumented(source(InstrumentationTestLanguage.ROOT)));
+                        isInstrumented(SourceSectionFilter.newBuilder().tagIs(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT).build(),
+                                        source(InstrumentationTestLanguage.ROOT)));
 
         Assert.assertFalse(//
-        SourceSectionFilter.newBuilder().tagIs(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT).build().//
-        isInstrumented(source()));
+                        isInstrumented(SourceSectionFilter.newBuilder().tagIs(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT).build(),
+                                        source()));
 
         Assert.assertTrue(//
-        SourceSectionFilter.newBuilder().tagIs(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT).build().//
-        isInstrumented(source(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT)));
+                        isInstrumented(SourceSectionFilter.newBuilder().tagIs(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT).build(),
+                                        source(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT)));
 
         Assert.assertTrue(//
-        SourceSectionFilter.newBuilder().tagIs(InstrumentationTestLanguage.STATEMENT).build().//
-        isInstrumented(source(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT)));
+                        isInstrumented(SourceSectionFilter.newBuilder().tagIs(InstrumentationTestLanguage.STATEMENT).build(),
+                                        source(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT)));
 
         Assert.assertNotNull(SourceSectionFilter.newBuilder().tagIs(InstrumentationTestLanguage.STATEMENT, InstrumentationTestLanguage.EXPRESSION).build().toString());
     }
@@ -346,36 +370,36 @@ public class SourceSectionFilterTest {
     @Test
     public void testTagsNotIn() {
         Assert.assertTrue(//
-        SourceSectionFilter.newBuilder().tagIsNot().build().//
-        isInstrumented(source()));
+                        isInstrumented(SourceSectionFilter.newBuilder().tagIsNot().build(),
+                                        source()));
 
         Assert.assertTrue(//
-        SourceSectionFilter.newBuilder().tagIsNot().build().//
-        isInstrumented(source(InstrumentationTestLanguage.STATEMENT)));
+                        isInstrumented(SourceSectionFilter.newBuilder().tagIsNot().build(),
+                                        source(InstrumentationTestLanguage.STATEMENT)));
 
         Assert.assertFalse(//
-        SourceSectionFilter.newBuilder().tagIsNot(InstrumentationTestLanguage.STATEMENT).build().//
-        isInstrumented(source(InstrumentationTestLanguage.STATEMENT)));
+                        isInstrumented(SourceSectionFilter.newBuilder().tagIsNot(InstrumentationTestLanguage.STATEMENT).build(),
+                                        source(InstrumentationTestLanguage.STATEMENT)));
 
         Assert.assertFalse(//
-        SourceSectionFilter.newBuilder().tagIsNot(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT).build().//
-        isInstrumented(source(InstrumentationTestLanguage.STATEMENT)));
+                        isInstrumented(SourceSectionFilter.newBuilder().tagIsNot(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT).build(),
+                                        source(InstrumentationTestLanguage.STATEMENT)));
 
         Assert.assertTrue(//
-        SourceSectionFilter.newBuilder().tagIsNot(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT).build().//
-        isInstrumented(source(InstrumentationTestLanguage.ROOT)));
+                        isInstrumented(SourceSectionFilter.newBuilder().tagIsNot(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT).build(),
+                                        source(InstrumentationTestLanguage.ROOT)));
 
         Assert.assertTrue(//
-        SourceSectionFilter.newBuilder().tagIsNot(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT).build().//
-        isInstrumented(source()));
+                        isInstrumented(SourceSectionFilter.newBuilder().tagIsNot(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT).build(),
+                                        source()));
 
         Assert.assertFalse(//
-        SourceSectionFilter.newBuilder().tagIsNot(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT).build().//
-        isInstrumented(source(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT)));
+                        isInstrumented(SourceSectionFilter.newBuilder().tagIsNot(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT).build(),
+                                        source(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT)));
 
         Assert.assertFalse(//
-        SourceSectionFilter.newBuilder().tagIsNot(InstrumentationTestLanguage.STATEMENT).build().//
-        isInstrumented(source(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT)));
+                        isInstrumented(SourceSectionFilter.newBuilder().tagIsNot(InstrumentationTestLanguage.STATEMENT).build(),
+                                        source(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT)));
 
         Assert.assertNotNull(SourceSectionFilter.newBuilder().tagIsNot(InstrumentationTestLanguage.STATEMENT, InstrumentationTestLanguage.EXPRESSION).build().toString());
     }
@@ -390,22 +414,22 @@ public class SourceSectionFilterTest {
         sourceIs(sampleSource1).sourceSectionEquals(sampleSource1.createSection(null, 0, 5)).//
         lineIn(1, 1).lineIs(1).mimeTypeIs("mime1", "mime2").build();
 
-        Assert.assertFalse(filter.isInstrumented(source()));
-        Assert.assertFalse(filter.isInstrumentedRoot(null));
-        Assert.assertFalse(filter.isInstrumentedNode(source()));
+        Assert.assertFalse(isInstrumented(filter, source()));
+        Assert.assertFalse(isInstrumentedRoot(filter, null));
+        Assert.assertFalse(isInstrumentedNode(filter, source()));
 
-        Assert.assertFalse(filter.isInstrumented(SourceSection.createUnavailable(null, null)));
-        Assert.assertFalse(filter.isInstrumentedRoot(SourceSection.createUnavailable(null, null)));
-        Assert.assertFalse(filter.isInstrumentedNode(SourceSection.createUnavailable(null, null)));
+        Assert.assertFalse(isInstrumented(filter, SourceSection.createUnavailable(null, null)));
+        Assert.assertFalse(isInstrumentedRoot(filter, SourceSection.createUnavailable(null, null)));
+        Assert.assertFalse(isInstrumentedNode(filter, SourceSection.createUnavailable(null, null)));
 
-        Assert.assertTrue(filter.isInstrumented(sampleSource1.createSection(null, 0, 5, tags(InstrumentationTestLanguage.EXPRESSION))));
-        Assert.assertTrue(filter.isInstrumentedRoot(sampleSource1.createSection(null, 0, 5)));
-        Assert.assertTrue(filter.isInstrumentedNode(sampleSource1.createSection(null, 0, 5, tags(InstrumentationTestLanguage.EXPRESSION))));
+        Assert.assertTrue(isInstrumented(filter, sampleSource1.createSection(null, 0, 5, tags(InstrumentationTestLanguage.EXPRESSION))));
+        Assert.assertTrue(isInstrumentedRoot(filter, sampleSource1.createSection(null, 0, 5)));
+        Assert.assertTrue(isInstrumentedNode(filter, sampleSource1.createSection(null, 0, 5, tags(InstrumentationTestLanguage.EXPRESSION))));
 
-        Assert.assertFalse(filter.isInstrumented(sampleSource1.createSection(null, 0, 5, tags(InstrumentationTestLanguage.STATEMENT))));
-        Assert.assertTrue(filter.isInstrumentedRoot(sampleSource1.createSection(null, 0, 5)));
-        Assert.assertFalse(filter.isInstrumentedRoot(sampleSource1.createSection(null, 10, 5)));
-        Assert.assertFalse(filter.isInstrumentedNode(sampleSource1.createSection(null, 0, 5, tags(InstrumentationTestLanguage.STATEMENT))));
+        Assert.assertFalse(isInstrumented(filter, sampleSource1.createSection(null, 0, 5, tags(InstrumentationTestLanguage.STATEMENT))));
+        Assert.assertTrue(isInstrumentedRoot(filter, sampleSource1.createSection(null, 0, 5)));
+        Assert.assertFalse(isInstrumentedRoot(filter, sampleSource1.createSection(null, 10, 5)));
+        Assert.assertFalse(isInstrumentedNode(filter, sampleSource1.createSection(null, 0, 5, tags(InstrumentationTestLanguage.STATEMENT))));
 
         Assert.assertNotNull(filter.toString());
     }


### PR DESCRIPTION
Trying to solve this problem:
https://travis-ci.org/graalvm/graal-core/jobs/109844273

I could not solve it with:
@RunWith(SeparateClassloaderTestRunner.Theories.class)

Its the reason I cannot integrate:
https://github.com/graalvm/graal-core/pull/39