### PR TITLE
Make loop counts reportable on Nodes instead of RootNodes; 

### DIFF
--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/LoopNodeTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/LoopNodeTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.truffle.api;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.nodes.ControlFlowException;
+import com.oracle.truffle.api.nodes.LoopNode;
+import com.oracle.truffle.api.nodes.Node;
+import com.oracle.truffle.api.nodes.RepeatingNode;
+import com.oracle.truffle.api.nodes.RootNode;
+import com.oracle.truffle.api.vm.InitializationTest.TestLanguage;
+
+public class LoopNodeTest {
+
+    @Test
+    public void testHundredInvocations() {
+        IterateNode iterate = new IterateNode(100);
+        BodyNode bodyNode = new BodyNode();
+        TestWhileNode whileNode = new TestWhileNode(iterate, bodyNode);
+        whileNode.execute(null);
+
+        Assert.assertEquals(100, bodyNode.invocations);
+        Assert.assertEquals(101, iterate.invocations);
+    }
+
+    @Test
+    public void testNoInvocations() {
+        IterateNode iterate = new IterateNode(0);
+        BodyNode bodyNode = new BodyNode();
+        TestWhileNode whileNode = new TestWhileNode(iterate, bodyNode);
+        whileNode.execute(null);
+
+        Assert.assertEquals(0, bodyNode.invocations);
+        Assert.assertEquals(1, iterate.invocations);
+    }
+
+    @Test
+    public void testBreak() {
+        IterateNode iterate = new IterateNode(5);
+        BodyNode bodyNode = new BodyNode() {
+
+            @Override
+            public Object execute(VirtualFrame frame) {
+                super.execute(frame);
+                throw new BreakException();
+            }
+
+        };
+        TestWhileNode whileNode = new TestWhileNode(iterate, bodyNode);
+        whileNode.execute(null);
+
+        Assert.assertEquals(1, whileNode.breaks);
+        Assert.assertEquals(1, bodyNode.invocations);
+        Assert.assertEquals(1, iterate.invocations);
+    }
+
+    @Test
+    public void testContinue() {
+        IterateNode iterate = new IterateNode(3);
+        BodyNode bodyNode = new BodyNode() {
+
+            @Override
+            public Object execute(VirtualFrame frame) {
+                super.execute(frame);
+                throw new ContinueException();
+            }
+
+        };
+        TestWhileNode whileNode = new TestWhileNode(iterate, bodyNode);
+        whileNode.execute(null);
+
+        Assert.assertEquals(3, whileNode.continues);
+        Assert.assertEquals(3, bodyNode.invocations);
+        Assert.assertEquals(4, iterate.invocations);
+    }
+
+    @Test
+    public void testLoopCountReportingWithNode() {
+        GuestLanguageNode node = new GuestLanguageNode() {
+            @Override
+            public Object execute(VirtualFrame frame) {
+                int[] data = new int[]{1, 2, 3, 4, 5};
+                try {
+                    int sum = 0;
+                    for (int i = 0; i < data.length; i++) {
+                        sum += data[i];
+                    }
+                    return sum;
+                } finally {
+                    LoopNode.reportLoopCount(this, data.length);
+                }
+            }
+        };
+        for (int i = 0; i < 1000; i++) {
+            Assert.assertEquals(15, node.execute(null));
+        }
+    }
+
+    @Test
+    public void testLoopCountReportingInCallTarget() {
+        final GuestLanguageNode node = new GuestLanguageNode() {
+            @Override
+            public Object execute(VirtualFrame frame) {
+                int[] data = new int[]{1, 2, 3, 4, 5};
+                try {
+                    int sum = 0;
+                    for (int i = 0; i < data.length; i++) {
+                        sum += data[i];
+                    }
+                    return sum;
+                } finally {
+                    LoopNode.reportLoopCount(this, data.length);
+                }
+            }
+        };
+        RootNode root = new RootNode(TestLanguage.INSTANCE.getClass(), null, null) {
+            @Override
+            public Object execute(VirtualFrame frame) {
+                return node.execute(frame);
+            }
+        };
+
+        CallTarget target = Truffle.getRuntime().createCallTarget(root);
+        for (int i = 0; i < 1000; i++) {
+            Assert.assertEquals(15, target.call());
+        }
+    }
+
+    private static class BodyNode extends GuestLanguageNode {
+
+        int invocations;
+
+        @Override
+        public Object execute(VirtualFrame frame) {
+            invocations++;
+            return null;
+        }
+    }
+
+    private static class IterateNode extends GuestLanguageNode {
+
+        int invocations;
+        int iterations;
+
+        IterateNode(int iterations) {
+            this.iterations = iterations;
+        }
+
+        @Override
+        public Object execute(VirtualFrame frame) {
+            invocations++;
+            if (iterations == 0) {
+                return false;
+            } else {
+                iterations--;
+                return true;
+            }
+        }
+
+    }
+
+    private static class TestWhileNode extends GuestLanguageNode {
+
+        @Child private LoopNode loop;
+
+        int breaks;
+        int continues;
+
+        TestWhileNode(GuestLanguageNode conditionNode, GuestLanguageNode bodyNode) {
+            loop = Truffle.getRuntime().createLoopNode(new WhileRepeatingNode(conditionNode, bodyNode));
+        }
+
+        @Override
+        public Object execute(VirtualFrame frame) {
+            loop.executeLoop(frame);
+            return null;
+        }
+
+        private class WhileRepeatingNode extends Node implements RepeatingNode {
+
+            @Child private GuestLanguageNode conditionNode;
+            @Child private GuestLanguageNode bodyNode;
+
+            WhileRepeatingNode(GuestLanguageNode conditionNode, GuestLanguageNode bodyNode) {
+                this.conditionNode = conditionNode;
+                this.bodyNode = bodyNode;
+            }
+
+            public boolean executeRepeating(VirtualFrame frame) {
+                if ((boolean) conditionNode.execute(frame)) {
+                    try {
+                        bodyNode.execute(frame);
+                    } catch (ContinueException ex) {
+                        continues++;
+                        // the body might throw a continue control-flow exception
+                        // continue loop invocation
+                    } catch (BreakException ex) {
+                        breaks++;
+                        // the body might throw a break control-flow exception
+                        // break loop invocation by returning false
+                        return false;
+                    }
+                    return true;
+                } else {
+                    return false;
+                }
+            }
+        }
+
+    }
+
+    // substitute with a guest language node type
+    private abstract static class GuestLanguageNode extends Node {
+
+        public abstract Object execute(VirtualFrame frame);
+
+    }
+
+    // thrown by guest language continue statements
+    @SuppressWarnings("serial")
+    private static final class ContinueException extends ControlFlowException {
+    }
+
+    // thrown by guest language break statements
+    @SuppressWarnings("serial")
+    private static final class BreakException extends ControlFlowException {
+    }
+
+}

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/LoopCountReceiver.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/LoopCountReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,11 +25,10 @@
 package com.oracle.truffle.api;
 
 /**
- * Accepts the execution count of a loop that is a child of this node. The optimization heuristics
- * can use the loop count to guide compilation and inlining.
- * 
  * @since 0.8 or earlier
+ * @deprecated no replacement.
  */
+@Deprecated
 public interface LoopCountReceiver {
     /** @since 0.8 or earlier */
     void reportLoopCount(int count);

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/LoopNode.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/LoopNode.java
@@ -24,9 +24,9 @@
  */
 package com.oracle.truffle.api.nodes;
 
+import com.oracle.truffle.api.CompilerDirectives;
 import com.oracle.truffle.api.TruffleRuntime;
 import com.oracle.truffle.api.frame.VirtualFrame;
-import com.oracle.truffle.api.nodes.Node.Child;
 
 /**
  * <p>
@@ -45,7 +45,7 @@ import com.oracle.truffle.api.nodes.Node.Child;
  * <code>
  * public class WhileNode extends GuestLanguageNode {
  * 
- *     &#064;{@link Child} private {@link LoopNode} loop;
+ *     &#064;{@link Node.Child} private {@link LoopNode} loop;
  * 
  *     public WhileNode(GuestLanguageNode conditionNode, GuestLanguageNode bodyNode) {
  *         loop = Truffle.getRuntime().createLoopNode(new WhileRepeatingNode(conditionNode, bodyNode));
@@ -59,8 +59,8 @@ import com.oracle.truffle.api.nodes.Node.Child;
  * 
  *     private static class WhileRepeatingNode extends {@link Node} implements {@link RepeatingNode} {
  * 
- *         &#064;{@link Child} private GuestLanguageNode conditionNode;
- *         &#064;{@link Child} private GuestLanguageNode bodyNode;
+ *         &#064;{@link Node.Child} private GuestLanguageNode conditionNode;
+ *         &#064;{@link Node.Child} private GuestLanguageNode bodyNode;
  * 
  *         public WhileRepeatingNode(GuestLanguageNode conditionNode, GuestLanguageNode bodyNode) {
  *             this.conditionNode = conditionNode;
@@ -133,5 +133,42 @@ public abstract class LoopNode extends Node {
      * @since 0.8 or earlier
      */
     public abstract RepeatingNode getRepeatingNode();
+
+    /**
+     * <p>
+     * Reports the execution count of a loop for which a no {@link LoopNode} was used. The
+     * optimization heuristics can use the loop count from non Truffle loops to guide compilation
+     * and inlining better. Do not use {@link LoopNode} and {@link #reportLoopCount(Node, int)} at
+     * the same time for one loop.
+     * </p>
+     *
+     * <p>
+     * Example usage with a custom loop: <code>
+     * <pre>
+     * public int executeCustomLoopSum(int[] data) {
+     *     try {
+     *         int sum = 0;
+     *         for (int i = 0; i < data.length; i++) {
+     *             sum += data[i];
+     *         }
+     *         return sum;
+     *     } finally {
+     *         LoopNode.reportLoopCount(data.length);
+     *     }
+     * }
+     * 
+     * </pre>
+     * </code>
+     * </p>
+     *
+     * @param source the Node which invoked the loop.
+     * @param iterations the number iterations to report to the runtime system
+     * @since 0.12
+     */
+    public static void reportLoopCount(Node source, int iterations) {
+        if (CompilerDirectives.inInterpreter()) {
+            ACCESSOR.onLoopCount(source, iterations);
+        }
+    }
 
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/Node.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/Node.java
@@ -600,6 +600,12 @@ public abstract class Node implements NodeInterface, Cloneable {
         protected void probeAST(RootNode rootNode) {
             super.probeAST(rootNode);
         }
+
+        @Override
+        protected void onLoopCount(Node source, int iterations) {
+            super.onLoopCount(source, iterations);
+        }
+
     }
 
     // registers into Accessor.NODES

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/RootNode.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/RootNode.java
@@ -24,11 +24,9 @@
  */
 package com.oracle.truffle.api.nodes;
 
-import com.oracle.truffle.api.CompilerAsserts;
 import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 import com.oracle.truffle.api.CompilerOptions;
 import com.oracle.truffle.api.ExecutionContext;
-import com.oracle.truffle.api.LoopCountReceiver;
 import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.TruffleLanguage;
 import com.oracle.truffle.api.TruffleRuntime;
@@ -109,16 +107,12 @@ public abstract class RootNode extends Node {
     }
 
     /**
-     * Reports the execution count of a loop that is a child of this node. The optimization
-     * heuristics can use the loop count to guide compilation and inlining.
-     * 
      * @since 0.8 or earlier
+     * @deprecated use {@link LoopNode#reportLoopCount(Node,int)} instead
      */
-    public final void reportLoopCount(int count) {
-        CompilerAsserts.neverPartOfCompilation("do not call RootNode.reportLoopCount from compiled code");
-        if (getCallTarget() instanceof LoopCountReceiver) {
-            ((LoopCountReceiver) getCallTarget()).reportLoopCount(count);
-        }
+    @Deprecated
+    public final void reportLoopCount(int iterations) {
+        LoopNode.reportLoopCount(this, iterations);
     }
 
     /**
@@ -153,10 +147,11 @@ public abstract class RootNode extends Node {
      *
      * Used for instance to determine the language of a <code>RootNode<code>:
      * 
-     * <pre>
      * <code>
+     * <pre>
      * rootNode.getExecutionContext().getLanguageShortName();
-     * </code> </pre>
+     * </pre>
+     * </code>
      *
      * Returns <code>null</code> by default.
      * 


### PR DESCRIPTION
Two improvements:
* Deprecated LoopCountReceiver that was never intended to be visible to guest languages and use the accessor pattern to call into the runtime instead. Tried to implement it in a compatible way, please verify.
* Move reportLoopCount from RootNode to Node to make the context(Node) of the reported loop count visible  to the Truffle runtime implementation. This is important to do a better OSR decision in the Graal runtime. Should be a compatible change.