### PR TITLE
Make DefaultCallTarget final. 

### DIFF
--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/DefaultCallTarget.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/DefaultCallTarget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import com.oracle.truffle.api.nodes.RootNode;
  * This is an implementation-specific class. Do not use or instantiate it. Instead, use
  * {@link TruffleRuntime#createCallTarget(RootNode)} to create a {@link RootCallTarget}.
  */
-public class DefaultCallTarget implements RootCallTarget {
+public final class DefaultCallTarget implements RootCallTarget {
 
     private final RootNode rootNode;
     private boolean initialized;
@@ -53,7 +53,7 @@ public class DefaultCallTarget implements RootCallTarget {
         return rootNode.toString();
     }
 
-    public final RootNode getRootNode() {
+    public RootNode getRootNode() {
         return rootNode;
     }
 


### PR DESCRIPTION
The class is not part of the API and should also not be extensible.