### PR TITLE
CallTarget initialization should not throw NPE when not using PolyglotEngine

### DIFF
--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/impl/AccessorTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/impl/AccessorTest.java
@@ -22,26 +22,41 @@
  */
 package com.oracle.truffle.api.impl;
 
+import static com.oracle.truffle.api.vm.ImplicitExplicitExportTest.L1;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.concurrent.Executors;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.oracle.truffle.api.CallTarget;
+import com.oracle.truffle.api.Truffle;
+import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.vm.ImplicitExplicitExportTest.ExportImportLanguage1;
-import static com.oracle.truffle.api.vm.ImplicitExplicitExportTest.L1;
 import com.oracle.truffle.api.vm.PolyglotEngine;
-import java.lang.reflect.Method;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 public class AccessorTest {
-    public static Method find;
+    private static Method find;
+    private static Field instrumenthandler;
 
+    /**
+     * Reflection access to package-private members.
+     *
+     * @see Accessor#findLanguageByClass(Object, Class)
+     * @see Accessor#INSTRUMENTHANDLER
+     */
     @BeforeClass
     public static void initAccessors() throws Exception {
         find = Accessor.class.getDeclaredMethod("findLanguageByClass", Object.class, Class.class);
         find.setAccessible(true);
+        instrumenthandler = Accessor.class.getDeclaredField("INSTRUMENTHANDLER");
+        instrumenthandler.setAccessible(true);
     }
 
     @Test
@@ -56,5 +71,21 @@ public class AccessorTest {
 
         ExportImportLanguage1 afterInitialization = (ExportImportLanguage1) find.invoke(null, vm, ExportImportLanguage1.class);
         assertNotNull("Language found", afterInitialization);
+    }
+
+    /**
+     * Test that {@link CallTarget}s can be called even when the instrumentation framework is not
+     * initialized (e.g., when not using the {@link PolyglotEngine}).
+     */
+    @Test
+    public void testAccessorInstrumentationHandlerNotInitialized() throws IllegalAccessException {
+        Accessor savedAccessor = (Accessor) instrumenthandler.get(null);
+        instrumenthandler.set(null, null);
+        try {
+            CallTarget testCallTarget = Truffle.getRuntime().createCallTarget(RootNode.createConstantNode(42));
+            assertEquals(42, testCallTarget.call(new Object[0]));
+        } finally {
+            instrumenthandler.set(null, savedAccessor);
+        }
     }
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/Accessor.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/Accessor.java
@@ -380,7 +380,10 @@ public abstract class Accessor {
      * instrumentation.
      */
     protected void initializeCallTarget(RootCallTarget target) {
-        INSTRUMENTHANDLER.initializeCallTarget(target);
+        Accessor accessor = INSTRUMENTHANDLER;
+        if (accessor != null) {
+            accessor.initializeCallTarget(target);
+        }
     }
 
     protected void collectEnvServices(Set<Object> collectTo, Object vm, TruffleLanguage<?> impl, Env context) {


### PR DESCRIPTION
Follow up to #65, this time for the Graal Truffle Runtime.