### PR TITLE
Add loop node documentation. Make loop nodes a non-experimental feature.

### DIFF
--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleRuntime.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleRuntime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 package com.oracle.truffle.api;
 
+import java.util.Collection;
+
 import com.oracle.truffle.api.frame.Frame;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.FrameInstance;
@@ -35,7 +37,6 @@ import com.oracle.truffle.api.nodes.IndirectCallNode;
 import com.oracle.truffle.api.nodes.LoopNode;
 import com.oracle.truffle.api.nodes.RepeatingNode;
 import com.oracle.truffle.api.nodes.RootNode;
-import java.util.Collection;
 
 /**
  * Interface representing a Truffle runtime object. The runtime is responsible for creating call
@@ -69,7 +70,11 @@ public interface TruffleRuntime {
     DirectCallNode createDirectCallNode(CallTarget target);
 
     /**
-     * Experimental API. May change without notice.
+     * Creates a new loop node with an implementation provided by a Truffle runtime implementation.
+     * Using Truffle loop nodes allows the runtime to do additional optimizations such as on stack
+     * replacement for loops.
+     *
+     * @see LoopNode usage example
      */
     LoopNode createLoopNode(RepeatingNode body);
 

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/LoopNode.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/LoopNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,15 +24,103 @@
  */
 package com.oracle.truffle.api.nodes;
 
+import com.oracle.truffle.api.TruffleRuntime;
 import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.Node.Child;
 
 /**
- * Experimental API: may change significantly without notice.
+ * <p>
+ * A loop node calls {@link RepeatingNode#executeRepeating(VirtualFrame) repeating nodes} as long as
+ * it returns <code>true</code>. Using the loop node in a guest language implementation allows the
+ * Truffle runtime to optimize loops in a better way. For example a Truffle runtime implementation
+ * might decide to optimize loop already during its first execution (also called on stack
+ * replacement OSR). Loop nodes are not intended to be implemented by Truffle runtime
+ * implementations and not by guest language implementations.
+ * </p>
+ * <p>
+ * Full usage example for guest language while node:
+ * </p>
+ *
+ * <pre>
+ * <code>
+ * public class WhileNode extends GuestLanguageNode {
+ *
+ *     &#064;{@link Child} private {@link LoopNode} loop;
+ *
+ *     public WhileNode(GuestLanguageNode conditionNode, GuestLanguageNode bodyNode) {
+ *         loop = Truffle.getRuntime().createLoopNode(new WhileRepeatingNode(conditionNode, bodyNode));
+ *     }
+ *
+ *     &#064;Override
+ *     public Object execute({@link VirtualFrame} frame) {
+ *         loop.executeLoop(frame);
+ *         return null;
+ *     }
+ *
+ *     private static class WhileRepeatingNode extends {@link Node} implements {@link RepeatingNode} {
+ *
+ *         &#064;{@link Child} private GuestLanguageNode conditionNode;
+ *         &#064;{@link Child} private GuestLanguageNode bodyNode;
+ *
+ *         public WhileRepeatingNode(GuestLanguageNode conditionNode, GuestLanguageNode bodyNode) {
+ *             this.conditionNode = conditionNode;
+ *             this.bodyNode = bodyNode;
+ *         }
+ *
+ *         public boolean executeRepeating({@link VirtualFrame} frame) {
+ *             if ((boolean) conditionNode.execute(frame)) {
+ *                 try {
+ *                     bodyNode.execute(frame);
+ *                 } catch (ContinueException ex) {
+ *                     // the body might throw a continue control-flow exception
+ *                     // continue loop invocation
+ *                 } catch (BreakException ex) {
+ *                     // the body might throw a break control-flow exception
+ *                     // break loop invocation by returning false
+ *                     return false;
+ *                 }
+ *                 return true;
+ *             } else {
+ *                 return false;
+ *             }
+ *         }
+ *     }
+ *
+ * }
+ *
+ * // substitute with a guest language node type
+ * public abstract class GuestLanguageNode extends {@link Node} {
+ *
+ *     public abstract Object execute({@link VirtualFrame} frame);
+ *
+ * }
+ * // thrown by guest language continue statements
+ * public final class ContinueException extends {@link ControlFlowException} {}
+ * // thrown by guest language break statements
+ * public final class BreakException extends {@link ControlFlowException} {}
+ * </code>
+ * </pre>
+ *
+ *
+ * @see RepeatingNode
+ * @see TruffleRuntime#createLoopNode(RepeatingNode)
  */
 public abstract class LoopNode extends Node {
 
+    /**
+     * Invokes one loop invocation by repeatedly call
+     * {@link RepeatingNode#executeRepeating(VirtualFrame) execute)} on the repeating node the loop
+     * was initialized with. Any exceptions that occur in the execution of the repeating node will
+     * just be forwarded to this method and will cancel the current loop invocation.
+     *
+     * @param frame the current execution frame or null if the repeating node does not require a
+     *            frame
+     */
     public abstract void executeLoop(VirtualFrame frame);
 
+    /**
+     * Returns the repeating node the loop node was created with.
+     */
     public abstract RepeatingNode getRepeatingNode();
 
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/RepeatingNode.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/RepeatingNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,13 +24,29 @@
  */
 package com.oracle.truffle.api.nodes;
 
+import com.oracle.truffle.api.TruffleRuntime;
 import com.oracle.truffle.api.frame.VirtualFrame;
 
 /**
- * Experimental API: may change significantly without notice.
+ * A node that is repeatedly invoked as part of a Truffle loop control structure. Repeating nodes
+ * must extend {@link Node} or a subclass of {@link Node}.
+ *
+ * Repeating nodes are intended to be implemented by guest language implementations. For a full
+ * usage example please see {@link LoopNode}.
+ *
+ * @see LoopNode
+ * @see TruffleRuntime#createLoopNode(RepeatingNode)
  */
 public interface RepeatingNode extends NodeInterface {
 
+    /**
+     * Repeatedly invoked by a {@link LoopNode loop node} implementation until the method returns
+     * <code>false</code> or throws an exception.
+     *
+     * @param frame the current execution frame passed through the interpreter
+     * @return <code>true</code> if the method should be executed again to complete the loop and
+     *         <code>false</code> if it must not.
+     */
     boolean executeRepeating(VirtualFrame frame);
 
 }


### PR DESCRIPTION
Long overdue documentation for loop nodes. They were also still marked as experimental, but they are used by most Truffle languages now.