### PR TITLE
Source section filter extension

### DIFF
--- a/truffle/com.oracle.truffle.api.instrumentation.test/src/com/oracle/truffle/api/instrumentation/SourceSectionFilterTest.java
+++ b/truffle/com.oracle.truffle.api.instrumentation.test/src/com/oracle/truffle/api/instrumentation/SourceSectionFilterTest.java
@@ -150,6 +150,61 @@ public class SourceSectionFilterTest {
         Assert.assertNotNull(SourceSectionFilter.newBuilder().lineIn(2, 2).build().toString());
     }
 
+    @Test
+    public void testLineNotIn() {
+        Source sampleSource = Source.fromText("line1\nline2\nline3\nline4", null);
+        SourceSection root = sampleSource.createSection(null, 0, 23);
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().lineNotIn(IndexRange.byLength(2, 1)).build(),
+                        root, sampleSource.createSection(null, 6, 5, tags())));
+
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().lineNotIn(IndexRange.byLength(1, 2)).build(),
+                        root, sampleSource.createSection(null, 2, 1, tags())));
+
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().lineNotIn(IndexRange.byLength(1, 1)).build(),
+                        root, sampleSource.createSection(null, 6, 5, tags())));
+
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().lineNotIn(IndexRange.byLength(2, 2)).build(),
+                        root, sampleSource.createSection(null, 3 * LINE_LENGTH, 1, tags())));
+
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().lineNotIn(IndexRange.byLength(2, 2)).build(),
+                        root, sampleSource.createSection(null, 3 * LINE_LENGTH - 1, 1, tags())));
+
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().lineNotIn(IndexRange.byLength(2, 2)).build(),
+                        root, sampleSource.createSection(null, 3 * LINE_LENGTH - 2, 5, tags())));
+
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().lineNotIn(IndexRange.byLength(2, 2)).build(),
+                        root, sampleSource.createSection(null, 0, LINE_LENGTH, tags())));
+
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().lineNotIn(IndexRange.byLength(2, 2)).build(),
+                        root, sampleSource.createSection(null, 0, LINE_LENGTH + 1, tags())));
+
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().lineNotIn(IndexRange.byLength(2, 2)).build(),
+                        root, sampleSource.createSection(null, 1 * LINE_LENGTH - 2, 5, tags())));
+
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().lineNotIn(IndexRange.byLength(2, 2)).build(),
+                        root, sampleSource.createSection(null, 1 * LINE_LENGTH, 1, tags())));
+
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().lineNotIn(IndexRange.byLength(2, 2)).build(),
+                        root, sampleSource.createSection(null, 1 * LINE_LENGTH - 2, 5, tags())));
+
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().lineNotIn(IndexRange.byLength(1, 1)).build(),
+                        root, SourceSection.createUnavailable(null, null)));
+
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().lineNotIn(IndexRange.byLength(1, 1)).build(),
+                        root, sampleSource.createSection(null, 0, LINE_LENGTH, tags())));
+
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().lineNotIn(IndexRange.byLength(1, 1)).build(),
+                        root, sampleSource.createSection(null, LINE_LENGTH, LINE_LENGTH, tags())));
+
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().lineNotIn(IndexRange.byLength(1, 1), IndexRange.between(2, 3), IndexRange.byLength(3, 1)).build(),
+                        root, sampleSource.createSection(null, LINE_LENGTH, LINE_LENGTH, tags())));
+
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().lineNotIn(IndexRange.byLength(1, 1), IndexRange.byLength(3, 1)).build(),
+                        root, sampleSource.createSection(null, LINE_LENGTH, LINE_LENGTH, tags())));
+
+        Assert.assertNotNull(SourceSectionFilter.newBuilder().lineIn(2, 2).build().toString());
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void testLineInFail1() {
         SourceSectionFilter.newBuilder().lineIn(0, 5);
@@ -237,6 +292,59 @@ public class SourceSectionFilterTest {
                         root, sampleSource.createSection(null, 5, 5, tags())));
 
         Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().indexIn(IndexRange.between(0, 5), IndexRange.between(11, 12)).build(),
+                        root, sampleSource.createSection(null, 5, 5, tags())));
+
+        Assert.assertNotNull(SourceSectionFilter.newBuilder().indexIn(5, 5).build().toString());
+
+    }
+
+    @Test
+    public void testIndexNotIn() {
+        Source sampleSource = Source.fromText("line1\nline2\nline3\nline4", null);
+        SourceSection root = sampleSource.createSection(null, 0, 23);
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().indexNotIn(IndexRange.byLength(0, 0)).build(),
+                        root, sampleSource.createSection(null, 0, 5, tags())));
+
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().indexNotIn(IndexRange.byLength(0, 1)).build(),
+                        root, sampleSource.createSection(null, 0, 5, tags())));
+
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().indexNotIn(IndexRange.byLength(5, 5)).build(),
+                        root, sampleSource.createSection(null, 5, 5, tags())));
+
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().indexNotIn(IndexRange.byLength(5, 5)).build(),
+                        root, sampleSource.createSection(null, 0, 4, tags())));
+
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().indexNotIn(IndexRange.byLength(5, 5)).build(),
+                        root, sampleSource.createSection(null, 0, 5, tags())));
+
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().indexNotIn(IndexRange.byLength(5, 5)).build(),
+                        root, sampleSource.createSection(null, 4, 5, tags())));
+
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().indexNotIn(IndexRange.byLength(5, 5)).build(),
+                        root, sampleSource.createSection(null, 4, 6, tags())));
+
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().indexNotIn(IndexRange.byLength(5, 5)).build(),
+                        root, sampleSource.createSection(null, 5, 5, tags())));
+
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().indexNotIn(IndexRange.byLength(5, 5)).build(),
+                        root, sampleSource.createSection(null, 10, 1, tags())));
+
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().indexNotIn(IndexRange.byLength(5, 5)).build(),
+                        root, sampleSource.createSection(null, 9, 1, tags())));
+
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().indexNotIn(IndexRange.byLength(5, 5)).build(),
+                        root, sampleSource.createSection(null, 9, 5, tags())));
+
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().indexNotIn(IndexRange.byLength(5, 5)).build(),
+                        root, SourceSection.createUnavailable(null, null)));
+
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().indexNotIn(IndexRange.between(0, 5)).build(),
+                        root, sampleSource.createSection(null, 5, 5, tags())));
+
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().indexNotIn(IndexRange.between(0, 5), IndexRange.between(5, 6)).build(),
+                        root, sampleSource.createSection(null, 5, 5, tags())));
+
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().indexNotIn(IndexRange.between(0, 5), IndexRange.between(11, 12)).build(),
                         root, sampleSource.createSection(null, 5, 5, tags())));
 
         Assert.assertNotNull(SourceSectionFilter.newBuilder().indexIn(5, 5).build().toString());

--- a/truffle/com.oracle.truffle.api.instrumentation.test/src/com/oracle/truffle/api/instrumentation/SourceSectionFilterTest.java
+++ b/truffle/com.oracle.truffle.api.instrumentation.test/src/com/oracle/truffle/api/instrumentation/SourceSectionFilterTest.java
@@ -439,6 +439,30 @@ public class SourceSectionFilterTest {
         Assert.assertNotNull(SourceSectionFilter.newBuilder().sourceSectionEquals(sampleSource1.createSection(null, 1, 6)).build().toString());
     }
 
+    @Test
+    public void testRootSourceSectionEquals() {
+        Source sampleSource1 = Source.fromText("line1\nline2\nline3\nline4", null);
+
+        Assert.assertTrue(isInstrumentedNode(SourceSectionFilter.newBuilder().rootSourceSectionEquals(sampleSource1.createSection(null, 1, 6)).build(),
+                        sampleSource1.createSection(null, 6, 4)));
+        Assert.assertTrue(isInstrumentedRoot(SourceSectionFilter.newBuilder().rootSourceSectionEquals(sampleSource1.createSection(null, 1, 6)).build(),
+                        sampleSource1.createSection(null, 1, 6)));
+
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().rootSourceSectionEquals(sampleSource1.createSection(null, 1, 6)).build(),
+                        sampleSource1.createSection(null, 1, 6), sampleSource1.createSection(null, 6, 4)));
+
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().rootSourceSectionEquals(sampleSource1.createSection(null, 1, 6)).build(),
+                        sampleSource1.createSection(null, 2, 6), sampleSource1.createSection(null, 1, 4)));
+
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().rootSourceSectionEquals(sampleSource1.createSection(null, 1, 6)).build(),
+                        sampleSource1.createSection(null, 1, 7), sampleSource1.createSection(null, 1, 4)));
+
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().rootSourceSectionEquals(sampleSource1.createSection(null, 1, 6)).build(),
+                        sampleSource1.createSection(null, 1, 6), SourceSection.createUnavailable(null, null)));
+
+        Assert.assertNotNull(SourceSectionFilter.newBuilder().rootSourceSectionEquals(sampleSource1.createSection(null, 1, 6)).build().toString());
+    }
+
     private static SourceSection source(String... tags) {
         return Source.fromText("foo", null).createSection(null, 0, 3, tags);
     }

--- a/truffle/com.oracle.truffle.api.instrumentation.test/src/com/oracle/truffle/api/instrumentation/SourceSectionFilterTest.java
+++ b/truffle/com.oracle.truffle.api.instrumentation.test/src/com/oracle/truffle/api/instrumentation/SourceSectionFilterTest.java
@@ -29,6 +29,7 @@ import java.lang.reflect.Method;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.oracle.truffle.api.instrumentation.SourceSectionFilter.IndexRange;
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.source.SourceSection;
 
@@ -40,8 +41,8 @@ public class SourceSectionFilterTest {
         return invokeAccessible(filter, "isInstrumentedNode", section);
     }
 
-    private static boolean isInstrumented(SourceSectionFilter filter, SourceSection section) {
-        return invokeAccessible(filter, "isInstrumented", section);
+    private static boolean isInstrumented(SourceSectionFilter filter, SourceSection rootSourceSection, SourceSection nodeSourceSection) {
+        return isInstrumentedRoot(filter, rootSourceSection) && isInstrumentedNode(filter, nodeSourceSection);
     }
 
     private static boolean isInstrumentedRoot(SourceSectionFilter filter, SourceSection section) {
@@ -61,6 +62,7 @@ public class SourceSectionFilterTest {
     @Test
     public void testEmpty() {
         Source sampleSource = Source.fromText("line1\nline2\nline3\nline4", null);
+        SourceSection root = sampleSource.createSection(null, 0, 23);
         SourceSection unavailable = SourceSection.createUnavailable(null, null);
         SourceSectionFilter filter = SourceSectionFilter.newBuilder().build();
         SourceSection sampleSection = sampleSource.createSection(null, 2);
@@ -73,19 +75,19 @@ public class SourceSectionFilterTest {
         Assert.assertTrue(isInstrumentedRoot(filter, unavailable));
         Assert.assertTrue(isInstrumentedRoot(filter, sampleSection));
 
-        Assert.assertTrue(isInstrumented(filter, source()));
-        Assert.assertTrue(isInstrumented(filter, unavailable));
-        Assert.assertTrue(isInstrumented(filter, sampleSection));
+        Assert.assertTrue(isInstrumented(filter, root, source()));
+        Assert.assertTrue(isInstrumented(filter, root, unavailable));
+        Assert.assertTrue(isInstrumented(filter, root, sampleSection));
 
         String prevTag = null;
         for (String tag : InstrumentationTestLanguage.TAGS) {
-            Assert.assertTrue(isInstrumented(filter, source(tag)));
-            Assert.assertTrue(isInstrumented(filter, unavailable));
-            Assert.assertTrue(isInstrumented(filter, sampleSource.createSection(null, 0, 4, tag)));
+            Assert.assertTrue(isInstrumented(filter, root, source(tag)));
+            Assert.assertTrue(isInstrumented(filter, root, unavailable));
+            Assert.assertTrue(isInstrumented(filter, root, sampleSource.createSection(null, 0, 4, tag)));
             if (prevTag != null) {
-                Assert.assertTrue(isInstrumented(filter, source(tag)));
-                Assert.assertTrue(isInstrumented(filter, unavailable));
-                Assert.assertTrue(isInstrumented(filter, sampleSource.createSection(null, 0, 4, tag, prevTag)));
+                Assert.assertTrue(isInstrumented(filter, root, source(tag)));
+                Assert.assertTrue(isInstrumented(filter, root, unavailable));
+                Assert.assertTrue(isInstrumented(filter, root, sampleSource.createSection(null, 0, 4, tag, prevTag)));
             }
             prevTag = tag;
         }
@@ -96,57 +98,54 @@ public class SourceSectionFilterTest {
     @Test
     public void testLineIn() {
         Source sampleSource = Source.fromText("line1\nline2\nline3\nline4", null);
-        Assert.assertTrue(
-                        isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 1).build(),
-                                        sampleSource.createSection(null, 6, 5, tags())));
+        SourceSection root = sampleSource.createSection(null, 0, 23);
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 1).build(),
+                        root, sampleSource.createSection(null, 6, 5, tags())));
 
-        Assert.assertTrue(
-                        isInstrumented(SourceSectionFilter.newBuilder().lineIn(1, 2).build(),
-                                        sampleSource.createSection(null, 2, 1, tags())));
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().lineIn(1, 2).build(),
+                        root, sampleSource.createSection(null, 2, 1, tags())));
 
-        Assert.assertFalse(
-                        isInstrumented(SourceSectionFilter.newBuilder().lineIn(1, 1).build(),
-                                        sampleSource.createSection(null, 6, 5, tags())));
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().lineIn(1, 1).build(),
+                        root, sampleSource.createSection(null, 6, 5, tags())));
 
-        Assert.assertFalse(
-                        isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 2).build(),
-                                        sampleSource.createSection(null, 3 * LINE_LENGTH, 1, tags())));
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 2).build(),
+                        root, sampleSource.createSection(null, 3 * LINE_LENGTH, 1, tags())));
 
-        Assert.assertTrue(
-                        isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 2).build(),
-                                        sampleSource.createSection(null, 3 * LINE_LENGTH - 1, 1, tags())));
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 2).build(),
+                        root, sampleSource.createSection(null, 3 * LINE_LENGTH - 1, 1, tags())));
 
-        Assert.assertTrue(
-                        isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 2).build(),
-                                        sampleSource.createSection(null, 3 * LINE_LENGTH - 2, 5, tags())));
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 2).build(),
+                        root, sampleSource.createSection(null, 3 * LINE_LENGTH - 2, 5, tags())));
 
-        Assert.assertFalse(
-                        isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 2).build(),
-                                        sampleSource.createSection(null, 0, LINE_LENGTH, tags())));
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 2).build(),
+                        root, sampleSource.createSection(null, 0, LINE_LENGTH, tags())));
 
-        Assert.assertTrue(
-                        isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 2).build(),
-                                        sampleSource.createSection(null, 0, LINE_LENGTH + 1, tags())));
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 2).build(),
+                        root, sampleSource.createSection(null, 0, LINE_LENGTH + 1, tags())));
 
-        Assert.assertTrue(
-                        isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 2).build(),
-                                        sampleSource.createSection(null, 1 * LINE_LENGTH - 2, 5, tags())));
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 2).build(),
+                        root, sampleSource.createSection(null, 1 * LINE_LENGTH - 2, 5, tags())));
 
-        Assert.assertTrue(
-                        isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 2).build(),
-                                        sampleSource.createSection(null, 1 * LINE_LENGTH, 1, tags())));
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 2).build(),
+                        root, sampleSource.createSection(null, 1 * LINE_LENGTH, 1, tags())));
 
-        Assert.assertTrue(
-                        isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 2).build(),
-                                        sampleSource.createSection(null, 1 * LINE_LENGTH - 2, 5, tags())));
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().lineIn(2, 2).build(),
+                        root, sampleSource.createSection(null, 1 * LINE_LENGTH - 2, 5, tags())));
 
-        Assert.assertFalse(
-                        isInstrumented(SourceSectionFilter.newBuilder().lineIn(1, 1).build(),
-                                        SourceSection.createUnavailable(null, null)));
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().lineIn(1, 1).build(),
+                        root, SourceSection.createUnavailable(null, null)));
 
-        Assert.assertTrue(
-                        isInstrumented(SourceSectionFilter.newBuilder().lineIs(1).build(),
-                                        sampleSource.createSection(null, 0, LINE_LENGTH, tags())));
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().lineIs(1).build(),
+                        root, sampleSource.createSection(null, 0, LINE_LENGTH, tags())));
+
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().lineIn(IndexRange.byLength(1, 1)).build(),
+                        root, sampleSource.createSection(null, LINE_LENGTH, LINE_LENGTH, tags())));
+
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().lineIn(IndexRange.byLength(1, 1), IndexRange.between(2, 3), IndexRange.byLength(3, 1)).build(),
+                        root, sampleSource.createSection(null, LINE_LENGTH, LINE_LENGTH, tags())));
+
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().lineIn(IndexRange.byLength(1, 1), IndexRange.byLength(3, 1)).build(),
+                        root, sampleSource.createSection(null, LINE_LENGTH, LINE_LENGTH, tags())));
 
         Assert.assertNotNull(SourceSectionFilter.newBuilder().lineIn(2, 2).build().toString());
     }
@@ -166,27 +165,27 @@ public class SourceSectionFilterTest {
         Source sampleSource = Source.fromText("line1\nline2\nline3\nline4", null);
         Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().mimeTypeIs().build(),
-                                        sampleSource.withMimeType("mime3").createSection(null, 0, 5, tags())));
+                                        null, sampleSource.withMimeType("mime3").createSection(null, 0, 5, tags())));
 
         Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().mimeTypeIs("mime1").build(),
-                                        sampleSource.withMimeType("mime1").createSection(null, 0, 5, tags())));
+                                        null, sampleSource.withMimeType("mime1").createSection(null, 0, 5, tags())));
 
         Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().mimeTypeIs("mime1").build(),
-                                        sampleSource.withMimeType("mime2").createSection(null, 0, 5, tags())));
+                                        null, sampleSource.withMimeType("mime2").createSection(null, 0, 5, tags())));
 
         Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().mimeTypeIs("mime1", "mime2").build(),
-                                        sampleSource.withMimeType("mime2").createSection(null, 0, 5, tags())));
+                                        null, sampleSource.withMimeType("mime2").createSection(null, 0, 5, tags())));
 
         Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().mimeTypeIs("mime1", "mime2").build(),
-                                        sampleSource.withMimeType("mime3").createSection(null, 0, 5, tags())));
+                                        null, sampleSource.withMimeType("mime3").createSection(null, 0, 5, tags())));
 
         Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().mimeTypeIs("mime1", "mime2").build(),
-                                        sampleSource.withMimeType(null).createSection(null, 0, 5, tags())));
+                                        null, sampleSource.withMimeType(null).createSection(null, 0, 5, tags())));
 
         Assert.assertNotNull(SourceSectionFilter.newBuilder().mimeTypeIs("mime1", "mime2").build().toString());
     }
@@ -194,53 +193,51 @@ public class SourceSectionFilterTest {
     @Test
     public void testIndexIn() {
         Source sampleSource = Source.fromText("line1\nline2\nline3\nline4", null);
-        Assert.assertFalse(
-                        isInstrumented(SourceSectionFilter.newBuilder().indexIn(0, 0).build(),
-                                        sampleSource.createSection(null, 0, 5, tags())));
+        SourceSection root = sampleSource.createSection(null, 0, 23);
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().indexIn(0, 0).build(),
+                        root, sampleSource.createSection(null, 0, 5, tags())));
 
-        Assert.assertTrue(
-                        isInstrumented(SourceSectionFilter.newBuilder().indexIn(0, 1).build(),
-                                        sampleSource.createSection(null, 0, 5, tags())));
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().indexIn(0, 1).build(),
+                        root, sampleSource.createSection(null, 0, 5, tags())));
 
-        Assert.assertTrue(
-                        isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
-                                        sampleSource.createSection(null, 5, 5, tags())));
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
+                        root, sampleSource.createSection(null, 5, 5, tags())));
 
-        Assert.assertFalse(
-                        isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
-                                        sampleSource.createSection(null, 0, 4, tags())));
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
+                        root, sampleSource.createSection(null, 0, 4, tags())));
 
-        Assert.assertTrue(
-                        isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
-                                        sampleSource.createSection(null, 0, 5, tags())));
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
+                        root, sampleSource.createSection(null, 0, 5, tags())));
 
-        Assert.assertTrue(
-                        isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
-                                        sampleSource.createSection(null, 4, 5, tags())));
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
+                        root, sampleSource.createSection(null, 4, 5, tags())));
 
-        Assert.assertTrue(
-                        isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
-                                        sampleSource.createSection(null, 4, 6, tags())));
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
+                        root, sampleSource.createSection(null, 4, 6, tags())));
 
-        Assert.assertTrue(
-                        isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
-                                        sampleSource.createSection(null, 5, 5, tags())));
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
+                        root, sampleSource.createSection(null, 5, 5, tags())));
 
-        Assert.assertFalse(
-                        isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
-                                        sampleSource.createSection(null, 10, 1, tags())));
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
+                        root, sampleSource.createSection(null, 10, 1, tags())));
 
-        Assert.assertTrue(
-                        isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
-                                        sampleSource.createSection(null, 9, 1, tags())));
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
+                        root, sampleSource.createSection(null, 9, 1, tags())));
 
-        Assert.assertTrue(
-                        isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
-                                        sampleSource.createSection(null, 9, 5, tags())));
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
+                        root, sampleSource.createSection(null, 9, 5, tags())));
 
-        Assert.assertFalse(
-                        isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
-                                        SourceSection.createUnavailable(null, null)));
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().indexIn(5, 5).build(),
+                        root, SourceSection.createUnavailable(null, null)));
+
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().indexIn(IndexRange.between(0, 5)).build(),
+                        root, sampleSource.createSection(null, 5, 5, tags())));
+
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().indexIn(IndexRange.between(0, 5), IndexRange.between(5, 6)).build(),
+                        root, sampleSource.createSection(null, 5, 5, tags())));
+
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().indexIn(IndexRange.between(0, 5), IndexRange.between(11, 12)).build(),
+                        root, sampleSource.createSection(null, 5, 5, tags())));
 
         Assert.assertNotNull(SourceSectionFilter.newBuilder().indexIn(5, 5).build().toString());
 
@@ -261,30 +258,33 @@ public class SourceSectionFilterTest {
         Source sampleSource1 = Source.fromText("line1\nline2\nline3\nline4", null);
         Source sampleSource2 = Source.fromText("line1\nline2\nline3\nline4", null);
         Source sampleSource3 = Source.fromText("line1\nline2\nline3\nline4", null);
+        SourceSection root1 = sampleSource1.createSection(null, 0, 23);
+        SourceSection root2 = sampleSource2.createSection(null, 0, 23);
+        SourceSection root3 = sampleSource3.createSection(null, 0, 23);
 
         Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().sourceIs(sampleSource1).build(),
-                                        sampleSource1.createSection(null, 0, 5, tags())));
+                                        root1, sampleSource1.createSection(null, 0, 5, tags())));
 
         Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().sourceIs(sampleSource1).build(),
-                                        SourceSection.createUnavailable(null, null)));
+                                        null, SourceSection.createUnavailable(null, null)));
 
         Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().sourceIs(sampleSource1).build(),
-                                        sampleSource2.createSection(null, 0, 5, tags())));
+                                        root2, sampleSource2.createSection(null, 0, 5, tags())));
 
         Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().sourceIs(sampleSource1, sampleSource2).build(),
-                                        sampleSource2.createSection(null, 0, 5, tags())));
+                                        root2, sampleSource2.createSection(null, 0, 5, tags())));
 
         Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().sourceIs(sampleSource1, sampleSource2).build(),
-                                        sampleSource1.createSection(null, 0, 5, tags())));
+                                        root1, sampleSource1.createSection(null, 0, 5, tags())));
 
         Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().sourceIs(sampleSource1, sampleSource2).build(),
-                                        sampleSource3.createSection(null, 0, 5, tags())));
+                                        root3, sampleSource3.createSection(null, 0, 5, tags())));
 
         Assert.assertNotNull(SourceSectionFilter.newBuilder().sourceIs(sampleSource1, sampleSource2).build().toString());
     }
@@ -293,38 +293,40 @@ public class SourceSectionFilterTest {
     public void testSourceSectionEquals() {
         Source sampleSource1 = Source.fromText("line1\nline2\nline3\nline4", null);
         Source sampleSource2 = Source.fromText("line1\nline2\nline3\nline4", null);
+        SourceSection root1 = sampleSource1.createSection(null, 0, 23);
+        SourceSection root2 = sampleSource2.createSection(null, 0, 23);
 
         Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().sourceSectionEquals(sampleSource1.createSection(null, 1, 6)).build(),
-                                        sampleSource1.createSection(null, 1, 6, tags())));
+                                        root1, sampleSource1.createSection(null, 1, 6, tags())));
 
         Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().sourceSectionEquals(sampleSource1.createSection(null, 1, 6)).build(),
-                                        sampleSource2.createSection(null, 1, 6, tags())));
+                                        root2, sampleSource2.createSection(null, 1, 6, tags())));
 
         Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().sourceSectionEquals(sampleSource1.createSection(null, 1, 7)).build(),
-                                        sampleSource1.createSection(null, 1, 6, tags())));
+                                        root1, sampleSource1.createSection(null, 1, 6, tags())));
 
         Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().sourceSectionEquals(sampleSource1.createSection(null, 2, 6)).build(),
-                                        sampleSource1.createSection(null, 1, 6, tags())));
+                                        root1, sampleSource1.createSection(null, 1, 6, tags())));
 
         Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().sourceSectionEquals(sampleSource1.createSection(null, 2, 6), sampleSource1.createSection(null, 2, 7)).build(),
-                                        sampleSource1.createSection(null, 2, 7, tags())));
+                                        root1, sampleSource1.createSection(null, 2, 7, tags())));
 
         Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().sourceSectionEquals(sampleSource1.createSection(null, 2, 6), sampleSource1.createSection(null, 2, 7)).build(),
-                                        sampleSource1.createSection(null, 2, 8, tags())));
+                                        root1, sampleSource1.createSection(null, 2, 8, tags())));
 
         Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().sourceSectionEquals(sampleSource1.createSection(null, 2, 6), sampleSource1.createSection(null, 2, 7)).build(),
-                                        SourceSection.createUnavailable(null, null)));
+                                        null, SourceSection.createUnavailable(null, null)));
 
         Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().sourceSectionEquals(sampleSource1.createSection(null, 2, 6), sampleSource1.createSection(null, 2, 7)).build(),
-                                        null));
+                                        root1, null));
 
         Assert.assertNotNull(SourceSectionFilter.newBuilder().sourceSectionEquals(sampleSource1.createSection(null, 1, 6)).build().toString());
     }
@@ -336,33 +338,33 @@ public class SourceSectionFilterTest {
     @Test
     public void testTagsIn() {
         Assert.assertFalse(
-                        isInstrumented(SourceSectionFilter.newBuilder().tagIs().build(), source()));
+                        isInstrumented(SourceSectionFilter.newBuilder().tagIs().build(), null, source()));
 
         Assert.assertFalse(
-                        isInstrumented(SourceSectionFilter.newBuilder().tagIs().build(), source(InstrumentationTestLanguage.STATEMENT)));
+                        isInstrumented(SourceSectionFilter.newBuilder().tagIs().build(), null, source(InstrumentationTestLanguage.STATEMENT)));
 
         Assert.assertTrue(
-                        isInstrumented(SourceSectionFilter.newBuilder().tagIs(InstrumentationTestLanguage.STATEMENT).build(), source(InstrumentationTestLanguage.STATEMENT)));
-
-        Assert.assertTrue(
-                        isInstrumented(SourceSectionFilter.newBuilder().tagIs(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT).build(),
-                                        source(InstrumentationTestLanguage.STATEMENT)));
-
-        Assert.assertFalse(
-                        isInstrumented(SourceSectionFilter.newBuilder().tagIs(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT).build(),
-                                        source(InstrumentationTestLanguage.ROOT)));
-
-        Assert.assertFalse(
-                        isInstrumented(SourceSectionFilter.newBuilder().tagIs(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT).build(),
-                                        source()));
+                        isInstrumented(SourceSectionFilter.newBuilder().tagIs(InstrumentationTestLanguage.STATEMENT).build(), null, source(InstrumentationTestLanguage.STATEMENT)));
 
         Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().tagIs(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT).build(),
-                                        source(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT)));
+                                        null, source(InstrumentationTestLanguage.STATEMENT)));
+
+        Assert.assertFalse(
+                        isInstrumented(SourceSectionFilter.newBuilder().tagIs(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT).build(),
+                                        null, source(InstrumentationTestLanguage.ROOT)));
+
+        Assert.assertFalse(
+                        isInstrumented(SourceSectionFilter.newBuilder().tagIs(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT).build(),
+                                        null, source()));
+
+        Assert.assertTrue(
+                        isInstrumented(SourceSectionFilter.newBuilder().tagIs(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT).build(),
+                                        null, source(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT)));
 
         Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().tagIs(InstrumentationTestLanguage.STATEMENT).build(),
-                                        source(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT)));
+                                        null, source(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT)));
 
         Assert.assertNotNull(SourceSectionFilter.newBuilder().tagIs(InstrumentationTestLanguage.STATEMENT, InstrumentationTestLanguage.EXPRESSION).build().toString());
     }
@@ -371,35 +373,35 @@ public class SourceSectionFilterTest {
     public void testTagsNotIn() {
         Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().tagIsNot().build(),
-                                        source()));
+                                        null, source()));
 
         Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().tagIsNot().build(),
-                                        source(InstrumentationTestLanguage.STATEMENT)));
+                                        null, source(InstrumentationTestLanguage.STATEMENT)));
 
         Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().tagIsNot(InstrumentationTestLanguage.STATEMENT).build(),
-                                        source(InstrumentationTestLanguage.STATEMENT)));
+                                        null, source(InstrumentationTestLanguage.STATEMENT)));
 
         Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().tagIsNot(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT).build(),
-                                        source(InstrumentationTestLanguage.STATEMENT)));
+                                        null, source(InstrumentationTestLanguage.STATEMENT)));
 
         Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().tagIsNot(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT).build(),
-                                        source(InstrumentationTestLanguage.ROOT)));
+                                        null, source(InstrumentationTestLanguage.ROOT)));
 
         Assert.assertTrue(
                         isInstrumented(SourceSectionFilter.newBuilder().tagIsNot(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT).build(),
-                                        source()));
+                                        null, source()));
 
         Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().tagIsNot(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT).build(),
-                                        source(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT)));
+                                        null, source(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT)));
 
         Assert.assertFalse(
                         isInstrumented(SourceSectionFilter.newBuilder().tagIsNot(InstrumentationTestLanguage.STATEMENT).build(),
-                                        source(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT)));
+                                        null, source(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.STATEMENT)));
 
         Assert.assertNotNull(SourceSectionFilter.newBuilder().tagIsNot(InstrumentationTestLanguage.STATEMENT, InstrumentationTestLanguage.EXPRESSION).build().toString());
     }
@@ -407,6 +409,7 @@ public class SourceSectionFilterTest {
     @Test
     public void testComplexFilter() {
         Source sampleSource1 = Source.fromText("line1\nline2\nline3\nline4", null).withMimeType("mime2");
+        SourceSection root = sampleSource1.createSection(null, 0, 23);
 
         SourceSectionFilter filter = SourceSectionFilter.newBuilder().tagIs(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.DEFINE).//
         tagIsNot(InstrumentationTestLanguage.DEFINE, InstrumentationTestLanguage.ROOT).//
@@ -414,19 +417,19 @@ public class SourceSectionFilterTest {
         sourceIs(sampleSource1).sourceSectionEquals(sampleSource1.createSection(null, 0, 5)).//
         lineIn(1, 1).lineIs(1).mimeTypeIs("mime1", "mime2").build();
 
-        Assert.assertFalse(isInstrumented(filter, source()));
-        Assert.assertFalse(isInstrumentedRoot(filter, null));
+        Assert.assertFalse(isInstrumented(filter, root, source()));
+        Assert.assertTrue(isInstrumentedRoot(filter, null));
         Assert.assertFalse(isInstrumentedNode(filter, source()));
 
-        Assert.assertFalse(isInstrumented(filter, SourceSection.createUnavailable(null, null)));
+        Assert.assertFalse(isInstrumented(filter, root, SourceSection.createUnavailable(null, null)));
         Assert.assertFalse(isInstrumentedRoot(filter, SourceSection.createUnavailable(null, null)));
         Assert.assertFalse(isInstrumentedNode(filter, SourceSection.createUnavailable(null, null)));
 
-        Assert.assertTrue(isInstrumented(filter, sampleSource1.createSection(null, 0, 5, tags(InstrumentationTestLanguage.EXPRESSION))));
+        Assert.assertTrue(isInstrumented(filter, root, sampleSource1.createSection(null, 0, 5, tags(InstrumentationTestLanguage.EXPRESSION))));
         Assert.assertTrue(isInstrumentedRoot(filter, sampleSource1.createSection(null, 0, 5)));
         Assert.assertTrue(isInstrumentedNode(filter, sampleSource1.createSection(null, 0, 5, tags(InstrumentationTestLanguage.EXPRESSION))));
 
-        Assert.assertFalse(isInstrumented(filter, sampleSource1.createSection(null, 0, 5, tags(InstrumentationTestLanguage.STATEMENT))));
+        Assert.assertFalse(isInstrumented(filter, root, sampleSource1.createSection(null, 0, 5, tags(InstrumentationTestLanguage.STATEMENT))));
         Assert.assertTrue(isInstrumentedRoot(filter, sampleSource1.createSection(null, 0, 5)));
         Assert.assertFalse(isInstrumentedRoot(filter, sampleSource1.createSection(null, 10, 5)));
         Assert.assertFalse(isInstrumentedNode(filter, sampleSource1.createSection(null, 0, 5, tags(InstrumentationTestLanguage.STATEMENT))));

--- a/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/InstrumentationHandler.java
+++ b/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/InstrumentationHandler.java
@@ -188,7 +188,7 @@ final class InstrumentationHandler {
         EventChainNode parent = null;
         for (int i = 0; i < bindings.size(); i++) {
             EventBinding<?> binding = bindings.get(i);
-            if (isInstrumented(probeNodeImpl, binding, sourceSection)) {
+            if (isInstrumented(null, probeNodeImpl, binding, sourceSection)) {
                 if (TRACE) {
                     trace("Found binding %s, %s%n", binding.getFilter(), binding.getElement());
                 }
@@ -326,20 +326,23 @@ final class InstrumentationHandler {
         return !(node instanceof WrapperNode) && !(node instanceof RootNode);
     }
 
-    private static boolean isInstrumented(Node node, EventBinding<?> binding, SourceSection section) {
-        return binding.getInstrumenter().isInstrumentable(node) && binding.getFilter().isInstrumented(section);
+    private static boolean isInstrumented(RootNode rootNode, Node node, EventBinding<?> binding, SourceSection section) {
+        if (isInstrumentedLeaf(binding, section)) {
+            RootNode root = rootNode == null ? node.getRootNode() : rootNode;
+            if (root == null) {
+                return false;
+            }
+            return isInstrumentedRoot(root, binding, root.getSourceSection());
+        }
+        return false;
     }
 
     private static boolean isInstrumentedRoot(RootNode node, EventBinding<?> binding, SourceSection section) {
         return binding.getInstrumenter().isInstrumentable(node) && binding.getFilter().isInstrumentedRoot(section);
     }
 
-    private static boolean isInstrumentedLeaf(Node node, EventBinding<?> binding, SourceSection section) {
-        if (binding.getFilter().isInstrumentedNode(section)) {
-            assert isInstrumented(node, binding, section);
-            return true;
-        }
-        return false;
+    private static boolean isInstrumentedLeaf(EventBinding<?> binding, SourceSection section) {
+        return binding.getFilter().isInstrumentedNode(section);
     }
 
     private static void trace(String message, Object... args) {
@@ -352,7 +355,8 @@ final class InstrumentationHandler {
             trace("Visit root %s wrappers for %s%n", visitor, root.toString());
         }
 
-        if (visitor.shouldVisit(root)) {
+        visitor.root = root;
+        if (visitor.shouldVisit()) {
             // found a filter that matched
             root.atomic(new Runnable() {
                 public void run() {
@@ -360,6 +364,7 @@ final class InstrumentationHandler {
                 }
             });
         }
+        visitor.root = null;
         if (TRACE) {
             trace("Visited root %s wrappers for %s%n", visitor, root.toString());
         }
@@ -408,7 +413,9 @@ final class InstrumentationHandler {
 
     private abstract class AbstractNodeVisitor implements NodeVisitor {
 
-        abstract boolean shouldVisit(RootNode root);
+        protected RootNode root;
+
+        abstract boolean shouldVisit();
 
     }
 
@@ -421,14 +428,14 @@ final class InstrumentationHandler {
         }
 
         @Override
-        boolean shouldVisit(RootNode root) {
+        boolean shouldVisit() {
             return isInstrumentedRoot(root, binding, root.getSourceSection());
         }
 
         public final boolean visit(Node node) {
             SourceSection sourceSection = node.getSourceSection();
             if (sourceSection != null) {
-                if (isInstrumentedLeaf(node, binding, sourceSection) && isInstrumentableNode(node)) {
+                if (isInstrumentableNode(node) && isInstrumentedLeaf(binding, sourceSection)) {
                     if (TRACE) {
                         trace("Filter hit section:%s%n", sourceSection);
                     }
@@ -451,7 +458,7 @@ final class InstrumentationHandler {
         }
 
         @Override
-        boolean shouldVisit(RootNode root) {
+        boolean shouldVisit() {
             SourceSection sourceSection = root.getSourceSection();
             for (int i = 0; i < bindings.size(); i++) {
                 EventBinding<?> binding = bindings.get(i);
@@ -468,7 +475,7 @@ final class InstrumentationHandler {
                 List<EventBinding<?>> b = bindings;
                 for (int i = 0; i < b.size(); i++) {
                     EventBinding<?> binding = b.get(i);
-                    if (isInstrumented(node, binding, sourceSection) && isInstrumentableNode(node)) {
+                    if (isInstrumentableNode(node) && isInstrumented(root, node, binding, sourceSection)) {
                         if (TRACE) {
                             trace("Filter hit section:%s", sourceSection);
                         }

--- a/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/SourceSectionFilter.java
+++ b/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/SourceSectionFilter.java
@@ -75,6 +75,10 @@ public final class SourceSectionFilter {
         return new SourceSectionFilter(null).new Builder();
     }
 
+    /**
+     * @return the filter expressions in a humand readable form for debugging.
+     * @since 0.12
+     */
     @Override
     public String toString() {
         StringBuilder b = new StringBuilder("SourceSectionFilter[");
@@ -117,7 +121,7 @@ public final class SourceSectionFilter {
     /**
      * Configure your own {@link SourceSectionFilter} before creating its instance. Specify various
      * parameters by calling individual {@link Builder} methods. When done, call {@link #build()}.
-     * 
+     *
      * @since 0.12
      */
     public final class Builder {
@@ -128,7 +132,7 @@ public final class SourceSectionFilter {
 
         /**
          * Add a filter for all source sections that reference one of the given sources.
-         * 
+         *
          * @since 0.12
          */
         public Builder sourceIs(Source... source) {
@@ -141,7 +145,9 @@ public final class SourceSectionFilter {
          * Add a filter for all source sections that declare one of the given mime-types. Mime-types
          * which are compared must match exactly one of the mime-types specified by the target guest
          * language.
-         * 
+         *
+         * @param mimeTypes matches one of the given mime types
+         * @return the builder to chain calls
          * @since 0.12
          */
         public Builder mimeTypeIs(String... mimeTypes) {
@@ -152,7 +158,9 @@ public final class SourceSectionFilter {
 
         /**
          * Add a filter for all source sections that are tagged with one of the given String tags.
-         * 
+         *
+         * @param tags matches one of the given tags
+         * @return the builder to chain calls
          * @since 0.12
          */
         public Builder tagIs(String... tags) {
@@ -163,7 +171,9 @@ public final class SourceSectionFilter {
 
         /**
          * Add a filter for all sources sections that declare not one of the given String tags.
-         * 
+         *
+         * @param tags matches not one of the given tags
+         * @return the builder to chain calls
          * @since 0.12
          */
         public Builder tagIsNot(String... tags) {
@@ -174,7 +184,9 @@ public final class SourceSectionFilter {
 
         /**
          * Add a filter for all sources sections that equal one of the given source sections.
-         * 
+         *
+         * @param section matches one of the given source sections
+         * @return the builder to chain calls
          * @since 0.12
          */
         public Builder sourceSectionEquals(SourceSection... section) {
@@ -189,6 +201,10 @@ public final class SourceSectionFilter {
          * filter. This can mean in the dynamic language domain that all nodes of a function for
          * which the root source section matches the given source section is instrumented but its
          * inner functions and its nodes are not instrumented.
+         *
+         * @param section matches one of the given root source sections
+         * @return the builder to chain calls
+         * @since 0.12
          */
         public Builder rootSourceSectionEquals(SourceSection... section) {
             verifyNotNull(section);
@@ -199,6 +215,10 @@ public final class SourceSectionFilter {
         /**
          * Add a filter for all sources sections which indices are not contained in one of the given
          * index ranges.
+         *
+         * @param ranges matches indices that are not contained one of the given index ranges
+         * @return the builder to chain calls
+         * @since 0.12
          */
         public Builder indexNotIn(IndexRange... ranges) {
             verifyNotNull(ranges);
@@ -209,6 +229,9 @@ public final class SourceSectionFilter {
         /**
          * Add a filter for all sources sections which indices are contained in one of the given
          * index ranges.
+         *
+         * @param ranges matches indices that are contained one of the given index ranges
+         * @return the builder to chain calls
          * @since 0.12
          */
         public Builder indexIn(IndexRange... ranges) {
@@ -220,7 +243,10 @@ public final class SourceSectionFilter {
         /**
          * Add a filter for all sources sections where the index is inside a startIndex (inclusive)
          * plus a given length (exclusive).
-         * 
+         *
+         * @param startIndex the start index (inclusive)
+         * @param length the number of matched characters
+         * @return the builder to chain calls
          * @since 0.12
          */
         public Builder indexIn(int startIndex, int length) {
@@ -230,13 +256,16 @@ public final class SourceSectionFilter {
         /**
          * Add a filter for all sources sections which lines are contained in one of the given index
          * ranges. Line indices must be greater or equal to <code>1</code>.
+         *
+         * @param ranges matches lines that are contained one of the given index ranges
+         * @return the builder to chain calls
          * @since 0.12
          */
         public Builder lineIn(IndexRange... ranges) {
             verifyNotNull(ranges);
             for (IndexRange indexRange : ranges) {
-                if (indexRange.getStartIndex() < 1) {
-                    throw new IllegalArgumentException(String.format("Start line indices must be >= 1 but were %s.", indexRange.getStartIndex()));
+                if (indexRange.startIndex < 1) {
+                    throw new IllegalArgumentException(String.format("Start line indices must be >= 1 but were %s.", indexRange.startIndex));
                 }
             }
             expressions.add(new EventFilterExpression.LineIn(ranges));
@@ -246,12 +275,16 @@ public final class SourceSectionFilter {
         /**
          * Add a filter for all sources sections which lines are not contained in one of the given
          * index ranges. Line indices must be greater or equal to <code>1</code>.
+         *
+         * @param ranges matches lines that are not contained one of the given index ranges
+         * @return the builder to chain calls
+         * @since 0.12
          */
         public Builder lineNotIn(IndexRange... ranges) {
             verifyNotNull(ranges);
             for (IndexRange indexRange : ranges) {
-                if (indexRange.getStartIndex() < 1) {
-                    throw new IllegalArgumentException(String.format("Start line indices must be >= 1 but were %s.", indexRange.getStartIndex()));
+                if (indexRange.startIndex < 1) {
+                    throw new IllegalArgumentException(String.format("Start line indices must be >= 1 but were %s.", indexRange.startIndex));
                 }
             }
             expressions.add(new Not(new EventFilterExpression.LineIn(ranges)));
@@ -261,7 +294,10 @@ public final class SourceSectionFilter {
         /**
          * Add a filter for all sources sections where the line is inside a startLine (first index
          * inclusive) plus a given length (last index exclusive).
-         * 
+         *
+         * @param startLine the start line (inclusive)
+         * @param length the number of matched lines
+         * @return the builder to chain calls
          * @since 0.12
          */
         public Builder lineIn(int startLine, int length) {
@@ -270,7 +306,10 @@ public final class SourceSectionFilter {
 
         /**
          * Add a filter for all sources sections where the line is exactly the given line. Line
-         * indices must be greater or equal to <code>1</code>.         * 
+         * indices must be greater or equal to <code>1</code>. *
+         *
+         * @param line the line to be matched
+         * @return the builder to chain calls
          * @since 0.12
          */
         public Builder lineIs(int line) {
@@ -279,7 +318,8 @@ public final class SourceSectionFilter {
 
         /**
          * Finalizes and constructs the {@link SourceSectionFilter} instance.
-         * 
+         *
+         * @return the built filter expression
          * @since 0.12
          */
         public SourceSectionFilter build() {
@@ -300,7 +340,6 @@ public final class SourceSectionFilter {
 
     }
 
-
     /**
      * Represents a range between two indices within a {@link SourceSectionFilter source section
      * filter}. Instances are immutable.
@@ -312,38 +351,12 @@ public final class SourceSectionFilter {
      */
     public static final class IndexRange {
 
-        private final int startIndex;
-        private final int endIndex;
+        final int startIndex;
+        final int endIndex;
 
         private IndexRange(int startIndex, int endIndex) {
             this.startIndex = startIndex;
             this.endIndex = endIndex;
-        }
-
-        /**
-         * Returns the start index of the index range. Invariants are
-         * <code>{@link #getStartIndex() startIndex} >= 0</code> and
-         * <code>{@link #getStartIndex() startIndex} <= {@link #getEndIndex() endIndex}</code>.
-         */
-        public int getStartIndex() {
-            return startIndex;
-        }
-
-        /**
-         * Returns the end index of the index range. Invariants are
-         * <code>{@link #getEndIndex() endIndex} >= 0</code> and
-         * <code>{@link #getStartIndex() startIndex} <= {@link #getEndIndex() endIndex}</code>.
-         */
-        public int getEndIndex() {
-            return endIndex;
-        }
-
-        /**
-         * Returns the length of the index range. The invariant is
-         * <code>{@link #getLength() length} >= 0</code>.
-         */
-        public int getLength() {
-            return endIndex - startIndex;
         }
 
         /**
@@ -389,6 +402,10 @@ public final class SourceSectionFilter {
             return startIndex <= otherEndIndex && otherStartIndex < endIndex;
         }
 
+        /**
+         * @return a human readable version of the index range
+         * @since 0.12
+         */
         @Override
         public String toString() {
             return "[" + startIndex + "-" + endIndex + "[";

--- a/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/SourceSectionFilter.java
+++ b/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/SourceSectionFilter.java
@@ -714,7 +714,7 @@ public final class SourceSectionFilter {
 
         private final EventFilterExpression delegate;
 
-        public Not(EventFilterExpression delegate) {
+        Not(EventFilterExpression delegate) {
             this.delegate = delegate;
         }
 


### PR DESCRIPTION
This should address https://github.com/graalvm/truffle/issues/80 with rootSourceSectionEquals.

Additionally I've added indexIn, indexNotIn, lineIn and lineNotIn with a set of ranges to allow arbitrary index and line based checks. 

@mickjordan please comment if this fits your needs.