### PR TITLE
Check API signatures against most recent API snapshot

### DIFF
--- a/.travis.sigtest.sh
+++ b/.travis.sigtest.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+wget http://hudson.apidesign.org/job/sigtest-truffle/lastSuccessfulBuild/artifact/truffle-signature.tgz
+tar fxvz truffle-signature.tgz
+mx/mx build
+mx/mx sigtest --check all || echo There are changes!

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
   - TEST_COMMAND='mx/mx checkoverlap'
   - TEST_COMMAND='mx/mx canonicalizeprojects'
   - TEST_COMMAND='mx/mx checkstyle'
+  - TEST_COMMAND='sh .travis.sigtest.sh'
   
 
 


### PR DESCRIPTION
I'd like the travis to download the most recent API snapshot and compare the signatures in the pull request with it. This way we can find out whether there are (signature) API changes in the PR or not.