### PR TITLE
Update mx to 5.8.0 and fix checkstyle issues

### DIFF
--- a/mx.truffle/suite.py
+++ b/mx.truffle/suite.py
@@ -1,5 +1,5 @@
 suite = {
-  "mxversion" : "5.6.14",
+  "mxversion" : "5.8.0",
   "name" : "truffle",
   "url" : "http://openjdk.java.net/projects/graal",
   "developer" : {

--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/CodeFormatTest.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/CodeFormatTest.java
@@ -41,7 +41,7 @@ public class CodeFormatTest {
 
     abstract static class LineWrappingTest extends ValueNode {
 
-        public LineWrappingTest() {
+        LineWrappingTest() {
         }
 
         protected static boolean guardWithaReeeeeeeeaaaaaaaaaaalllllllllyyyyyyyyLLLLLLLLLLLLLoooooooonnnnnnngggggggName1() {

--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/ExecuteGroupingTest.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/ExecuteGroupingTest.java
@@ -51,7 +51,7 @@ public class ExecuteGroupingTest {
 
         private final Object returnValue;
 
-        public ExecuteGroupingChild(Object returnValue) {
+        ExecuteGroupingChild(Object returnValue) {
             this.returnValue = returnValue;
         }
 

--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/MergeSpecializationsTest.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/MergeSpecializationsTest.java
@@ -208,7 +208,7 @@ public class MergeSpecializationsTest {
         public final Object secondValue;
         public final Object thirdValue;
 
-        public Executions(Object firstValue, Object secondValue, Object thirdValue) {
+        Executions(Object firstValue, Object secondValue, Object thirdValue) {
             this.firstValue = firstValue;
             this.secondValue = secondValue;
             this.thirdValue = thirdValue;

--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/SourceSectionTest.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/SourceSectionTest.java
@@ -132,7 +132,7 @@ public class SourceSectionTest {
         // BEGIN: NodeWithFixedSourceSection
         private final SourceSection section;
 
-        public NodeWithFixedSourceSection(SourceSection section) {
+        NodeWithFixedSourceSection(SourceSection section) {
             this.section = section;
         }
 

--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/SpecializationFallthroughTest.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/SpecializationFallthroughTest.java
@@ -66,7 +66,7 @@ public class SpecializationFallthroughTest {
 
         static int fallthroughCount = 0;
 
-        public FallthroughTest0() {
+        FallthroughTest0() {
             fallthroughCount = 0;
         }
 
@@ -111,7 +111,7 @@ public class SpecializationFallthroughTest {
 
         static int fallthroughCount;
 
-        public FallthroughTest1() {
+        FallthroughTest1() {
             fallthroughCount = 0;
         }
 

--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/examples/ExampleNode.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/examples/ExampleNode.java
@@ -72,7 +72,7 @@ public abstract class ExampleNode extends Node {
 
         @Child ExampleNode child;
 
-        public ExampleRootNode(ExampleNode child) {
+        ExampleRootNode(ExampleNode child) {
             super(TestingLanguage.class, null, null);
             this.child = child;
         }
@@ -88,7 +88,7 @@ public abstract class ExampleNode extends Node {
 
         private final int index;
 
-        public ExampleArgumentNode(int index) {
+        ExampleArgumentNode(int index) {
             this.index = index;
         }
 
@@ -110,7 +110,7 @@ public abstract class ExampleNode extends Node {
 
         private final int argumentIndex;
 
-        public DummyCallRootNode(int argumentIndex) {
+        DummyCallRootNode(int argumentIndex) {
             super(TestingLanguage.class, null, null);
             this.argumentIndex = argumentIndex;
         }

--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/processor/Compile.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/processor/Compile.java
@@ -140,7 +140,7 @@ final class Compile implements DiagnosticListener<JavaFileObject> {
 
                 private final String n;
 
-                public VirtFO(URI uri, Kind kind, String n) {
+                VirtFO(URI uri, Kind kind, String n) {
                     super(uri, kind);
                     this.n = n;
                 }

--- a/truffle/com.oracle.truffle.api.instrumentation.test/src/com/oracle/truffle/api/instrumentation/examples/DebuggerExample.java
+++ b/truffle/com.oracle.truffle.api.instrumentation.test/src/com/oracle/truffle/api/instrumentation/examples/DebuggerExample.java
@@ -62,7 +62,7 @@ public final class DebuggerExample extends TruffleInstrument {
         private EventBinding<?> stepping;
         private Callback currentStatementCallback;
 
-        public Controller(Instrumenter instrumenter) {
+        Controller(Instrumenter instrumenter) {
             this.instrumenter = instrumenter;
         }
 

--- a/truffle/com.oracle.truffle.api.interop.java.test/src/com/oracle/truffle/api/interop/java/test/JavaInteropTest.java
+++ b/truffle/com.oracle.truffle.api.interop.java.test/src/com/oracle/truffle/api/interop/java/test/JavaInteropTest.java
@@ -179,7 +179,7 @@ public class JavaInteropTest {
         private final Object[] args;
 
         @SuppressWarnings("rawtypes")
-        public TemporaryRoot(Class<? extends TruffleLanguage> lang, Node foreignAccess, TruffleObject function, Object... args) {
+        TemporaryRoot(Class<? extends TruffleLanguage> lang, Node foreignAccess, TruffleObject function, Object... args) {
             super(lang, null, null);
             this.foreignAccess = foreignAccess;
             this.function = function;

--- a/truffle/com.oracle.truffle.api.interop/src/com/oracle/truffle/api/interop/ForeignAccess.java
+++ b/truffle/com.oracle.truffle.api.interop/src/com/oracle/truffle/api/interop/ForeignAccess.java
@@ -603,7 +603,7 @@ public final class ForeignAccess {
         private final Class<?> baseClass;
         private final Factory10 factory;
 
-        public DelegatingFactory(Class<?> baseClass, Factory10 factory) {
+        DelegatingFactory(Class<?> baseClass, Factory10 factory) {
             this.baseClass = baseClass;
             this.factory = factory;
         }

--- a/truffle/com.oracle.truffle.api.interop/src/com/oracle/truffle/api/interop/GenericObjectAccessNode.java
+++ b/truffle/com.oracle.truffle.api.interop/src/com/oracle/truffle/api/interop/GenericObjectAccessNode.java
@@ -37,12 +37,12 @@ final class GenericObjectAccessNode extends ObjectAccessNode {
 
     @Child private ForeignAccessArguments accessArguments = new ForeignAccessArguments();
 
-    public GenericObjectAccessNode(Message access) {
+    GenericObjectAccessNode(Message access) {
         this.access = access;
         indirectCallNode = Truffle.getRuntime().createIndirectCallNode();
     }
 
-    public GenericObjectAccessNode(GenericObjectAccessNode prev) {
+    GenericObjectAccessNode(GenericObjectAccessNode prev) {
         this(prev.access);
     }
 

--- a/truffle/com.oracle.truffle.api.interop/src/com/oracle/truffle/api/interop/impl/ReadOnlyArrayList.java
+++ b/truffle/com.oracle.truffle.api.interop/src/com/oracle/truffle/api/interop/impl/ReadOnlyArrayList.java
@@ -236,7 +236,7 @@ public final class ReadOnlyArrayList<T> implements List<T> {
     private final class LI implements ListIterator<T>, Iterator<T> {
         private int index;
 
-        public LI(int index) {
+        LI(int index) {
             this.index = index;
         }
 

--- a/truffle/com.oracle.truffle.object.basic/src/com/oracle/truffle/object/basic/BasicAllocator.java
+++ b/truffle/com.oracle.truffle.object.basic/src/com/oracle/truffle/object/basic/BasicAllocator.java
@@ -47,12 +47,12 @@ import com.oracle.truffle.object.basic.BasicLocations.ObjectArrayLocation;
 
 abstract class BasicAllocator extends ShapeImpl.BaseAllocator {
 
-    public BasicAllocator(LayoutImpl layout) {
+    BasicAllocator(LayoutImpl layout) {
         super(layout);
         advance(((BasicLayout) layout).getPrimitiveArrayLocation());
     }
 
-    public BasicAllocator(ShapeImpl shape) {
+    BasicAllocator(ShapeImpl shape) {
         super(shape);
     }
 

--- a/truffle/com.oracle.truffle.tck/src/com/oracle/truffle/tck/ComplexNumberAEntry.java
+++ b/truffle/com.oracle.truffle.tck/src/com/oracle/truffle/tck/ComplexNumberAEntry.java
@@ -32,7 +32,7 @@ final class ComplexNumberAEntry implements TruffleObject {
     private final ComplexNumbersA numbers;
     private final int index;
 
-    public ComplexNumberAEntry(ComplexNumbersA numbers, int index) {
+    ComplexNumberAEntry(ComplexNumbersA numbers, int index) {
         this.numbers = numbers;
         this.index = index;
     }

--- a/truffle/com.oracle.truffle.tck/src/com/oracle/truffle/tck/ComplexNumberBEntry.java
+++ b/truffle/com.oracle.truffle.tck/src/com/oracle/truffle/tck/ComplexNumberBEntry.java
@@ -32,7 +32,7 @@ class ComplexNumberBEntry implements TruffleObject {
     private final ComplexNumbersB numbers;
     private final int index;
 
-    public ComplexNumberBEntry(ComplexNumbersB numbers, int index) {
+    ComplexNumberBEntry(ComplexNumbersB numbers, int index) {
         this.numbers = numbers;
         this.index = index;
     }

--- a/truffle/com.oracle.truffle.tck/src/com/oracle/truffle/tck/ConstantFunction.java
+++ b/truffle/com.oracle.truffle.tck/src/com/oracle/truffle/tck/ConstantFunction.java
@@ -29,7 +29,7 @@ import com.oracle.truffle.tck.impl.ObjectBinaryOperation;
 final class ConstantFunction implements ObjectBinaryOperation {
     private final Object constant;
 
-    public ConstantFunction(Object constant) {
+    ConstantFunction(Object constant) {
         this.constant = constant;
     }
 

--- a/truffle/com.oracle.truffle.tck/src/com/oracle/truffle/tck/EagerStackTraceDecorator.java
+++ b/truffle/com.oracle.truffle.tck/src/com/oracle/truffle/tck/EagerStackTraceDecorator.java
@@ -28,7 +28,7 @@ import org.junit.runner.notification.Failure;
 
 class EagerStackTraceDecorator extends TruffleJUnitRunListenerDecorator {
 
-    public EagerStackTraceDecorator(TruffleJUnitRunListener l) {
+    EagerStackTraceDecorator(TruffleJUnitRunListener l) {
         super(l);
     }
 

--- a/truffle/com.oracle.truffle.tck/src/com/oracle/truffle/tck/GCAfterTestDecorator.java
+++ b/truffle/com.oracle.truffle.tck/src/com/oracle/truffle/tck/GCAfterTestDecorator.java
@@ -28,7 +28,7 @@ import org.junit.runner.Description;
 
 final class GCAfterTestDecorator extends TruffleJUnitRunListenerDecorator {
 
-    public GCAfterTestDecorator(TruffleJUnitRunListener l) {
+    GCAfterTestDecorator(TruffleJUnitRunListener l) {
         super(l);
     }
 

--- a/truffle/com.oracle.truffle.tck/src/com/oracle/truffle/tck/MaxMinObject.java
+++ b/truffle/com.oracle.truffle.tck/src/com/oracle/truffle/tck/MaxMinObject.java
@@ -29,7 +29,7 @@ import com.oracle.truffle.tck.impl.LongBinaryOperation;
 final class MaxMinObject implements LongBinaryOperation {
     private final boolean max;
 
-    public MaxMinObject(boolean max) {
+    MaxMinObject(boolean max) {
         this.max = max;
     }
 

--- a/truffle/com.oracle.truffle.tck/src/com/oracle/truffle/tck/Schema.java
+++ b/truffle/com.oracle.truffle.tck/src/com/oracle/truffle/tck/Schema.java
@@ -35,7 +35,7 @@ final class Schema {
 
         private final int size;
 
-        private Type(int size) {
+        Type(int size) {
             this.size = size;
         }
     }

--- a/truffle/com.oracle.truffle.tck/src/com/oracle/truffle/tck/TimingDecorator.java
+++ b/truffle/com.oracle.truffle.tck/src/com/oracle/truffle/tck/TimingDecorator.java
@@ -34,7 +34,7 @@ class TimingDecorator extends TruffleJUnitRunListenerDecorator {
     private long startTime;
     private long classStartTime;
 
-    public TimingDecorator(TruffleJUnitRunListener l) {
+    TimingDecorator(TruffleJUnitRunListener l) {
         super(l);
     }
 

--- a/truffle/com.oracle.truffle.tck/src/com/oracle/truffle/tck/TruffleJUnitRunListenerDecorator.java
+++ b/truffle/com.oracle.truffle.tck/src/com/oracle/truffle/tck/TruffleJUnitRunListenerDecorator.java
@@ -33,7 +33,7 @@ class TruffleJUnitRunListenerDecorator implements TruffleJUnitRunListener {
 
     private final TruffleJUnitRunListener l;
 
-    public TruffleJUnitRunListenerDecorator(TruffleJUnitRunListener l) {
+    TruffleJUnitRunListenerDecorator(TruffleJUnitRunListener l) {
         this.l = l;
     }
 

--- a/truffle/com.oracle.truffle.tck/src/com/oracle/truffle/tck/TruffleTextListener.java
+++ b/truffle/com.oracle.truffle.tck/src/com/oracle/truffle/tck/TruffleTextListener.java
@@ -37,11 +37,11 @@ class TruffleTextListener implements TruffleJUnitRunListener {
     private final PrintStream fWriter;
     protected Failure lastFailure;
 
-    public TruffleTextListener(JUnitSystem system) {
+    TruffleTextListener(JUnitSystem system) {
         this(system.out());
     }
 
-    public TruffleTextListener(PrintStream writer) {
+    TruffleTextListener(PrintStream writer) {
         fWriter = writer;
     }
 
@@ -120,7 +120,7 @@ class TruffleTextListener implements TruffleJUnitRunListener {
             private boolean failed;
 
             @Override
-            public final void testStarted(Description description) {
+            public void testStarted(Description description) {
                 Class<?> currentClass = description.getTestClass();
                 if (currentClass != lastClass) {
                     if (lastClass != null) {
@@ -137,13 +137,13 @@ class TruffleTextListener implements TruffleJUnitRunListener {
             }
 
             @Override
-            public final void testFailure(Failure failure) {
+            public void testFailure(Failure failure) {
                 failed = true;
                 l.testFailed(failure);
             }
 
             @Override
-            public final void testFinished(Description description) {
+            public void testFinished(Description description) {
                 // we have to do this because there is no callback for successful tests
                 if (!failed) {
                     l.testSucceeded(description);

--- a/truffle/com.oracle.truffle.tck/src/com/oracle/truffle/tck/TruffleVerboseTextListener.java
+++ b/truffle/com.oracle.truffle.tck/src/com/oracle/truffle/tck/TruffleVerboseTextListener.java
@@ -31,11 +31,11 @@ import org.junit.runner.notification.Failure;
 
 class TruffleVerboseTextListener extends TruffleTextListener {
 
-    public TruffleVerboseTextListener(JUnitSystem system) {
+    TruffleVerboseTextListener(JUnitSystem system) {
         this(system.out());
     }
 
-    public TruffleVerboseTextListener(PrintStream writer) {
+    TruffleVerboseTextListener(PrintStream writer) {
         super(writer);
     }
 

--- a/truffle/com.oracle.truffle.tck/src/com/oracle/truffle/tck/impl/TckLanguage.java
+++ b/truffle/com.oracle.truffle.tck/src/com/oracle/truffle/tck/impl/TckLanguage.java
@@ -106,7 +106,7 @@ public final class TckLanguage extends TruffleLanguage<Env> {
     private static final class MultiplyNode extends RootNode implements TruffleObject, ForeignAccess.Factory {
         private final Source code;
 
-        public MultiplyNode(Source toParse) {
+        MultiplyNode(Source toParse) {
             super(TckLanguage.class, null, null);
             this.code = toParse;
         }

--- a/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/client/REPLCommand.java
+++ b/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/client/REPLCommand.java
@@ -31,7 +31,7 @@ abstract class REPLCommand {
     private final String abbreviation;
     private final String description;
 
-    public REPLCommand(String command, String abbreviation, String description) {
+    REPLCommand(String command, String abbreviation, String description) {
         this.command = command;
         this.abbreviation = abbreviation;
         this.description = description;

--- a/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/client/SimpleREPLClient.java
+++ b/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/client/SimpleREPLClient.java
@@ -260,7 +260,7 @@ public class SimpleREPLClient implements REPLClient {
         /**
          * Create a new context on the occasion of an execution halting.
          */
-        public ClientContextImpl(ClientContextImpl predecessor, REPLMessage message) {
+        ClientContextImpl(ClientContextImpl predecessor, REPLMessage message) {
             this.predecessor = predecessor;
             this.level = predecessor == null ? 0 : predecessor.level + 1;
 
@@ -696,7 +696,7 @@ public class SimpleREPLClient implements REPLClient {
      */
     private abstract class REPLLocalCommand extends REPLCommand {
 
-        public REPLLocalCommand(String command, String abbreviation, String description) {
+        REPLLocalCommand(String command, String abbreviation, String description) {
             super(command, abbreviation, description);
         }
 
@@ -708,7 +708,7 @@ public class SimpleREPLClient implements REPLClient {
      */
     private abstract class REPLIndirectCommand extends REPLCommand {
 
-        public REPLIndirectCommand(String command, String abbreviation, String description) {
+        REPLIndirectCommand(String command, String abbreviation, String description) {
             super(command, abbreviation, description);
         }
 
@@ -1350,7 +1350,7 @@ public class SimpleREPLClient implements REPLClient {
 
         private Boolean value;
 
-        public BooleanOption(boolean value, String name, String description) {
+        BooleanOption(boolean value, String name, String description) {
             super(name, description);
             this.value = value;
         }
@@ -1380,7 +1380,7 @@ public class SimpleREPLClient implements REPLClient {
 
         private Integer value;
 
-        public IntegerOption(int value, String name, String description) {
+        IntegerOption(int value, String name, String description) {
             super(name, description);
             this.value = value;
         }

--- a/truffle/com.oracle.truffle.tools.test/src/com/oracle/truffle/tools/test/ToolTestUtil.java
+++ b/truffle/com.oracle.truffle.tools.test/src/com/oracle/truffle/tools/test/ToolTestUtil.java
@@ -51,7 +51,7 @@ public class ToolTestUtil {
 
     static final String MIME_TYPE = "text/x-toolTest";
 
-    static enum ToolTestTag implements SyntaxTag {
+    enum ToolTestTag implements SyntaxTag {
 
         ADD_TAG("addition", "test language addition node"),
 
@@ -60,7 +60,7 @@ public class ToolTestUtil {
         private final String name;
         private final String description;
 
-        private ToolTestTag(String name, String description) {
+        ToolTestTag(String name, String description) {
             this.name = name;
             this.description = description;
         }
@@ -186,7 +186,7 @@ public class ToolTestUtil {
         @Child private ToolTestLangNode child;
         @Child private EventHandlerNode eventHandlerNode;
 
-        public ToolTestWrapperNode(ToolTestLangNode child) {
+        ToolTestWrapperNode(ToolTestLangNode child) {
             super(null);
             assert !(child instanceof ToolTestWrapperNode);
             this.child = child;
@@ -232,7 +232,7 @@ public class ToolTestUtil {
     static class TestValueNode extends ToolTestLangNode {
         private final int value;
 
-        public TestValueNode(int value, SourceSection s) {
+        TestValueNode(int value, SourceSection s) {
             super(s);
             this.value = value;
         }
@@ -250,7 +250,7 @@ public class ToolTestUtil {
         @Child private ToolTestLangNode leftChild;
         @Child private ToolTestLangNode rightChild;
 
-        public TestAdditionNode(TestValueNode leftChild, TestValueNode rightChild, SourceSection s) {
+        TestAdditionNode(TestValueNode leftChild, TestValueNode rightChild, SourceSection s) {
             super(s);
             this.leftChild = insert(leftChild);
             this.rightChild = insert(rightChild);
@@ -275,7 +275,7 @@ public class ToolTestUtil {
          * newly created AST. Global registry is not used, since that would interfere with other
          * tests run in the same environment.
          */
-        public InstrumentationTestRootNode(ToolTestLangNode body) {
+        InstrumentationTestRootNode(ToolTestLangNode body) {
             super(ToolTestLang.class, null, null);
             this.body = body;
         }
@@ -307,7 +307,7 @@ public class ToolTestUtil {
          * newly created AST. Global registry is not used, since that would interfere with other
          * tests run in the same environment.
          */
-        public TestRootNode(ToolTestLangNode body, Instrumenter instrumenter) {
+        TestRootNode(ToolTestLangNode body, Instrumenter instrumenter) {
             super(ToolTestLang.class, null, null);
             this.instrumenter = instrumenter;
             this.body = body;

--- a/truffle/com.oracle.truffle.tools/src/com/oracle/truffle/tools/NodeExecCounter.java
+++ b/truffle/com.oracle.truffle.tools/src/com/oracle/truffle/tools/NodeExecCounter.java
@@ -121,7 +121,7 @@ public final class NodeExecCounter extends Instrumenter.Tool {
                 /*
                  * Everything up to here is inlined by Truffle compilation. Delegate the next part
                  * to a method behind an inlining boundary.
-                 *
+                 * 
                  * Note that it is not permitted to pass a {@link VirtualFrame} across an inlining
                  * boundary; they are truly virtual in inlined code.
                  */
@@ -334,7 +334,7 @@ public final class NodeExecCounter extends Instrumenter.Tool {
         private final Class<?> nodeClass;
         private final long count;
 
-        public NodeExecCountImpl(Class<?> nodeClass, long count) {
+        NodeExecCountImpl(Class<?> nodeClass, long count) {
             this.nodeClass = nodeClass;
             this.count = count;
         }


### PR DESCRIPTION
This fixes the superfluous keyword issues reported by the latest checkstyle version and updates mx to make sure these rules are enforced in the future.