### PR TITLE
Making sure all API elements have @since tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,20 @@
 
 This changelog summarizes major changes between Truffle versions relevant to languages implementors building upon the Truffle framework. The main focus is on APIs exported by Truffle.
 
+## Version 0.12
+* New instrumentation API
 
-## `tip`
-### Truffle
-* The Instrumentation Framework has been revised and has new APIs that are integrated into the PolyglotEngine.
-  * Instrumention support required of language implementatins is specified as abstract methods on TruffleLanguage.
-  * Clients access instrumentation sevices via an instance of Instrumenter, provided by the Polyglot framework.
+## Version 0.11
+* Improved interop API
+* PolyglotEngine.Builder.getConfig
+* TruffleLanguage.Env.isMimeTypeSupported
+
+## Version 0.10
+
+* Profile API classes moved into its own com.oracle.truffle.api.profiles package
+
+## Version 0.9
+* Debugger API
 
 ## Version 0.8
 17-Jul-2015, [Repository Revision](http://lafo.ssw.uni-linz.ac.at/hg/truffle/shortlog/graal-0.8)

--- a/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/Breakpoint.java
+++ b/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/Breakpoint.java
@@ -34,12 +34,16 @@ import com.oracle.truffle.api.source.Source;
  * breakpoint by calling
  * {@link Debugger#setLineBreakpoint(int, com.oracle.truffle.api.source.LineLocation, boolean)} or
  * other methods in the {@link Debugger} class.
+ * 
+ * @since 0.9
  */
 @SuppressWarnings("javadoc")
 public abstract class Breakpoint {
 
     /**
      * A general model of the states occupied by a {@link Breakpoint} during its lifetime.
+     * 
+     * @since 0.9
      */
     public enum State {
 
@@ -78,10 +82,12 @@ public abstract class Breakpoint {
             this.name = name;
         }
 
+        /** @since 0.9 */
         public String getName() {
             return name;
         }
 
+        /** @since 0.9 */
         @Override
         public String toString() {
             return name;
@@ -94,6 +100,8 @@ public abstract class Breakpoint {
 
     /**
      * Gets current state of the breakpoint.
+     * 
+     * @since 0.9
      */
     public abstract State getState();
 
@@ -102,11 +110,14 @@ public abstract class Breakpoint {
      *
      * @param enabled <code>true</code> to activate the breakpoint, <code>false</code> to deactivate
      *            it so that it has no effect.
+     * @since 0.9
      */
     public abstract void setEnabled(boolean enabled);
 
     /**
      * Is this breakpoint active?
+     * 
+     * @since 0.9
      */
     public abstract boolean isEnabled();
 
@@ -117,22 +128,29 @@ public abstract class Breakpoint {
      *            evaluated in the lexical context at the breakpoint location.
      * @throws IOException if condition is invalid
      * @throws UnsupportedOperationException if the breakpoint does not support conditions
+     * @since 0.9
      */
     public abstract void setCondition(String expr) throws IOException;
 
     /**
      * Gets the text that defines the current condition on this breakpoint; {@code null} if this
      * breakpoint is currently unconditional.
+     * 
+     * @since 0.9
      */
     public abstract Source getCondition();
 
     /**
      * Does this breakpoint remove itself after first activation?
+     * 
+     * @since 0.9
      */
     public abstract boolean isOneShot();
 
     /**
      * Gets the number of hits left to be ignored before halting.
+     * 
+     * @since 0.9
      */
     public abstract int getIgnoreCount();
 
@@ -141,23 +159,31 @@ public abstract class Breakpoint {
      * ignore count and a {@linkplain #setCondition(String) condition} are specified, the condition
      * is evaluated first: if {@code false} it is not considered to be a hit. In other words, the
      * ignore count is for successful conditions only.
+     * 
+     * @since 0.9
      */
     public abstract void setIgnoreCount(int ignoreCount);
 
     /**
      * Number of times this breakpoint has reached, with one exception; if the breakpoint has a
      * condition that evaluates to {@code false}, it does not count as a hit.
+     * 
+     * @since 0.9
      */
     public abstract int getHitCount();
 
     /**
      * Disables this breakpoint and removes any associated instrumentation; it becomes permanently
      * inert.
+     * 
+     * @since 0.9
      */
     public abstract void dispose();
 
     /**
      * Gets a human-sensible description of this breakpoint's location in a {@link Source}.
+     * 
+     * @since 0.9
      */
     public abstract String getLocationDescription();
 }

--- a/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/Debugger.java
+++ b/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/Debugger.java
@@ -62,6 +62,8 @@ import com.oracle.truffle.api.vm.PolyglotEngine;
  * Instance of this class is delivered via {@link SuspendedEvent#getDebugger()} and
  * {@link ExecutionEvent#getDebugger()} events, once {@link com.oracle.truffle.api.debug debugging
  * is turned on}.
+ * 
+ * @since 0.9
  */
 public final class Debugger {
 
@@ -69,6 +71,8 @@ public final class Debugger {
      * A {@link SourceSection#withTags(java.lang.String...) tag} used to mark program locations
      * where ordinary stepping should halt. The debugger will halt just <em>before</em> a code
      * location is executed that is marked with this tag.
+     * 
+     * @since 0.9
      */
     public static final String HALT_TAG = "debug-HALT";
 
@@ -78,6 +82,7 @@ public final class Debugger {
      * The debugger will halt at the code location that has just executed the call that returned.
      *
      * @see #HALT_TAG
+     * @since 0.9
      */
     public static final String CALL_TAG = "debug-CALL";
 
@@ -100,6 +105,7 @@ public final class Debugger {
      *
      * @param engine the engine to find debugger for
      * @return an instance of associated debugger, never <code>null</code>
+     * @since 0.9
      */
     public static Debugger find(PolyglotEngine engine) {
         return find(engine, true);
@@ -196,6 +202,7 @@ public final class Debugger {
      * @param oneShot breakpoint disposes itself after fist hit, if {@code true}
      * @return a new breakpoint, initially enabled
      * @throws IOException if the breakpoint can not be set.
+     * @since 0.9
      */
     @TruffleBoundary
     public Breakpoint setLineBreakpoint(int ignoreCount, LineLocation lineLocation, boolean oneShot) throws IOException {
@@ -213,6 +220,7 @@ public final class Debugger {
      * @param oneShot if {@code true} breakpoint removes it self after a hit
      * @return a new breakpoint, initially enabled
      * @throws IOException if the breakpoint already set
+     * @since 0.9
      */
     @SuppressWarnings("static-method")
     @Deprecated
@@ -224,6 +232,8 @@ public final class Debugger {
     /**
      * Gets all existing breakpoints, whatever their status, in natural sorted order. Modification
      * save.
+     * 
+     * @since 0.9
      */
     @TruffleBoundary
     public Collection<Breakpoint> getBreakpoints() {

--- a/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/ExecutionEvent.java
+++ b/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/ExecutionEvent.java
@@ -36,6 +36,8 @@ package com.oracle.truffle.api.debug;
  * {@link IllegalStateException}. One can however obtain reference to {@link Debugger} instance and
  * keep it to further manipulate with debugging capabilities of the
  * {@link com.oracle.truffle.api.vm.PolyglotEngine} when it is running.
+ * 
+ * @since 0.9
  */
 @SuppressWarnings("javadoc")
 public final class ExecutionEvent {
@@ -52,6 +54,7 @@ public final class ExecutionEvent {
      *
      * @return instance of debugger associated with the just starting execution and any subsequent
      *         ones in the same {@link com.oracle.truffle.api.vm.PolyglotEngine}.
+     * @since 0.9
      */
     public Debugger getDebugger() {
         return debugger;
@@ -68,6 +71,8 @@ public final class ExecutionEvent {
      * <li>execution completes.</li>
      * </ol>
      * </ul>
+     * 
+     * @since 0.9
      */
     public void prepareContinue() {
         debugger.prepareContinue(-1);
@@ -90,6 +95,7 @@ public final class ExecutionEvent {
      * </ul>
      *
      * @throws IllegalArgumentException if the specified number is {@code <= 0}
+     * @since 0.9
      */
     public void prepareStepInto() {
         debugger.prepareStepInto(1);

--- a/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/SuspendedEvent.java
+++ b/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/SuspendedEvent.java
@@ -44,6 +44,8 @@ import com.oracle.truffle.api.nodes.Node;
  * used while the handlers process the event. Then the state of the event becomes invalid and
  * subsequent calls to the event methods yield {@link IllegalStateException}. One can call
  * {@link #getDebugger()} and keep reference to it for as long as necessary.
+ * 
+ * @since 0.9
  */
 @SuppressWarnings("javadoc")
 public final class SuspendedEvent {
@@ -82,19 +84,23 @@ public final class SuspendedEvent {
      *
      * @return instance of debugger associated with the just suspended execution and any subsequent
      *         ones in the same {@link com.oracle.truffle.api.vm.PolyglotEngine}.
+     * @since 0.9
      */
     public Debugger getDebugger() {
         return debugger;
     }
 
+    /** @since 0.9 */
     public Node getNode() {
         return haltedNode;
     }
 
+    /** @since 0.9 */
     public MaterializedFrame getFrame() {
         return haltedFrame;
     }
 
+    /** @since 0.9 */
     public List<String> getRecentWarnings() {
         return Collections.unmodifiableList(warnings);
     }
@@ -105,6 +111,7 @@ public final class SuspendedEvent {
      * where halted.
      *
      * @return list of stack frames
+     * @since 0.9
      */
     @CompilerDirectives.TruffleBoundary
     public List<FrameInstance> getStack() {
@@ -122,6 +129,8 @@ public final class SuspendedEvent {
      * <li>execution completes.</li>
      * </ol>
      * </ul>
+     * 
+     * @since 0.9
      */
     public void prepareContinue() {
         debugger.prepareContinue(-1);
@@ -144,6 +153,7 @@ public final class SuspendedEvent {
      *
      * @param stepCount the number of times to perform StepInto before halting
      * @throws IllegalArgumentException if the specified number is {@code <= 0}
+     * @since 0.9
      */
     public void prepareStepInto(int stepCount) {
         debugger.prepareStepInto(stepCount);
@@ -162,6 +172,8 @@ public final class SuspendedEvent {
      * <li>StepOut mode persists only through one resumption, and reverts by default to Continue
      * mode.</li>
      * </ul>
+     * 
+     * @since 0.9
      */
     public void prepareStepOut() {
         debugger.prepareStepOut();
@@ -185,6 +197,7 @@ public final class SuspendedEvent {
      *
      * @param stepCount the number of times to perform StepInto before halting
      * @throws IllegalArgumentException if the specified number is {@code <= 0}
+     * @since 0.9
      */
     public void prepareStepOver(int stepCount) {
         debugger.prepareStepOver(stepCount);
@@ -198,6 +211,7 @@ public final class SuspendedEvent {
      *            location.
      * @return the computed value
      * @throws IOException in case an evaluation goes wrong
+     * @since 0.9
      */
     public Object eval(String code, FrameInstance frame) throws IOException {
         return debugger.evalInContext(this, code, frame);

--- a/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/Cached.java
+++ b/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/Cached.java
@@ -223,6 +223,7 @@ import java.lang.annotation.Target;
  * @see Specialization#contains()
  * @see Specialization#limit()
  * @see ImportStatic
+ * @since 0.8 or earlier
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.PARAMETER})

--- a/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/CreateCast.java
+++ b/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/CreateCast.java
@@ -32,6 +32,8 @@ import java.lang.annotation.Target;
 
 /**
  * Specifies a factory method that creates a {@link Node} which is used to cast this child.
+ * 
+ * @since 0.8 or earlier
  */
 @Retention(RetentionPolicy.CLASS)
 @Target({ElementType.METHOD})

--- a/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/Fallback.java
+++ b/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/Fallback.java
@@ -73,6 +73,7 @@ import java.lang.annotation.Target;
  *
  * @see Specialization
  * @see NodeChild
+ * @since 0.8 or earlier
  */
 @Retention(RetentionPolicy.CLASS)
 @Target({ElementType.METHOD})

--- a/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/GenerateNodeFactory.java
+++ b/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/GenerateNodeFactory.java
@@ -33,6 +33,8 @@ import java.lang.annotation.Target;
  * Annotate nodes or base classes of nodes to generate factory handlers implementing the
  * {@link NodeFactory} interface. The generated factory handlers class name starts with the source
  * original class and ends with 'Factory'.
+ * 
+ * @since 0.8 or earlier
  */
 @Retention(RetentionPolicy.CLASS)
 @Target({ElementType.TYPE})

--- a/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/GeneratedBy.java
+++ b/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/GeneratedBy.java
@@ -31,6 +31,8 @@ import java.lang.annotation.Target;
 
 /**
  * Marks a type as being generated based on another class or method of a class.
+ * 
+ * @since 0.8 or earlier
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE})

--- a/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/ImplicitCast.java
+++ b/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/ImplicitCast.java
@@ -29,6 +29,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/** @since 0.8 or earlier */
 @Retention(RetentionPolicy.CLASS)
 @Target({ElementType.METHOD})
 public @interface ImplicitCast {

--- a/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/ImportStatic.java
+++ b/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/ImportStatic.java
@@ -37,6 +37,7 @@ import java.lang.annotation.Target;
  * @see Specialization#assumptions()
  * @see Specialization#limit()
  * @see Cached
+ * @since 0.8 or earlier
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE})

--- a/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/NodeChild.java
+++ b/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/NodeChild.java
@@ -33,6 +33,8 @@ import java.lang.annotation.Target;
 /**
  * A {@link NodeChild} element defines an executable child for the enclosing {@link Node}. A
  * {@link Node} contains multiple {@link NodeChildren} specified in linear execution order.
+ * 
+ * @since 0.8 or earlier
  */
 @Retention(RetentionPolicy.CLASS)
 @Target({ElementType.TYPE})

--- a/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/NodeChildren.java
+++ b/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/NodeChildren.java
@@ -29,6 +29,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/** @since 0.8 or earlier */
 @Retention(RetentionPolicy.CLASS)
 @Target({ElementType.TYPE})
 public @interface NodeChildren {

--- a/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/NodeFactory.java
+++ b/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/NodeFactory.java
@@ -30,6 +30,8 @@ import java.util.List;
 /**
  * Enables the dynamic creation of generated nodes. It provides an convenient way to instantiate
  * generated node classes without using reflection.
+ * 
+ * @since 0.8 or earlier
  */
 public interface NodeFactory<T> {
 
@@ -41,6 +43,7 @@ public interface NodeFactory<T> {
      * @param arguments the argument values
      * @return the instantiated node
      * @throws IllegalArgumentException
+     * @since 0.8 or earlier
      */
     T createNode(Object... arguments);
 
@@ -48,17 +51,23 @@ public interface NodeFactory<T> {
      * Returns the node class that will get created by {@link #createNode(Object...)}. The node
      * class does not match exactly to the instantiated object but they are guaranteed to be
      * assignable.
+     * 
+     * @since 0.8 or earlier
      */
     Class<T> getNodeClass();
 
     /**
      * Returns a list of signatures that can be used to invoke {@link #createNode(Object...)}.
+     * 
+     * @since 0.8 or earlier
      */
     List<List<Class<?>>> getNodeSignatures();
 
     /**
      * Returns a list of children that will be executed by the created node. This is useful for base
      * nodes that can execute a variable amount of nodes.
+     * 
+     * @since 0.8 or earlier
      */
     List<Class<? extends Node>> getExecutionSignature();
 

--- a/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/NodeField.java
+++ b/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/NodeField.java
@@ -35,6 +35,8 @@ import java.lang.annotation.Target;
  * contains multiple {@link NodeFields} specified in linear declaration order. The field can be
  * accessed by declaring an abstract getter named
  * <code>"get" + firstLetterUpperCase({@link #name()})()</code>.
+ * 
+ * @since 0.8 or earlier
  */
 @Retention(RetentionPolicy.CLASS)
 @Target({ElementType.TYPE})

--- a/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/NodeFields.java
+++ b/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/NodeFields.java
@@ -35,6 +35,8 @@ import java.lang.annotation.Target;
  * contains multiple {@link NodeFields} specified in linear declaration order. The field can be
  * accessed by declaring an abstract getter named
  * <code>"get" + firstLetterUpperCase({@link #value()})()</code>.
+ * 
+ * @since 0.8 or earlier
  */
 @Retention(RetentionPolicy.CLASS)
 @Target({ElementType.TYPE})

--- a/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/ShortCircuit.java
+++ b/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/ShortCircuit.java
@@ -29,6 +29,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/** @since 0.8 or earlier */
 @Retention(RetentionPolicy.CLASS)
 @Target({ElementType.METHOD})
 public @interface ShortCircuit {

--- a/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/Specialization.java
+++ b/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/Specialization.java
@@ -115,6 +115,7 @@ import java.lang.annotation.Target;
  * @see TypeSystem
  * @see TypeSystemReference
  * @see UnsupportedSpecializationException
+ * @since 0.8 or earlier
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})

--- a/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/TypeCast.java
+++ b/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/TypeCast.java
@@ -48,6 +48,7 @@ import java.lang.annotation.Target;
  * </pre>
  *
  * @see TypeCheck
+ * @since 0.8 or earlier
  */
 @Retention(RetentionPolicy.CLASS)
 @Target({ElementType.METHOD})

--- a/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/TypeCheck.java
+++ b/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/TypeCheck.java
@@ -48,6 +48,7 @@ import java.lang.annotation.Target;
  * </pre>
  *
  * @see TypeCast
+ * @since 0.8 or earlier
  */
 @Retention(RetentionPolicy.CLASS)
 @Target({ElementType.METHOD})

--- a/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/TypeSystem.java
+++ b/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/TypeSystem.java
@@ -63,12 +63,12 @@ import java.lang.annotation.Target;
  *
  * {@literal @}TypeSystem(types = {boolean.class, int.class, double.class})
  * public abstract class ExampleTypeSystem {
- *
+ * 
  *     {@literal @}TypeCheck
  *     public boolean isInteger(Object value) {
  *         return value instanceof Integer || value instanceof Double;
  *     }
- *
+ * 
  *     {@literal @}TypeCast
  *     public double asInteger(Object value) {
  *         return ((Number)value).doubleValue();
@@ -79,6 +79,7 @@ import java.lang.annotation.Target;
  *
  * @see TypeCast
  * @see TypeCheck
+ * @since 0.8 or earlier
  */
 @Retention(RetentionPolicy.CLASS)
 @Target({ElementType.TYPE})

--- a/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/TypeSystemReference.java
+++ b/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/TypeSystemReference.java
@@ -36,6 +36,7 @@ import java.lang.annotation.Target;
  *
  * @see TypeSystem
  * @see Node
+ * @since 0.8 or earlier
  */
 @Retention(RetentionPolicy.CLASS)
 @Target({ElementType.TYPE})

--- a/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/UnsupportedSpecializationException.java
+++ b/truffle/com.oracle.truffle.api.dsl/src/com/oracle/truffle/api/dsl/UnsupportedSpecializationException.java
@@ -32,6 +32,8 @@ import java.util.Objects;
 /**
  * Thrown by the generated code of Truffle-DSL if no compatible Specialization could be found for
  * the provided values.
+ * 
+ * @since 0.8 or earlier
  */
 public final class UnsupportedSpecializationException extends RuntimeException {
 
@@ -41,6 +43,7 @@ public final class UnsupportedSpecializationException extends RuntimeException {
     private final Node[] suppliedNodes;
     private final Object[] suppliedValues;
 
+    /** @since 0.8 or earlier */
     @TruffleBoundary
     public UnsupportedSpecializationException(Node node, Node[] suppliedNodes, Object... suppliedValues) {
         Objects.requireNonNull(suppliedNodes, "The suppliedNodes parameter must not be null.");
@@ -52,6 +55,7 @@ public final class UnsupportedSpecializationException extends RuntimeException {
         this.suppliedValues = suppliedValues;
     }
 
+    /** @since 0.8 or earlier */
     @Override
     public String getMessage() {
         StringBuilder str = new StringBuilder();
@@ -64,6 +68,8 @@ public final class UnsupportedSpecializationException extends RuntimeException {
 
     /**
      * Returns the {@link Node} that caused the this {@link UnsupportedSpecializationException}.
+     * 
+     * @since 0.8 or earlier
      */
     public Node getNode() {
         return node;
@@ -74,6 +80,8 @@ public final class UnsupportedSpecializationException extends RuntimeException {
      * values returned by {@link #getSuppliedValues()}. The array returned by
      * {@link #getSuppliedNodes()} has the same length as the array returned by
      * {@link #getSuppliedValues()}. Never returns null.
+     * 
+     * @since 0.8 or earlier
      */
     public Node[] getSuppliedNodes() {
         return suppliedNodes;
@@ -83,6 +91,8 @@ public final class UnsupportedSpecializationException extends RuntimeException {
      * Returns the dynamic values that were supplied to the node.The array returned by
      * {@link #getSuppliedNodes()} has the same length as the array returned by
      * {@link #getSuppliedValues()}. Never returns null.
+     * 
+     * @since 0.8 or earlier
      */
     public Object[] getSuppliedValues() {
         return suppliedValues;

--- a/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/EventBinding.java
+++ b/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/EventBinding.java
@@ -43,6 +43,7 @@ import com.oracle.truffle.api.instrumentation.InstrumentationHandler.LanguageIns
  *
  * @param <T> represents the concrete type of the element bound. Either an implementation of
  *            {@link ExecutionEventListener} or {@link ExecutionEventNodeFactory}.
+ * @since 0.12
  */
 public final class EventBinding<T> {
 
@@ -70,6 +71,8 @@ public final class EventBinding<T> {
     /**
      * Returns the bound element, either a {@link ExecutionEventNodeFactory factory} or a
      * {@link ExecutionEventListener listener} implementation.
+     * 
+     * @since 0.12
      */
     public T getElement() {
         return element;
@@ -79,6 +82,7 @@ public final class EventBinding<T> {
      * Returns the bound filter for this binding.
      *
      * @return the filter never null
+     * @since 0.12
      */
     public SourceSectionFilter getFilter() {
         return filter;
@@ -86,6 +90,8 @@ public final class EventBinding<T> {
 
     /**
      * Returns <code>true</code> if the binding was already disposed, otherwise <code>false</code>.
+     * 
+     * @since 0.12
      */
     public boolean isDisposed() {
         return disposed;
@@ -94,6 +100,8 @@ public final class EventBinding<T> {
     /**
      * Disposes this binding. If a binding of a listener or factory is disposed then their methods
      * are not invoked again by the instrumentation framework.
+     * 
+     * @since 0.12
      */
     public void dispose() throws IllegalStateException {
         CompilerAsserts.neverPartOfCompilation();

--- a/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/EventContext.java
+++ b/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/EventContext.java
@@ -40,6 +40,7 @@ import com.oracle.truffle.api.source.SourceSection;
  *
  * @see ExecutionEventNodeFactory
  * @see ExecutionEventListener
+ * @since 0.12
  */
 public final class EventContext {
 
@@ -59,6 +60,8 @@ public final class EventContext {
      * <b>Performance note:</b> this is method may be invoked in compiled code and is guaranteed to
      * always return a compilation constant .
      * </p>
+     * 
+     * @since 0.12
      */
     public SourceSection getInstrumentedSourceSection() {
         return sourceSection;
@@ -71,6 +74,8 @@ public final class EventContext {
      * <b>Performance note:</b> this is method may be invoked in compiled code and is guaranteed to
      * always return a compilation constant .
      * </p>
+     * 
+     * @since 0.12
      */
     public Node getInstrumentedNode() {
         WrapperNode wrapper = probeNode.findWrapper();
@@ -88,6 +93,7 @@ public final class EventContext {
      *            can be referenced from the source
      * @return the call target representing the parsed result
      * @throws IOException if the parsing or evaluation fails for some reason
+     * @since 0.12
      */
     public CallTarget parseInContext(Source source, String... argumentNames) throws IOException {
         return InstrumentationHandler.ACCESSOR.parse(null, source, getInstrumentedNode(), argumentNames);
@@ -97,7 +103,7 @@ public final class EventContext {
      * TODO (chumer) a way to parse code in the current language and return something like a node
      * that is directly embeddable into the AST as a @Child.
      */
-
+    /** @since 0.12 */
     @Override
     public String toString() {
         return "EventContext[source=" + getInstrumentedSourceSection() + "]";

--- a/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/ExecutionEventListener.java
+++ b/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/ExecutionEventListener.java
@@ -29,6 +29,8 @@ import com.oracle.truffle.api.frame.VirtualFrame;
 /**
  * A listener attached by an {@link Instrumenter} to specific locations of a guest language program
  * to listen to instrumentation events.
+ * 
+ * @since 0.12
  */
 public interface ExecutionEventListener {
 
@@ -40,6 +42,7 @@ public interface ExecutionEventListener {
      *
      * @param context indicating the current location in the guest language AST
      * @param frame the frame that was used for executing instrumented node
+     * @since 0.12
      */
     void onEnter(EventContext context, VirtualFrame frame);
 
@@ -51,6 +54,7 @@ public interface ExecutionEventListener {
      *
      * @param context indicating the current location in the guest language AST
      * @param frame the frame that was used for executing instrumented node
+     * @since 0.12
      */
     void onReturnValue(EventContext context, VirtualFrame frame, Object result);
 
@@ -62,6 +66,7 @@ public interface ExecutionEventListener {
      *
      * @param context indicating the current location in the guest language AST
      * @param frame the frame that was used for executing instrumented node
+     * @since 0.12
      */
     void onReturnExceptional(EventContext context, VirtualFrame frame, Throwable exception);
 

--- a/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/ExecutionEventNode.java
+++ b/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/ExecutionEventNode.java
@@ -34,11 +34,13 @@ import com.oracle.truffle.api.nodes.NodeInfo;
  * language program to listen to instrumentation events. In addition to
  * {@link ExecutionEventListener listeners} event nodes allow to store state for a particular
  * {@link EventContext program location}.
+ * 
+ * @since 0.12
  */
 @NodeInfo(cost = NodeCost.NONE)
 @SuppressWarnings("unused")
 public abstract class ExecutionEventNode extends Node {
-
+    /** @since 0.12 */
     protected ExecutionEventNode() {
     }
 
@@ -49,6 +51,7 @@ public abstract class ExecutionEventNode extends Node {
      * .
      *
      * @param frame the current frame used in the instrumented node
+     * @since 0.12
      */
     protected void onEnter(VirtualFrame frame) {
         // do nothing by default
@@ -61,6 +64,7 @@ public abstract class ExecutionEventNode extends Node {
      * {@link Instrumenter#attachListener(SourceSectionFilter, ExecutionEventListener) attached}.
      *
      * @param frame the frame that was used for executing instrumented node
+     * @since 0.12
      */
     protected void onReturnValue(VirtualFrame frame, Object result) {
         // do nothing by default
@@ -73,6 +77,7 @@ public abstract class ExecutionEventNode extends Node {
      * {@link Instrumenter#attachListener(SourceSectionFilter, ExecutionEventListener) attached}.
      *
      * @param frame the frame that was used for executing instrumented node
+     * @since 0.12
      */
     protected void onReturnExceptional(VirtualFrame frame, Throwable exception) {
         // do nothing by default
@@ -87,6 +92,7 @@ public abstract class ExecutionEventNode extends Node {
      * executed.
      *
      * @param frame the frame that was used for executing instrumented node
+     * @since 0.12
      */
     protected void onDispose(VirtualFrame frame) {
     }

--- a/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/ExecutionEventNodeFactory.java
+++ b/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/ExecutionEventNodeFactory.java
@@ -37,6 +37,8 @@ import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
  * as a {@link CompilationFinal compilation final}, so no peak performance overhead persists for
  * looking up the counter on the fast path.
  * </p>
+ * 
+ * @since 0.12
  */
 public interface ExecutionEventNodeFactory {
 
@@ -48,6 +50,7 @@ public interface ExecutionEventNodeFactory {
      *
      * @param context the current context where this event node should get created.
      * @return a new event node instance
+     * @since 0.12
      */
     ExecutionEventNode create(EventContext context);
 

--- a/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/Instrumentable.java
+++ b/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/Instrumentable.java
@@ -72,21 +72,22 @@ import com.oracle.truffle.api.source.SourceSection;
  * &#064;Instrumentable(factory = BaseNodeWrapper.class)
  * public abstract class BaseNode extends Node {
  *     private final String addtionalData;
- *
+ * 
  *     public BaseNode(String additonalData) {
  *         this.additionalData = additionalData;
  *     }
- *
+ * 
  *     public BaseNode(BaseNode delegate) {
  *         this.additionalData = delegate.additionalData;
  *     }
- *
+ * 
  *     public abstract Object execute(VirtualFrame frame);
  * }
  * </pre>
  *
  * @see WrapperNode
  * @see ProbeNode
+ * @since 0.12
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE})

--- a/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/InstrumentableFactory.java
+++ b/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/InstrumentableFactory.java
@@ -32,6 +32,7 @@ import com.oracle.truffle.api.nodes.Node;
  * the factory for you.
  * 
  * @param <T> the type of node this factory operates on
+ * @since 0.12
  */
 public interface InstrumentableFactory<T extends Node> {
 
@@ -45,6 +46,7 @@ public interface InstrumentableFactory<T extends Node> {
      *
      * @param probe the {@link ProbeNode probe} that should get adopted by the wrapper node.
      * @return a {@link WrapperNode wrapper} implementation
+     * @since 0.12
      */
     WrapperNode createWrapper(T node, ProbeNode probe);
 
@@ -52,17 +54,23 @@ public interface InstrumentableFactory<T extends Node> {
      * Interface for instrumentation wrapper nodes Abstract class provided by
      * {@link InstrumentableFactory#createWrapper(Node, ProbeNode)} to notify the instrumentation
      * API about execution events.
-     **/
+     *
+     * @since 0.12
+     */
     public interface WrapperNode {
 
         /**
          * Returns the original node that this node delegates to.
+         * 
+         * @since 0.12
          */
         Node getDelegateNode();
 
         /**
          * Returns the probe that was returned by
          * {@link InstrumentableFactory#createWrapper(Node, ProbeNode)}.
+         * 
+         * @since 0.12
          */
         ProbeNode getProbeNode();
 

--- a/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/Instrumenter.java
+++ b/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/Instrumenter.java
@@ -31,6 +31,7 @@ package com.oracle.truffle.api.instrumentation;
  *
  * @see #attachFactory(SourceSectionFilter, ExecutionEventNodeFactory)
  * @see #attachListener(SourceSectionFilter, ExecutionEventListener)
+ * @since 0.12
  */
 public abstract class Instrumenter {
 
@@ -40,12 +41,16 @@ public abstract class Instrumenter {
     /**
      * Starts event notification for a given {@link ExecutionEventNodeFactory factory} and returns a
      * {@link EventBinding binding} which represents a handle to dispose the notification.
+     * 
+     * @since 0.12
      */
     public abstract <T extends ExecutionEventNodeFactory> EventBinding<T> attachFactory(SourceSectionFilter filter, T factory);
 
     /**
      * Starts event notification for a given {@link ExecutionEventListener listener} and returns a
      * {@link EventBinding binding} which represents a handle to dispose the notification.
+     * 
+     * @since 0.12
      */
     public abstract <T extends ExecutionEventListener> EventBinding<T> attachListener(SourceSectionFilter filter, T listener);
 

--- a/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/ProbeNode.java
+++ b/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/ProbeNode.java
@@ -62,6 +62,8 @@ import com.oracle.truffle.api.source.SourceSection;
  *     }
  * }
  * </pre>
+ * 
+ * @since 0.12
  */
 public final class ProbeNode extends Node {
 
@@ -86,6 +88,7 @@ public final class ProbeNode extends Node {
      * Should get invoked before the node is invoked.
      *
      * @param frame the current frame of the execution.
+     * @since 0.12
      */
     public void onEnter(VirtualFrame frame) {
         if (lazyUpdate(frame)) {
@@ -98,6 +101,7 @@ public final class ProbeNode extends Node {
      *
      * @param result the result value of the operation
      * @param frame the current frame of the execution.
+     * @since 0.12
      */
     public void onReturnValue(VirtualFrame frame, Object result) {
         if (lazyUpdate(frame)) {
@@ -110,6 +114,7 @@ public final class ProbeNode extends Node {
      *
      * @param exception the exception that occured during the execution
      * @param frame the current frame of the execution.
+     * @since 0.12
      */
     public void onReturnExceptional(VirtualFrame frame, Throwable exception) {
         if (lazyUpdate(frame)) {
@@ -217,6 +222,7 @@ public final class ProbeNode extends Node {
         exception.printStackTrace(stream);
     }
 
+    /** @since 0.12 */
     @Override
     public NodeCost getCost() {
         return NodeCost.NONE;

--- a/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/SourceSectionFilter.java
+++ b/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/SourceSectionFilter.java
@@ -42,6 +42,7 @@ import com.oracle.truffle.api.source.SourceSection;
  * @see SourceSectionFilter#newBuilder()
  * @see Instrumenter#attachFactory(SourceSectionFilter, ExecutionEventNodeFactory)
  * @see Instrumenter#attachListener(SourceSectionFilter, ExecutionEventListener)
+ * @since 0.12
  */
 public final class SourceSectionFilter {
 
@@ -70,6 +71,7 @@ public final class SourceSectionFilter {
      * @see Builder#build()
      *
      * @return a new builder to create new {@link SourceSectionFilter} instances
+     * @since 0.12
      */
     public static Builder newBuilder() {
         return new SourceSectionFilter(null, null).new Builder();
@@ -78,14 +80,20 @@ public final class SourceSectionFilter {
     /**
      * Configure your own {@link SourceSectionFilter} before creating its instance. Specify various
      * parameters by calling individual {@link Builder} methods. When done, call {@link #build()}.
+     * 
+     * @since 0.12
      */
     public final class Builder {
-
         private List<EventFilterExpression> nodeExpressions = new ArrayList<>();
         private List<EventFilterExpression> rootNodeExpressions = new ArrayList<>();
 
+        private Builder() {
+        }
+
         /**
          * Add a filter for all source sections that reference one of the given sources.
+         * 
+         * @since 0.12
          */
         public Builder sourceIs(Source... source) {
             verifyNotNull(source);
@@ -97,6 +105,8 @@ public final class SourceSectionFilter {
          * Add a filter for all source sections that declare one of the given mime-types. Mime-types
          * which are compared must match exactly one of the mime-types specified by the target guest
          * language.
+         * 
+         * @since 0.12
          */
         public Builder mimeTypeIs(String... mimeTypes) {
             verifyNotNull(mimeTypes);
@@ -106,6 +116,8 @@ public final class SourceSectionFilter {
 
         /**
          * Add a filter for all source sections that are tagged with one of the given String tags.
+         * 
+         * @since 0.12
          */
         public Builder tagIs(String... tags) {
             verifyNotNull(tags);
@@ -115,6 +127,8 @@ public final class SourceSectionFilter {
 
         /**
          * Add a filter for all sources sections that declare not one of the given String tags.
+         * 
+         * @since 0.12
          */
         public Builder tagIsNot(String... tags) {
             verifyNotNull(tags);
@@ -124,6 +138,8 @@ public final class SourceSectionFilter {
 
         /**
          * Add a filter for all sources sections that equal one of the given source sections.
+         * 
+         * @since 0.12
          */
         public Builder sourceSectionEquals(SourceSection... section) {
             verifyNotNull(section);
@@ -136,6 +152,8 @@ public final class SourceSectionFilter {
         /**
          * Add a filter for all sources sections where the index is inside a startIndex (inclusive)
          * plus a given length (exclusive).
+         * 
+         * @since 0.12
          */
         public Builder indexIn(int startIndex, int length) {
             if (startIndex < 0) {
@@ -153,6 +171,8 @@ public final class SourceSectionFilter {
         /**
          * Add a filter for all sources sections where the line is inside a startLine (first index
          * inclusive) plus a given length (last index exclusive).
+         * 
+         * @since 0.12
          */
         public Builder lineIn(int startLine, int length) {
             if (startLine < 1) {
@@ -169,6 +189,8 @@ public final class SourceSectionFilter {
 
         /**
          * Add a filter for all sources sections where the line is exactly the given line.
+         * 
+         * @since 0.12
          */
         public Builder lineIs(int line) {
             return lineIn(line, 1);
@@ -176,6 +198,8 @@ public final class SourceSectionFilter {
 
         /**
          * Finalizes and constructs the {@link SourceSectionFilter} instance.
+         * 
+         * @since 0.12
          */
         public SourceSectionFilter build() {
             Collections.sort(rootNodeExpressions);
@@ -197,6 +221,7 @@ public final class SourceSectionFilter {
 
     }
 
+    /** @since 0.12 */
     @Override
     public String toString() {
         StringBuilder b = new StringBuilder("SourceSectionFilter[");

--- a/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/TruffleInstrument.java
+++ b/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/TruffleInstrument.java
@@ -66,13 +66,13 @@ import com.oracle.truffle.api.source.Source;
  * <pre>
  * &#064;Registration(name = Coverage.NAME, version = Coverage.VERSION, instrumentType = Coverage.TYPE)
  * public final class Coverage extends Instrumentation {
- *
+ * 
  *     public static final String NAME = &quot;sample-coverage&quot;;
  *     public static final String TYPE = &quot;coverage&quot;;
  *     public static final String VERSION = &quot;coverage&quot;;
- *
+ * 
  *     private final Set&lt;SourceSection&gt; coverage = new HashSet&lt;&gt;();
- *
+ * 
  *     &#064;Override
  *     protected void onCreate(Env env, Instrumenter instrumenter) {
  *         instrumenter.attachFactory(SourceSectionFilter.newBuilder() //
@@ -80,7 +80,7 @@ import com.oracle.truffle.api.source.Source;
  *             public EventNode create(final EventContext context) {
  *                 return new EventNode() {
  *                     &#064;CompilationFinal private boolean visited;
- *
+ * 
  *                     &#064;Override
  *                     public void onReturnValue(VirtualFrame vFrame, Object result) {
  *                         if (!visited) {
@@ -93,16 +93,25 @@ import com.oracle.truffle.api.source.Source;
  *             }
  *         });
  *     }
- *
+ * 
  *     &#064;Override
  *     protected void onDispose(Env env) {
  *         // print result
  *     }
- *
+ * 
  * }
  * </pre>
+ * 
+ * @since 0.12
  */
 public abstract class TruffleInstrument {
+    /**
+     * Constructor for subclasses.
+     * 
+     * @since 0.12
+     */
+    protected TruffleInstrument() {
+    }
 
     /**
      * Method invoked if the instrumentation is allocated and used by the runtime system. Invoked
@@ -127,6 +136,7 @@ public abstract class TruffleInstrument {
      * @param env environment information for the instrumentation
      *
      * @see Env#getInstrumenter()
+     * @since 0.12
      */
     protected abstract void onCreate(Env env);
 
@@ -136,6 +146,7 @@ public abstract class TruffleInstrument {
      * {@link TruffleInstrument} implementation instance is created.
      *
      * @param env environment information for the instrumentation
+     * @since 0.12
      */
     protected void onDispose(Env env) {
         // default implementation does nothing
@@ -144,6 +155,8 @@ public abstract class TruffleInstrument {
     /**
      * Provides ways and means to access input, output and error streams. Also allows to parse
      * arbitrary code from other Truffle languages.
+     * 
+     * @since 0.12
      */
     public static final class Env {
 
@@ -164,6 +177,7 @@ public abstract class TruffleInstrument {
          * Returns the instrumenter which lets you instrument guest language ASTs.
          *
          * @see Instrumenter
+         * @since 0.12
          */
         public Instrumenter getInstrumenter() {
             return instrumenter;
@@ -174,6 +188,7 @@ public abstract class TruffleInstrument {
          * {@link TruffleInstrument instrument} is being executed in.
          *
          * @return reader, never <code>null</code>
+         * @since 0.12
          */
         public InputStream in() {
             return in;
@@ -184,6 +199,7 @@ public abstract class TruffleInstrument {
          * {@link TruffleInstrument instrument} is being executed in.
          *
          * @return writer, never <code>null</code>
+         * @since 0.12
          */
         public OutputStream out() {
             return out;
@@ -194,6 +210,7 @@ public abstract class TruffleInstrument {
          * {@link TruffleInstrument instrument} is being executed in.
          *
          * @return writer, never <code>null</code>
+         * @since 0.12
          */
         public OutputStream err() {
             return err;
@@ -214,6 +231,7 @@ public abstract class TruffleInstrument {
          * @throws IllegalStateException if the method is called later than from
          *             {@link #onCreate(com.oracle.truffle.api.instrumentation.TruffleInstrument.Env) }
          *             method
+         * @since 0.12
          */
         public void registerService(Object service) {
             if (services == null) {
@@ -244,6 +262,7 @@ public abstract class TruffleInstrument {
          *            that can be referenced from the source
          * @return the call target representing the parsed result
          * @throws IOException if the parsing or evaluation fails for some reason
+         * @since 0.12
          */
         @SuppressWarnings("static-method")
         public CallTarget parse(Source source, String... argumentNames) throws IOException {
@@ -255,6 +274,8 @@ public abstract class TruffleInstrument {
     /**
      * Annotation to register an {@link TruffleInstrument instrument} implementations for automatic
      * discovery.
+     * 
+     * @since 0.12
      */
     @Retention(RetentionPolicy.SOURCE)
     @Target(ElementType.TYPE)

--- a/truffle/com.oracle.truffle.api.interop.java/src/com/oracle/truffle/api/interop/java/JavaInterop.java
+++ b/truffle/com.oracle.truffle.api.interop.java/src/com/oracle/truffle/api/interop/java/JavaInterop.java
@@ -84,6 +84,8 @@ import com.oracle.truffle.api.nodes.RootNode;
  * execute} ones. The real semantic however depends on the actual language one is communicating
  * with.
  * <p>
+ * 
+ * @since 0.9
  */
 public final class JavaInterop {
 
@@ -131,6 +133,7 @@ public final class JavaInterop {
      * @return instance of requested interface granting access to specified
      *         <code>foreignObject</code>, can be <code>null</code>, if the foreignObject parameter
      *         was <code>null</code>
+     * @since 0.9
      */
     public static <T> T asJavaObject(Class<T> type, TruffleObject foreignObject) {
         RootNode root = new TemporaryConvertRoot(TruffleLanguage.class, new ToJavaNode(), foreignObject, type);
@@ -167,6 +170,7 @@ public final class JavaInterop {
      *
      * @param obj a Java object to convert into one suitable for <em>Truffle</em> languages
      * @return converted object
+     * @since 0.9
      */
     public static TruffleObject asTruffleObject(Object obj) {
         if (obj instanceof TruffleObject) {
@@ -191,6 +195,7 @@ public final class JavaInterop {
      * @param function <em>Truffle</em> that responds to {@link Message#IS_EXECUTABLE} and can be
      *            invoked
      * @return instance of interface that wraps the provided <code>function</code>
+     * @since 0.9
      */
     public static <T> T asJavaFunction(Class<T> functionalType, TruffleObject function) {
         RootNode root = new TemporaryConvertRoot(TruffleLanguage.class, new ToJavaNode(), function, functionalType);
@@ -216,6 +221,7 @@ public final class JavaInterop {
      *            defining the required behavior
      * @return an {@link Message#IS_EXECUTABLE executable} {@link TruffleObject} ready to be used in
      *         any <em>Truffle</em> language
+     * @since 0.9
      */
     public static <T> TruffleObject asTruffleFunction(Class<T> functionalType, T implementation) {
         final Method[] arr = functionalType.getDeclaredMethods();

--- a/truffle/com.oracle.truffle.api.interop.java/src/com/oracle/truffle/api/interop/java/MethodMessage.java
+++ b/truffle/com.oracle.truffle.api.interop.java/src/com/oracle/truffle/api/interop/java/MethodMessage.java
@@ -64,6 +64,8 @@ import java.lang.annotation.Target;
  * </pre>
  * 
  * the value of the <em>x</em> field is going to be <em>10</em> then.
+ * 
+ * @since 0.9
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/truffle/com.oracle.truffle.api.interop/src/com/oracle/truffle/api/interop/AcceptMessage.java
+++ b/truffle/com.oracle.truffle.api.interop/src/com/oracle/truffle/api/interop/AcceptMessage.java
@@ -55,6 +55,7 @@ import com.oracle.truffle.api.frame.VirtualFrame;
  *
  * {@codesnippet getForeignAccessMethod}
  *
+ * @since 0.11
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.SOURCE)

--- a/truffle/com.oracle.truffle.api.interop/src/com/oracle/truffle/api/interop/ArityException.java
+++ b/truffle/com.oracle.truffle.api.interop/src/com/oracle/truffle/api/interop/ArityException.java
@@ -27,6 +27,8 @@ package com.oracle.truffle.api.interop;
 /**
  * An exception thrown if a foreign function or method invocation provides the wrong number of
  * arguments.
+ * 
+ * @since 0.11
  */
 public final class ArityException extends InteropException {
 
@@ -45,6 +47,7 @@ public final class ArityException extends InteropException {
      * Returns the number of arguments that the foreign object expects.
      *
      * @return the number of expected arguments
+     * @since 0.11
      */
     public int getExpectedArity() {
         return expectedArity;
@@ -54,6 +57,7 @@ public final class ArityException extends InteropException {
      * Returns the actual number of arguments provided by the foreign access.
      *
      * @return the number of provided arguments
+     * @since 0.11
      */
     public int getActualArity() {
         return actualArity;
@@ -69,6 +73,7 @@ public final class ArityException extends InteropException {
      * @param actualArity the number of provided by the foreign access
      *
      * @return the exception
+     * @since 0.11
      */
     public static RuntimeException raise(int expectedArity, int actualArity) {
         return silenceException(RuntimeException.class, new ArityException(expectedArity, actualArity));

--- a/truffle/com.oracle.truffle.api.interop/src/com/oracle/truffle/api/interop/ForeignAccess.java
+++ b/truffle/com.oracle.truffle.api.interop/src/com/oracle/truffle/api/interop/ForeignAccess.java
@@ -38,6 +38,8 @@ import com.oracle.truffle.api.nodes.Node;
  * foreign language implementations, you need to implement {@link TruffleObject} and its
  * {@link TruffleObject#getForeignAccess()} method. To create instance of <code>ForeignAccess</code>
  * , use one of the factory methods available in this class.
+ * 
+ * @since 0.8 or earlier
  */
 public final class ForeignAccess {
     private final Factory factory;
@@ -58,6 +60,7 @@ public final class ForeignAccess {
      * @param factory the factory that handles access requests to {@link Message}s known as of
      *            version 1.0
      * @return new instance wrapping <code>factory</code>
+     * @since 0.8 or earlier
      */
     public static ForeignAccess create(final Class<? extends TruffleObject> baseClass, final Factory10 factory) {
         if (baseClass == null) {
@@ -72,6 +75,7 @@ public final class ForeignAccess {
      *
      * @param factory the factory that handles various access requests {@link Message}s.
      * @return new instance wrapping <code>factory</code>
+     * @since 0.8 or earlier
      */
     public static ForeignAccess create(Factory factory) {
         return new ForeignAccess(factory);
@@ -95,6 +99,7 @@ public final class ForeignAccess {
      *             {@link Message#createNode()} method.
      * @throws IllegalStateException if any error occurred while accessing the <code>receiver</code>
      *             object
+     * @since 0.8 or earlier
      */
     @SuppressWarnings("deprecation")
     @Deprecated
@@ -117,6 +122,7 @@ public final class ForeignAccess {
      *             {@link Message#createNode()} method.
      * @throws InteropException if any error occurred while accessing the <code>receiver</code>
      *             object
+     * @since 0.11
      */
     public static Object send(Node foreignNode, VirtualFrame frame, TruffleObject receiver, Object... arguments) throws InteropException {
         ForeignObjectAccessHeadNode fn = (ForeignObjectAccessHeadNode) foreignNode;
@@ -143,6 +149,7 @@ public final class ForeignAccess {
      *             {@link Message#createNode() message represented} by <code>readNode</code>
      * @throws UnknownIdentifierException if the <code>receiver</code> does not allow reading a
      *             property for the given <code>identifier</code>
+     * @since 0.11
      */
     public static Object sendRead(Node readNode, VirtualFrame frame, TruffleObject receiver, Object identifier) throws UnknownIdentifierException, UnsupportedMessageException {
         ForeignObjectAccessHeadNode fn = (ForeignObjectAccessHeadNode) readNode;
@@ -175,6 +182,7 @@ public final class ForeignAccess {
      * @throws UnknownIdentifierException if the <code>receiver</code> does not allow writing a
      *             property for the given <code>identifier</code>
      * @throws UnsupportedTypeException if <code>value</code> has an unsupported type
+     * @since 0.11
      */
     public static Object sendWrite(Node writeNode, VirtualFrame frame, TruffleObject receiver, Object identifier, Object value)
                     throws UnknownIdentifierException, UnsupportedTypeException, UnsupportedMessageException {
@@ -201,6 +209,7 @@ public final class ForeignAccess {
      *             {@link Message#createNode()} method.
      * @throws UnsupportedMessageException if the <code>receiver</code> does not support the
      *             {@link Message#createNode() message represented} by <code>unboxNode</code>
+     * @since 0.11
      */
     public static Object sendUnbox(Node unboxNode, VirtualFrame frame, TruffleObject receiver) throws UnsupportedMessageException {
         ForeignObjectAccessHeadNode fn = (ForeignObjectAccessHeadNode) unboxNode;
@@ -231,6 +240,7 @@ public final class ForeignAccess {
      *             of arguments for the foreign function
      * @throws UnsupportedMessageException if the <code>receiver</code> does not support the
      *             {@link Message#createNode() message represented} by <code>executeNode</code>
+     * @since 0.11
      */
     public static Object sendExecute(Node executeNode, VirtualFrame frame, TruffleObject receiver, Object... arguments) throws UnsupportedTypeException, ArityException, UnsupportedMessageException {
         ForeignObjectAccessHeadNode fn = (ForeignObjectAccessHeadNode) executeNode;
@@ -254,6 +264,7 @@ public final class ForeignAccess {
      * @return return value, if any
      * @throws ClassCastException if the createNode has not been created by
      *             {@link Message#createNode()} method.
+     * @since 0.11
      */
     public static boolean sendIsExecutable(Node isExecutableNode, VirtualFrame frame, TruffleObject receiver) {
         try {
@@ -283,6 +294,7 @@ public final class ForeignAccess {
      *             of arguments for the foreign function
      * @throws UnsupportedMessageException if the <code>receiver</code> does not support the
      *             {@link Message#createNode() message represented} by <code>invokeNode</code>
+     * @since 0.11
      */
     public static Object sendInvoke(Node invokeNode, VirtualFrame frame, TruffleObject receiver, String identifier, Object... arguments)
                     throws UnsupportedTypeException, ArityException, UnknownIdentifierException, UnsupportedMessageException {
@@ -317,6 +329,7 @@ public final class ForeignAccess {
      *             of arguments for the foreign function
      * @throws UnsupportedMessageException if the <code>receiver</code> does not support the
      *             {@link Message#createNode() message represented} by <code>newNode</code>
+     * @since 0.11
      */
     public static Object sendNew(Node newNode, VirtualFrame frame, TruffleObject receiver, Object... arguments) throws UnsupportedTypeException, ArityException, UnsupportedMessageException {
         ForeignObjectAccessHeadNode fn = (ForeignObjectAccessHeadNode) newNode;
@@ -340,6 +353,7 @@ public final class ForeignAccess {
      * @return return value, if any
      * @throws ClassCastException if the createNode has not been created by
      *             {@link Message#createNode()} method.
+     * @since 0.11
      */
     public static boolean sendIsNull(Node isNullNode, VirtualFrame frame, TruffleObject receiver) {
         try {
@@ -360,6 +374,7 @@ public final class ForeignAccess {
      * @return return value, if any
      * @throws ClassCastException if the createNode has not been created by
      *             {@link Message#createNode()} method.
+     * @since 0.11
      */
     public static boolean sendHasSize(Node hasSizeNode, VirtualFrame frame, TruffleObject receiver) {
         try {
@@ -382,6 +397,7 @@ public final class ForeignAccess {
      *             {@link Message#createNode()} method.
      * @throws UnsupportedMessageException if the <code>receiver</code> does not support the
      *             {@link Message#createNode() message represented} by <code>getSizeNode</code>
+     * @since 0.11
      */
     public static Object sendGetSize(Node getSizeNode, VirtualFrame frame, TruffleObject receiver) throws UnsupportedMessageException {
         ForeignObjectAccessHeadNode fn = (ForeignObjectAccessHeadNode) getSizeNode;
@@ -405,6 +421,7 @@ public final class ForeignAccess {
      * @return return value, if any
      * @throws ClassCastException if the createNode has not been created by
      *             {@link Message#createNode()} method.
+     * @since 0.11
      */
     public static boolean sendIsBoxed(Node isBoxedNode, VirtualFrame frame, TruffleObject receiver) {
         try {
@@ -420,6 +437,7 @@ public final class ForeignAccess {
      * @param frame the frame that was called via
      *            {@link #execute(com.oracle.truffle.api.nodes.Node, com.oracle.truffle.api.frame.VirtualFrame, com.oracle.truffle.api.interop.TruffleObject, java.lang.Object...) }
      * @return read-only list of parameters passed to the frame
+     * @since 0.11
      */
     public static List<Object> getArguments(Frame frame) {
         final Object[] arr = frame.getArguments();
@@ -432,11 +450,13 @@ public final class ForeignAccess {
      * @param frame the frame that was called via
      *            {@link #execute(com.oracle.truffle.api.nodes.Node, com.oracle.truffle.api.frame.VirtualFrame, com.oracle.truffle.api.interop.TruffleObject, java.lang.Object...) }
      * @return the receiver used when invoking the frame
+     * @since 0.8 or earlier
      */
     public static TruffleObject getReceiver(Frame frame) {
         return (TruffleObject) frame.getArguments()[ForeignAccessArguments.RECEIVER_INDEX];
     }
 
+    /** @since 0.8 or earlier */
     @Override
     public String toString() {
         Object f;
@@ -470,6 +490,8 @@ public final class ForeignAccess {
      * that provides an AST snippet for a given {@link Message}. Rather than using this generic
      * {@code Factory}, consider implementing {@link Factory10} interface that captures the set of
      * messages each language should implement as of Truffle version 1.0.
+     * 
+     * @since 0.8 or earlier
      */
     public interface Factory {
 
@@ -479,6 +501,7 @@ public final class ForeignAccess {
          *
          * @param obj the object to check
          * @return true, if the object can be processed
+         * @since 0.8 or earlier
          */
         boolean canHandle(TruffleObject obj);
 
@@ -488,6 +511,7 @@ public final class ForeignAccess {
          * @param tree the {@code Message} that represents the access to a {@code TruffleObject}.
          * @return the AST snippet for accessing the {@code TruffleObject}, wrapped as a
          *         {@code CallTarget}.
+         * @since 0.8 or earlier
          */
         CallTarget accessMessage(Message tree);
     }
@@ -496,6 +520,7 @@ public final class ForeignAccess {
      * Specialized {@link Factory factory} that handles {@link Message messages} known as of release
      * 1.0 of Truffle API.
      *
+     * @since 0.8 or earlier
      */
     public interface Factory10 {
         /**
@@ -503,6 +528,7 @@ public final class ForeignAccess {
          *
          * @return call target to handle the message or <code>null</code> if this message is not
          *         supported
+         * @since 0.8 or earlier
          */
         CallTarget accessIsNull();
 
@@ -511,6 +537,7 @@ public final class ForeignAccess {
          *
          * @return call target to handle the message or <code>null</code> if this message is not
          *         supported
+         * @since 0.8 or earlier
          */
         CallTarget accessIsExecutable();
 
@@ -519,6 +546,7 @@ public final class ForeignAccess {
          *
          * @return call target to handle the message or <code>null</code> if this message is not
          *         supported
+         * @since 0.8 or earlier
          */
         CallTarget accessIsBoxed();
 
@@ -527,6 +555,7 @@ public final class ForeignAccess {
          *
          * @return call target to handle the message or <code>null</code> if this message is not
          *         supported
+         * @since 0.8 or earlier
          */
         CallTarget accessHasSize();
 
@@ -535,6 +564,7 @@ public final class ForeignAccess {
          *
          * @return call target to handle the message or <code>null</code> if this message is not
          *         supported
+         * @since 0.8 or earlier
          */
         CallTarget accessGetSize();
 
@@ -543,6 +573,7 @@ public final class ForeignAccess {
          *
          * @return call target to handle the message or <code>null</code> if this message is not
          *         supported
+         * @since 0.8 or earlier
          */
         CallTarget accessUnbox();
 
@@ -551,6 +582,7 @@ public final class ForeignAccess {
          *
          * @return call target to handle the message or <code>null</code> if this message is not
          *         supported
+         * @since 0.8 or earlier
          */
         CallTarget accessRead();
 
@@ -559,6 +591,7 @@ public final class ForeignAccess {
          *
          * @return call target to handle the message or <code>null</code> if this message is not
          *         supported
+         * @since 0.8 or earlier
          */
         CallTarget accessWrite();
 
@@ -568,6 +601,7 @@ public final class ForeignAccess {
          * @param argumentsLength number of parameters the messages has been created for
          * @return call target to handle the message or <code>null</code> if this message is not
          *         supported
+         * @since 0.8 or earlier
          */
         CallTarget accessExecute(int argumentsLength);
 
@@ -577,6 +611,7 @@ public final class ForeignAccess {
          * @param argumentsLength number of parameters the messages has been created for
          * @return call target to handle the message or <code>null</code> if this message is not
          *         supported
+         * @since 0.8 or earlier
          */
         CallTarget accessInvoke(int argumentsLength);
 
@@ -586,6 +621,7 @@ public final class ForeignAccess {
          * @param argumentsLength number of parameters the messages has been created for
          * @return call target to handle the message or <code>null</code> if this message is not
          *         supported
+         * @since 0.9
          */
         CallTarget accessNew(int argumentsLength);
 
@@ -595,6 +631,7 @@ public final class ForeignAccess {
          * @param unknown the message
          * @return call target to handle the message or <code>null</code> if this message is not
          *         supported
+         * @since 0.8 or earlier
          */
         CallTarget accessMessage(Message unknown);
     }

--- a/truffle/com.oracle.truffle.api.interop/src/com/oracle/truffle/api/interop/InteropException.java
+++ b/truffle/com.oracle.truffle.api.interop/src/com/oracle/truffle/api/interop/InteropException.java
@@ -27,6 +27,8 @@ package com.oracle.truffle.api.interop;
 /**
  * Common super class for exceptions that can occur when sending {@link Message interop messages}.
  * This super class is used to catch any kind of these exceptions.
+ * 
+ * @since 0.11
  */
 public abstract class InteropException extends Exception {
 

--- a/truffle/com.oracle.truffle.api.interop/src/com/oracle/truffle/api/interop/Message.java
+++ b/truffle/com.oracle.truffle.api.interop/src/com/oracle/truffle/api/interop/Message.java
@@ -33,6 +33,8 @@ import com.oracle.truffle.api.nodes.Node;
  * Inter-operability is based on sending messages. Standard messages are defined as as constants
  * like {@link #IS_NULL} or factory methods in this class, but one can always define their own,
  * specialized messages.
+ * 
+ * @since 0.8 or earlier
  */
 public abstract class Message {
     /**
@@ -41,6 +43,8 @@ public abstract class Message {
      * {@link #hashCode()} methods will operate on the class equivalence. Only then the subclass
      * will work properly with {@link #valueOf(java.lang.String)} and
      * {@link #toString(com.oracle.truffle.api.interop.Message)} methods.
+     * 
+     * @since 0.8 or earlier
      */
     protected Message() {
     }
@@ -65,6 +69,8 @@ public abstract class Message {
      * <p>
      * To achieve good performance it is essential to cache/keep reference to the
      * {@link Message#createNode() created node}.
+     * 
+     * @since 0.8 or earlier
      */
     public static final Message READ = Read.INSTANCE;
 
@@ -85,6 +91,8 @@ public abstract class Message {
      * <p>
      * To achieve good performance it is essential to cache/keep reference to the
      * {@link Message#createNode() created node}.
+     * 
+     * @since 0.8 or earlier
      */
     public static final Message UNBOX = Unbox.INSTANCE;
 
@@ -109,6 +117,8 @@ public abstract class Message {
      * <p>
      * To achieve good performance it is essential to cache/keep reference to the
      * {@link Message#createNode() created node}.
+     * 
+     * @since 0.8 or earlier
      */
     public static final Message WRITE = Write.INSTANCE;
 
@@ -156,6 +166,7 @@ public abstract class Message {
      *
      * @param argumentsLength number of parameters to pass to the target
      * @return execute message
+     * @since 0.8 or earlier
      */
     public static Message createExecute(int argumentsLength) {
         return Execute.create(Execute.EXECUTE, argumentsLength);
@@ -181,6 +192,8 @@ public abstract class Message {
      * <p>
      * To achieve good performance it is essential to cache/keep reference to the
      * {@link Message#createNode() created node}.
+     * 
+     * @since 0.8 or earlier
      */
     public static final Message IS_EXECUTABLE = IsExecutable.INSTANCE;
 
@@ -247,6 +260,7 @@ public abstract class Message {
      * @param argumentsLength number of parameters to pass to the target
      * @return message combining read & execute messages tailored for use with object oriented
      *         languages
+     * @since 0.8 or earlier
      */
     public static Message createInvoke(int argumentsLength) {
         return Execute.create(Execute.INVOKE, argumentsLength);
@@ -261,6 +275,7 @@ public abstract class Message {
      *
      * @param argumentsLength number of parameters to pass to the target
      * @return new instance message
+     * @since 0.8 or earlier
      */
     public static Message createNew(int argumentsLength) {
         return Execute.create(Execute.NEW, argumentsLength);
@@ -284,6 +299,8 @@ public abstract class Message {
      * <p>
      * To achieve good performance it is essential to cache/keep reference to the
      * {@link Message#createNode() created node}.
+     * 
+     * @since 0.8 or earlier
      */
     public static final Message IS_NULL = IsNull.INSTANCE;
 
@@ -292,6 +309,8 @@ public abstract class Message {
      * <p>
      * Calling {@link Factory#access(com.oracle.truffle.api.interop.Message) the target} created for
      * this message should yield value of {@link Boolean}.
+     * 
+     * @since 0.8 or earlier
      */
     public static final Message HAS_SIZE = HasSize.INSTANCE;
 
@@ -301,6 +320,8 @@ public abstract class Message {
      * <p>
      * Calling {@link Factory#access(com.oracle.truffle.api.interop.Message) the target} created for
      * this message should yield value of {@link Integer}.
+     * 
+     * @since 0.8 or earlier
      */
     public static final Message GET_SIZE = GetSize.INSTANCE;
 
@@ -320,6 +341,8 @@ public abstract class Message {
      * Calling {@link Factory#accessMessage(com.oracle.truffle.api.interop.Message) the target}
      * created for this message should yield value of {@link Boolean}. If the object responds with
      * {@link Boolean#TRUE}, it is safe to continue by sending it {@link #UNBOX} message.
+     * 
+     * @since 0.8 or earlier
      */
     public static final Message IS_BOXED = IsBoxed.INSTANCE;
 
@@ -331,6 +354,7 @@ public abstract class Message {
      *
      * @param message the object to compare to
      * @return true, if the structure of the message is that same as of <code>this</code> one.
+     * @since 0.8 or earlier
      */
     @Override
     public abstract boolean equals(Object message);
@@ -340,6 +364,7 @@ public abstract class Message {
      * implement <code>hashCode()</code>.
      *
      * @return hash code
+     * @since 0.8 or earlier
      */
     @Override
     public abstract int hashCode();
@@ -351,6 +376,7 @@ public abstract class Message {
      * @return node to be inserted into your AST and passed back to
      *         {@link ForeignAccess#execute(com.oracle.truffle.api.nodes.Node, com.oracle.truffle.api.frame.VirtualFrame, com.oracle.truffle.api.interop.TruffleObject, java.lang.Object[])}
      *         method.
+     * @since 0.8 or earlier
      */
     public final Node createNode() {
         return new ForeignObjectAccessHeadNode(this);
@@ -363,6 +389,7 @@ public abstract class Message {
      *
      * @param message the message to convert
      * @return canonical string representation
+     * @since 0.9
      */
     public static String toString(Message message) {
         if (Message.READ == message) {
@@ -403,6 +430,7 @@ public abstract class Message {
      * @param message canonical string representation of a message
      * @return the message
      * @throws IllegalArgumentException if the string does not represent known message
+     * @since 0.9
      */
     public static Message valueOf(String message) {
         try {

--- a/truffle/com.oracle.truffle.api.interop/src/com/oracle/truffle/api/interop/TruffleObject.java
+++ b/truffle/com.oracle.truffle.api.interop/src/com/oracle/truffle/api/interop/TruffleObject.java
@@ -27,12 +27,15 @@ package com.oracle.truffle.api.interop;
 /**
  * Interface for any entity of a Truffle guest language implementations that can be shared across
  * other language implementations.
+ * 
+ * @since 0.8 or earlier
  */
 public interface TruffleObject {
     /**
      * Provides the {@code ForeignAccessFactory} instance for this {@code TruffleObject} instance.
      *
      * @return the {@code ForeignAccessFactory} instance for this {@code TruffleObject} instance.
+     * @since 0.8 or earlier
      */
     ForeignAccess getForeignAccess();
 }

--- a/truffle/com.oracle.truffle.api.interop/src/com/oracle/truffle/api/interop/UnknownIdentifierException.java
+++ b/truffle/com.oracle.truffle.api.interop/src/com/oracle/truffle/api/interop/UnknownIdentifierException.java
@@ -28,6 +28,8 @@ package com.oracle.truffle.api.interop;
 /**
  * An exception thrown if a foreign access tries to access a property of a {@link TruffleObject}
  * that is not accessible.
+ * 
+ * @since 0.11
  */
 public final class UnknownIdentifierException extends InteropException {
 
@@ -44,6 +46,7 @@ public final class UnknownIdentifierException extends InteropException {
      * Returns the identifier that could not be accessed.
      *
      * @return the unaccessible identifier
+     * @since 0.11
      */
     public String getUnknownIdentifier() {
         return unknownIdentifier;
@@ -58,6 +61,7 @@ public final class UnknownIdentifierException extends InteropException {
      * @param unknownIdentifier the identifier that could not be accessed
      *
      * @return the exception
+     * @since 0.11
      */
     public static RuntimeException raise(String unknownIdentifier) {
         return silenceException(RuntimeException.class, new UnknownIdentifierException(unknownIdentifier));

--- a/truffle/com.oracle.truffle.api.interop/src/com/oracle/truffle/api/interop/UnsupportedMessageException.java
+++ b/truffle/com.oracle.truffle.api.interop/src/com/oracle/truffle/api/interop/UnsupportedMessageException.java
@@ -26,6 +26,8 @@ package com.oracle.truffle.api.interop;
 
 /**
  * An exception thrown if a {@link TruffleObject} does not support a {@link Message}.
+ * 
+ * @since 0.11
  */
 public final class UnsupportedMessageException extends InteropException {
 
@@ -42,6 +44,7 @@ public final class UnsupportedMessageException extends InteropException {
      * Returns the {@link Message} that was not supported by the {@link TruffleObject}.
      *
      * @return the unsupported message
+     * @since 0.11
      */
     public Message getUnsupportedMessage() {
         return message;
@@ -56,6 +59,7 @@ public final class UnsupportedMessageException extends InteropException {
      * @param message message that is not supported
      *
      * @return the exception
+     * @since 0.11
      */
     public static RuntimeException raise(Message message) {
         return silenceException(RuntimeException.class, new UnsupportedMessageException(message));

--- a/truffle/com.oracle.truffle.api.interop/src/com/oracle/truffle/api/interop/UnsupportedTypeException.java
+++ b/truffle/com.oracle.truffle.api.interop/src/com/oracle/truffle/api/interop/UnsupportedTypeException.java
@@ -28,6 +28,8 @@ package com.oracle.truffle.api.interop;
 /**
  * An exception thrown if a {@link TruffleObject} does not support the type of one ore more
  * arguments provided by a foreign access.
+ * 
+ * @since 0.11
  */
 public final class UnsupportedTypeException extends InteropException {
 
@@ -49,6 +51,7 @@ public final class UnsupportedTypeException extends InteropException {
      * {@link TruffleObject}.
      *
      * @return the unsupported arguments
+     * @since 0.11
      */
     public Object[] getSuppliedValues() {
         return suppliedValues;
@@ -63,6 +66,7 @@ public final class UnsupportedTypeException extends InteropException {
      * @param suppliedValues values that were not supported
      *
      * @return the exception
+     * @since 0.11
      */
     public static RuntimeException raise(Object[] suppliedValues) {
         return raise(null, suppliedValues);
@@ -78,6 +82,7 @@ public final class UnsupportedTypeException extends InteropException {
      * @param suppliedValues values that were not supported
      *
      * @return the exception
+     * @since 0.11
      */
     public static RuntimeException raise(Exception cause, Object[] suppliedValues) {
         return silenceException(RuntimeException.class, new UnsupportedTypeException(cause, suppliedValues));

--- a/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/BooleanLocation.java
+++ b/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/BooleanLocation.java
@@ -24,31 +24,38 @@
  */
 package com.oracle.truffle.api.object;
 
+/** @since 0.8 or earlier */
 public interface BooleanLocation extends TypedLocation {
     /**
      * @see #get(DynamicObject, Shape)
+     * @since 0.8 or earlier
      */
     boolean getBoolean(DynamicObject store, Shape shape);
 
     /**
      * @see #get(DynamicObject, boolean)
+     * @since 0.8 or earlier
      */
     boolean getBoolean(DynamicObject store, boolean condition);
 
     /**
      * @see #set(DynamicObject, Object)
+     * @since 0.8 or earlier
      */
     void setBoolean(DynamicObject store, boolean value) throws FinalLocationException;
 
     /**
      * @see #set(DynamicObject, Object, Shape)
+     * @since 0.8 or earlier
      */
     void setBoolean(DynamicObject store, boolean value, Shape shape) throws FinalLocationException;
 
     /**
      * @see #set(DynamicObject, Object, Shape, Shape)
+     * @since 0.8 or earlier
      */
     void setBoolean(DynamicObject store, boolean value, Shape oldShape, Shape newShape);
 
+    /** @since 0.8 or earlier */
     Class<Boolean> getType();
 }

--- a/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/DoubleLocation.java
+++ b/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/DoubleLocation.java
@@ -24,31 +24,38 @@
  */
 package com.oracle.truffle.api.object;
 
+/** @since 0.8 or earlier */
 public interface DoubleLocation extends TypedLocation {
     /**
      * @see #get(DynamicObject, Shape)
+     * @since 0.8 or earlier
      */
     double getDouble(DynamicObject store, Shape shape);
 
     /**
      * @see #get(DynamicObject, boolean)
+     * @since 0.8 or earlier
      */
     double getDouble(DynamicObject store, boolean condition);
 
     /**
      * @see #set(DynamicObject, Object)
+     * @since 0.8 or earlier
      */
     void setDouble(DynamicObject store, double value) throws FinalLocationException;
 
     /**
      * @see #set(DynamicObject, Object, Shape)
+     * @since 0.8 or earlier
      */
     void setDouble(DynamicObject store, double value, Shape shape) throws FinalLocationException;
 
     /**
      * @see #set(DynamicObject, Object, Shape, Shape)
+     * @since 0.8 or earlier
      */
     void setDouble(DynamicObject store, double value, Shape oldShape, Shape newShape);
 
+    /** @since 0.8 or earlier */
     Class<Double> getType();
 }

--- a/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/DynamicObject.java
+++ b/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/DynamicObject.java
@@ -31,10 +31,22 @@ import com.oracle.truffle.api.interop.TruffleObject;
  * Represents an object members of which can be dynamically added and removed at run time.
  *
  * @see Shape
+ * @since 0.8 or earlier
  */
 public abstract class DynamicObject implements TypedObject, TruffleObject {
+
+    /**
+     * Constructor for subclasses.
+     *
+     * @since 0.8 or earlier
+     */
+    protected DynamicObject() {
+    }
+
     /**
      * Get the object's current shape.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract Shape getShape();
 
@@ -43,6 +55,7 @@ public abstract class DynamicObject implements TypedObject, TruffleObject {
      *
      * @param key property identifier
      * @return property value or {@code null} if object has no such property
+     * @since 0.8 or earlier
      */
     public final Object get(Object key) {
         return get(key, null);
@@ -54,6 +67,7 @@ public abstract class DynamicObject implements TypedObject, TruffleObject {
      * @param key property identifier
      * @param defaultValue return value if property is not found
      * @return property value or defaultValue if object has no such property
+     * @since 0.8 or earlier
      */
     public abstract Object get(Object key, Object defaultValue);
 
@@ -63,11 +77,14 @@ public abstract class DynamicObject implements TypedObject, TruffleObject {
      * @param key property identifier
      * @param value value to be set
      * @return {@code true} if successful or {@code false} if property not found
+     * @since 0.8 or earlier
      */
     public abstract boolean set(Object key, Object value);
 
     /**
      * Returns {@code true} if this object contains a property with the given key.
+     * 
+     * @since 0.8 or earlier
      */
     public final boolean containsKey(Object key) {
         return getShape().getProperty(key) != null;
@@ -78,6 +95,7 @@ public abstract class DynamicObject implements TypedObject, TruffleObject {
      *
      * @param key property identifier
      * @param value value to be set
+     * @since 0.8 or earlier
      */
     public final void define(Object key, Object value) {
         define(key, value, 0);
@@ -89,6 +107,7 @@ public abstract class DynamicObject implements TypedObject, TruffleObject {
      * @param key property identifier
      * @param value value to be set
      * @param flags flags to be set
+     * @since 0.8 or earlier
      */
     public abstract void define(Object key, Object value, int flags);
 
@@ -99,6 +118,7 @@ public abstract class DynamicObject implements TypedObject, TruffleObject {
      * @param value value to be set
      * @param flags flags to be set
      * @param locationFactory factory function that creates a location for a given shape and value
+     * @since 0.8 or earlier
      */
     public abstract void define(Object key, Object value, int flags, LocationFactory locationFactory);
 
@@ -107,16 +127,21 @@ public abstract class DynamicObject implements TypedObject, TruffleObject {
      *
      * @param key property identifier
      * @return {@code true} if successful or {@code false} if property not found
+     * @since 0.8 or earlier
      */
     public abstract boolean delete(Object key);
 
     /**
      * Returns the number of properties in this object.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract int size();
 
     /**
      * Returns {@code true} if this object contains no properties.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract boolean isEmpty();
 
@@ -125,6 +150,7 @@ public abstract class DynamicObject implements TypedObject, TruffleObject {
      *
      * @param oldShape the object's current shape (must equal {@link #getShape()})
      * @param newShape the new shape to be set
+     * @since 0.8 or earlier
      */
     public abstract void setShapeAndGrow(Shape oldShape, Shape newShape);
 
@@ -133,6 +159,7 @@ public abstract class DynamicObject implements TypedObject, TruffleObject {
      *
      * @param oldShape the object's current shape (must equal {@link #getShape()})
      * @param newShape the new shape to be set
+     * @since 0.8 or earlier
      */
     public abstract void setShapeAndResize(Shape oldShape, Shape newShape);
 
@@ -140,6 +167,7 @@ public abstract class DynamicObject implements TypedObject, TruffleObject {
      * Ensure object shape is up-to-date.
      *
      * @return {@code true} if shape has changed
+     * @since 0.8 or earlier
      */
     public abstract boolean updateShape();
 
@@ -147,6 +175,7 @@ public abstract class DynamicObject implements TypedObject, TruffleObject {
      * Create a shallow copy of this object.
      *
      * @param currentShape the object's current shape (must equal {@link #getShape()})
+     * @since 0.8 or earlier
      */
     public abstract DynamicObject copy(Shape currentShape);
 }

--- a/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/DynamicObjectFactory.java
+++ b/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/DynamicObjectFactory.java
@@ -29,6 +29,7 @@ package com.oracle.truffle.api.object;
  * instance properties initialized to the values passed to {@link #newInstance(Object...)}.
  *
  * @see Shape#createFactory()
+ * @since 0.8 or earlier
  */
 public interface DynamicObjectFactory {
     /**
@@ -37,11 +38,13 @@ public interface DynamicObjectFactory {
      *
      * @param initialValues the values to initialize the object with, in order.
      * @return a new {@link DynamicObject} initialized with the provided values.
+     * @since 0.8 or earlier
      */
     DynamicObject newInstance(Object... initialValues);
 
     /**
      * @return the shape of objects created by this factory.
+     * @since 0.8 or earlier
      */
     Shape getShape();
 }

--- a/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/FinalLocationException.java
+++ b/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/FinalLocationException.java
@@ -28,7 +28,17 @@ import com.oracle.truffle.api.nodes.SlowPathException;
 
 /**
  * This exception is thrown on an attempt to assign a value to a final location.
+ * 
+ * @since 0.8 or earlier
  */
 public final class FinalLocationException extends SlowPathException {
     private static final long serialVersionUID = -30188494510914293L;
+
+    /**
+     * Default constructor.
+     * 
+     * @since 0.8 or earlier
+     */
+    public FinalLocationException() {
+    }
 }

--- a/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/HiddenKey.java
+++ b/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/HiddenKey.java
@@ -27,18 +27,23 @@ package com.oracle.truffle.api.object;
 /**
  * A unique key to be used for private object fields; excluded from enumeration and compared by
  * object identity.
+ * 
+ * @since 0.8 or earlier
  */
 public final class HiddenKey {
     private final String name;
 
+    /** @since 0.8 or earlier */
     public HiddenKey(String name) {
         this.name = name;
     }
 
+    /** @since 0.8 or earlier */
     public String getName() {
         return name;
     }
 
+    /** @since 0.8 or earlier */
     @Override
     public String toString() {
         return name;

--- a/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/IncompatibleLocationException.java
+++ b/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/IncompatibleLocationException.java
@@ -28,7 +28,17 @@ import com.oracle.truffle.api.nodes.SlowPathException;
 
 /**
  * This exception is thrown on an attempt to assign an incompatible value to a location.
+ * 
+ * @since 0.8 or earlier
  */
 public final class IncompatibleLocationException extends SlowPathException {
     private static final long serialVersionUID = -7734865392357341789L;
+
+    /**
+     * Default constructor.
+     * 
+     * @since 0.8 or earlier
+     */
+    public IncompatibleLocationException() {
+    }
 }

--- a/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/IntLocation.java
+++ b/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/IntLocation.java
@@ -24,31 +24,38 @@
  */
 package com.oracle.truffle.api.object;
 
+/** @since 0.8 or earlier */
 public interface IntLocation extends TypedLocation {
     /**
      * @see #get(DynamicObject, Shape)
+     * @since 0.8 or earlier
      */
     int getInt(DynamicObject store, Shape shape);
 
     /**
      * @see #get(DynamicObject, boolean)
+     * @since 0.8 or earlier
      */
     int getInt(DynamicObject store, boolean condition);
 
     /**
      * @see #set(DynamicObject, Object)
+     * @since 0.8 or earlier
      */
     void setInt(DynamicObject store, int value) throws FinalLocationException;
 
     /**
      * @see #set(DynamicObject, Object, Shape)
+     * @since 0.8 or earlier
      */
     void setInt(DynamicObject store, int value, Shape shape) throws FinalLocationException;
 
     /**
      * @see #set(DynamicObject, Object, Shape, Shape)
+     * @since 0.8 or earlier
      */
     void setInt(DynamicObject store, int value, Shape oldShape, Shape newShape);
 
+    /** @since 0.8 or earlier */
     Class<Integer> getType();
 }

--- a/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/Layout.java
+++ b/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/Layout.java
@@ -33,22 +33,39 @@ import com.oracle.truffle.api.object.Shape.Allocator;
  * Describes layout and behavior of a {@link DynamicObject} subclass and is used to create shapes.
  *
  * An object may change its shape but only to shapes of the same layout.
+ * 
+ * @since 0.8 or earlier
  */
 public abstract class Layout {
+    /** @since 0.8 or earlier */
     public static final String OPTION_PREFIX = "truffle.object.";
 
     private static final LayoutFactory LAYOUT_FACTORY = loadLayoutFactory();
 
     /**
+     * Constructor for subclasses.
+     * 
+     * @since 0.8 or earlier
+     */
+    protected Layout() {
+    }
+
+    /**
      * Specifies the allowed implicit casts between primitive types without losing type information.
+     * 
+     * @since 0.8 or earlier
      */
     public enum ImplicitCast {
+        /** @since 0.8 or earlier */
         IntToDouble,
-        IntToLong,
+        /** @since 0.8 or earlier */
+        IntToLong
     }
 
     /**
      * Creates a new {@link Builder}.
+     * 
+     * @since 0.8 or earlier
      */
     public static Builder newLayout() {
         return new Builder();
@@ -56,19 +73,24 @@ public abstract class Layout {
 
     /**
      * Equivalent to {@code Layout.newLayout().build()}.
+     * 
+     * @since 0.8 or earlier
      */
     public static Layout createLayout() {
         return newLayout().build();
     }
 
+    /** @since 0.8 or earlier */
     public abstract DynamicObject newInstance(Shape shape);
 
+    /** @since 0.8 or earlier */
     public abstract Class<? extends DynamicObject> getType();
 
     /**
      * Create a root shape.
      *
      * @param objectType that describes the object instance with this shape.
+     * @since 0.8 or earlier
      */
     public abstract Shape createShape(ObjectType objectType);
 
@@ -77,6 +99,7 @@ public abstract class Layout {
      *
      * @param objectType that describes the object instance with this shape.
      * @param sharedData for language-specific use
+     * @since 0.8 or earlier
      */
     public abstract Shape createShape(ObjectType objectType, Object sharedData);
 
@@ -87,14 +110,18 @@ public abstract class Layout {
      * @param sharedData for language-specific use
      * @param id for language-specific use
      * @return new instance of a shape
+     * @since 0.8 or earlier
      */
     public abstract Shape createShape(ObjectType objectType, Object sharedData, int id);
 
     /**
      * Create an allocator for static property creation. Reserves all array extension slots.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract Allocator createAllocator();
 
+    /** @since 0.8 or earlier */
     protected static LayoutFactory getFactory() {
         return LAYOUT_FACTORY;
     }
@@ -137,6 +164,7 @@ public abstract class Layout {
      * Layout builder.
      *
      * @see Layout
+     * @since 0.8 or earlier
      */
     public static final class Builder {
         private EnumSet<ImplicitCast> allowedImplicitCasts;
@@ -151,6 +179,8 @@ public abstract class Layout {
 
         /**
          * Build {@link Layout} from the configuration in this builder.
+         * 
+         * @since 0.8 or earlier
          */
         public Layout build() {
             return Layout.getFactory().createLayout(this);
@@ -160,6 +190,7 @@ public abstract class Layout {
          * Set the allowed implicit casts in this layout.
          *
          * @see Layout.ImplicitCast
+         * @since 0.8 or earlier
          */
         public Builder setAllowedImplicitCasts(EnumSet<ImplicitCast> allowedImplicitCasts) {
             this.allowedImplicitCasts = allowedImplicitCasts;
@@ -170,6 +201,7 @@ public abstract class Layout {
          * Add an allowed implicit cast in this layout.
          *
          * @see Layout.ImplicitCast
+         * @since 0.8 or earlier
          */
         public Builder addAllowedImplicitCast(ImplicitCast allowedImplicitCast) {
             this.allowedImplicitCasts.add(allowedImplicitCast);
@@ -178,6 +210,8 @@ public abstract class Layout {
 
         /**
          * If {@code true}, try to keep properties with polymorphic primitive types unboxed.
+         * 
+         * @since 0.8 or earlier
          */
         public Builder setPolymorphicUnboxing(boolean polymorphicUnboxing) {
             this.polymorphicUnboxing = polymorphicUnboxing;
@@ -185,10 +219,12 @@ public abstract class Layout {
         }
     }
 
+    /** @since 0.8 or earlier */
     protected static EnumSet<ImplicitCast> getAllowedImplicitCasts(Builder builder) {
         return builder.allowedImplicitCasts;
     }
 
+    /** @since 0.8 or earlier */
     protected static boolean getPolymorphicUnboxing(Builder builder) {
         return builder.polymorphicUnboxing;
     }

--- a/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/LayoutFactory.java
+++ b/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/LayoutFactory.java
@@ -26,13 +26,19 @@ package com.oracle.truffle.api.object;
 
 /**
  * Implementation class.
+ * 
+ * @since 0.8 or earlier
  */
 public interface LayoutFactory {
+    /** @since 0.8 or earlier */
     Layout createLayout(Layout.Builder layoutBuilder);
 
+    /** @since 0.8 or earlier */
     Property createProperty(Object id, Location location);
 
+    /** @since 0.8 or earlier */
     Property createProperty(Object id, Location location, int flags);
 
+    /** @since 0.8 or earlier */
     int getPriority();
 }

--- a/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/Location.java
+++ b/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/Location.java
@@ -32,13 +32,24 @@ import com.oracle.truffle.api.CompilerDirectives;
  * @see Shape
  * @see Property
  * @see DynamicObject
+ * @since 0.8 or earlier
  */
 public abstract class Location {
+    /**
+     * Constructor for subclasses.
+     * 
+     * @since 0.8 or earlier
+     */
+    protected Location() {
+    }
+
+    /** @since 0.8 or earlier */
     protected static IncompatibleLocationException incompatibleLocation() throws IncompatibleLocationException {
         CompilerDirectives.transferToInterpreterAndInvalidate();
         throw new IncompatibleLocationException();
     }
 
+    /** @since 0.8 or earlier */
     protected static FinalLocationException finalLocation() throws FinalLocationException {
         CompilerDirectives.transferToInterpreterAndInvalidate();
         throw new FinalLocationException();
@@ -48,6 +59,7 @@ public abstract class Location {
      * Get object value as object at this location in store.
      *
      * @param shape the current shape of the object, which must contain this location
+     * @since 0.8 or earlier
      */
     public final Object get(DynamicObject store, Shape shape) {
         return get(store, checkShape(store, shape));
@@ -59,6 +71,7 @@ public abstract class Location {
      *
      * @param condition the result of a shape check or {@code false}
      * @see #get(DynamicObject, Shape)
+     * @since 0.8 or earlier
      */
     public Object get(DynamicObject store, boolean condition) {
         return getInternal(store);
@@ -67,6 +80,7 @@ public abstract class Location {
     /**
      * Get object value as object at this location in store.
      *
+     * @since 0.8 or earlier
      */
     public final Object get(DynamicObject store) {
         return get(store, false);
@@ -78,6 +92,7 @@ public abstract class Location {
      * @param shape the current shape of the storage object
      * @throws IncompatibleLocationException for storage type invalidations
      * @throws FinalLocationException for effectively final fields
+     * @since 0.8 or earlier
      */
     public void set(DynamicObject store, Object value, Shape shape) throws IncompatibleLocationException, FinalLocationException {
         setInternal(store, value);
@@ -89,6 +104,7 @@ public abstract class Location {
      * @param oldShape the shape before the transition
      * @param newShape new shape after the transition
      * @throws IncompatibleLocationException if value is of non-assignable type
+     * @since 0.8 or earlier
      */
     public final void set(DynamicObject store, Object value, Shape oldShape, Shape newShape) throws IncompatibleLocationException {
         if (canStore(value)) {
@@ -108,11 +124,13 @@ public abstract class Location {
      *
      * @throws IncompatibleLocationException for storage type invalidations
      * @throws FinalLocationException for effectively final fields
+     * @since 0.8 or earlier
      */
     public final void set(DynamicObject store, Object value) throws IncompatibleLocationException, FinalLocationException {
         set(store, value, null);
     }
 
+    /** @since 0.8 or earlier */
     protected abstract Object getInternal(DynamicObject store);
 
     /**
@@ -121,6 +139,7 @@ public abstract class Location {
      * with predefined properties.
      *
      * @throws IncompatibleLocationException if value is of non-assignable type
+     * @since 0.8 or earlier
      */
     protected abstract void setInternal(DynamicObject store, Object value) throws IncompatibleLocationException;
 
@@ -129,6 +148,7 @@ public abstract class Location {
      *
      * @param store the receiver object
      * @param value the value in question
+     * @since 0.8 or earlier
      */
     public boolean canSet(DynamicObject store, Object value) {
         return canStore(value);
@@ -138,6 +158,7 @@ public abstract class Location {
      * Returns {@code true} if the location can be set to the value.
      *
      * @param value the value in question
+     * @since 0.8 or earlier
      */
     public boolean canSet(Object value) {
         return canStore(value);
@@ -150,6 +171,7 @@ public abstract class Location {
      * false.
      *
      * @param value the value in question
+     * @since 0.8 or earlier
      */
     public boolean canStore(Object value) {
         return true;
@@ -157,6 +179,8 @@ public abstract class Location {
 
     /**
      * Returns {@code true} if this is a final location, i.e. readonly once set.
+     * 
+     * @since 0.8 or earlier
      */
     public boolean isFinal() {
         return false;
@@ -164,25 +188,33 @@ public abstract class Location {
 
     /**
      * Returns {@code true} if this is an immutable constant location.
+     * 
+     * @since 0.8 or earlier
      */
     public boolean isConstant() {
         return false;
     }
 
-    /*
+    /**
      * Abstract to force overriding.
+     * 
+     * @since 0.8 or earlier
      */
     @Override
     public abstract int hashCode();
 
-    /*
+    /**
      * Abstract to force overriding.
+     * 
+     * @since 0.8 or earlier
      */
     @Override
     public abstract boolean equals(Object obj);
 
     /**
      * Equivalent to {@link Shape#check(DynamicObject)}.
+     * 
+     * @since 0.8 or earlier
      */
     protected static boolean checkShape(DynamicObject store, Shape shape) {
         return store.getShape() == shape;

--- a/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/LocationFactory.java
+++ b/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/LocationFactory.java
@@ -28,7 +28,9 @@ package com.oracle.truffle.api.object;
  * This interface allows to provide a custom location for a given shape and value.
  *
  * @see DynamicObject#define(Object, Object, int, LocationFactory)
+ * @since 0.8 or earlier
  */
 public interface LocationFactory {
+    /** @since 0.8 or earlier */
     Location createLocation(Shape shape, Object value);
 }

--- a/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/LocationModifier.java
+++ b/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/LocationModifier.java
@@ -27,14 +27,20 @@ package com.oracle.truffle.api.object;
 /**
  * Location modifiers specify the desired semantics and allowed use of a location to be allocated by
  * {@link Shape.Allocator}.
+ * 
+ * @since 0.8 or earlier
  */
 public enum LocationModifier {
     /**
      * Location is going to be set only during object initialization.
+     * 
+     * @since 0.8 or earlier
      */
     Final,
     /**
      * Location is never set to {@code null} and initialized before it is read.
+     * 
+     * @since 0.8 or earlier
      */
-    NonNull,
+    NonNull
 }

--- a/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/LongLocation.java
+++ b/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/LongLocation.java
@@ -24,31 +24,38 @@
  */
 package com.oracle.truffle.api.object;
 
+/** @since 0.8 or earlier */
 public interface LongLocation extends TypedLocation {
     /**
      * @see #get(DynamicObject, Shape)
+     * @since 0.8 or earlier
      */
     long getLong(DynamicObject store, Shape shape);
 
     /**
      * @see #get(DynamicObject, boolean)
+     * @since 0.8 or earlier
      */
     long getLong(DynamicObject store, boolean condition);
 
     /**
      * @see #set(DynamicObject, Object)
+     * @since 0.8 or earlier
      */
     void setLong(DynamicObject store, long value) throws FinalLocationException;
 
     /**
      * @see #set(DynamicObject, Object, Shape)
+     * @since 0.8 or earlier
      */
     void setLong(DynamicObject store, long value, Shape shape) throws FinalLocationException;
 
     /**
      * @see #set(DynamicObject, Object, Shape, Shape)
+     * @since 0.8 or earlier
      */
     void setLong(DynamicObject store, long value, Shape oldShape, Shape newShape);
 
+    /** @since 0.8 or earlier */
     Class<Long> getType();
 }

--- a/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/ObjectLocation.java
+++ b/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/ObjectLocation.java
@@ -24,11 +24,15 @@
  */
 package com.oracle.truffle.api.object;
 
+/** @since 0.8 or earlier */
 public interface ObjectLocation extends TypedLocation {
+    /** @since 0.8 or earlier */
     Class<? extends Object> getType();
 
     /**
      * If {@code true}, this location does not accept {@code null} values.
+     * 
+     * @since 0.8 or earlier
      */
     boolean isNonNull();
 }

--- a/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/ObjectType.java
+++ b/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/ObjectType.java
@@ -32,10 +32,22 @@ import com.oracle.truffle.api.interop.TruffleObject;
 
 /**
  * An extensible object type descriptor for {@link DynamicObject}s.
+ * 
+ * @since 0.8 or earlier
  */
 public class ObjectType {
     /**
+     * Default constructor.
+     * 
+     * @since 0.8 or earlier
+     */
+    public ObjectType() {
+    }
+
+    /**
      * Delegate method for {@link DynamicObject#equals(Object)}.
+     * 
+     * @since 0.8 or earlier
      */
     public boolean equals(DynamicObject object, Object other) {
         return object == other;
@@ -43,6 +55,8 @@ public class ObjectType {
 
     /**
      * Delegate method for {@link DynamicObject#hashCode()}.
+     * 
+     * @since 0.8 or earlier
      */
     public int hashCode(DynamicObject object) {
         return System.identityHashCode(object);
@@ -50,6 +64,8 @@ public class ObjectType {
 
     /**
      * Delegate method for {@link DynamicObject#toString()}.
+     * 
+     * @since 0.8 or earlier
      */
     @TruffleBoundary
     public String toString(DynamicObject object) {
@@ -60,11 +76,13 @@ public class ObjectType {
      * Creates a data object to be associated with a newly created shape.
      *
      * @param shape the shape for which to create the data object
+     * @since 0.8 or earlier
      */
     public Object createShapeData(Shape shape) {
         return null;
     }
 
+    /** @since 0.8 or earlier */
     @Deprecated
     public ForeignAccess getForeignAccessFactory() {
         return ForeignAccess.create(new com.oracle.truffle.api.interop.ForeignAccess.Factory() {
@@ -83,6 +101,7 @@ public class ObjectType {
      * Create a {@link ForeignAccess} to access a specific {@link DynamicObject}.
      *
      * @param object the object to be accessed
+     * @since 0.8 or earlier
      */
     public ForeignAccess getForeignAccessFactory(DynamicObject object) {
         return getForeignAccessFactory();

--- a/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/Property.java
+++ b/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/Property.java
@@ -27,8 +27,15 @@ package com.oracle.truffle.api.object;
 /**
  * Property objects represent the mapping between property identifiers (keys) and storage locations.
  * Optionally, properties may have metadata attached to them.
+ * 
+ * @since 0.8 or earlier
  */
 public abstract class Property {
+    /**
+     * Constructor for subclasses.
+     * 
+     * @since 0.8 or earlier
+     */
     protected Property() {
     }
 
@@ -39,6 +46,7 @@ public abstract class Property {
      * @param location location of the property
      * @param flags for language-specific use
      * @return new instance of the property
+     * @since 0.8 or earlier
      */
     public static Property create(Object key, Location location, int flags) {
         return Layout.getFactory().createProperty(key, location, flags);
@@ -46,11 +54,15 @@ public abstract class Property {
 
     /**
      * Get property identifier.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract Object getKey();
 
     /**
      * Get property flags, which are free for language-specific use.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract int getFlags();
 
@@ -58,6 +70,7 @@ public abstract class Property {
      * Change the property's location.
      *
      * @return a Property with the new location (or {@code this} if the location is unchanged).
+     * @since 0.8 or earlier
      */
     public abstract Property relocate(Location newLocation);
 
@@ -67,6 +80,7 @@ public abstract class Property {
      * @param store the store that this property resides in
      * @param shape the current shape of the object, which must contain this location
      * @see DynamicObject#get(Object, Object)
+     * @since 0.8 or earlier
      */
     public abstract Object get(DynamicObject store, Shape shape);
 
@@ -77,6 +91,7 @@ public abstract class Property {
      * @param condition the result of a shape check or {@code false}
      * @see DynamicObject#get(Object, Object)
      * @see #get(DynamicObject, Shape)
+     * @since 0.8 or earlier
      */
     public abstract Object get(DynamicObject store, boolean condition);
 
@@ -91,6 +106,7 @@ public abstract class Property {
      * @throws IncompatibleLocationException if the value is incompatible with the property location
      * @throws FinalLocationException if the location is final and values differ
      * @see DynamicObject#set(Object, Object)
+     * @since 0.8 or earlier
      */
     public abstract void set(DynamicObject store, Object value, Shape shape) throws IncompatibleLocationException, FinalLocationException;
 
@@ -100,12 +116,15 @@ public abstract class Property {
      * Automatically relocates the property if the value cannot be assigned to its current location.
      *
      * @param shape the current shape of the object or {@code null}
+     * @since 0.8 or earlier
      */
     public abstract void setGeneric(DynamicObject store, Object value, Shape shape);
 
     /**
      * Like {@link #set(DynamicObject, Object, Shape)}, but throws an {@link IllegalStateException}
      * instead.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract void setSafe(DynamicObject store, Object value, Shape shape);
 
@@ -114,6 +133,7 @@ public abstract class Property {
      *
      * @param store the store that this property resides in
      * @param value the value to assign
+     * @since 0.8 or earlier
      */
     public abstract void setInternal(DynamicObject store, Object value);
 
@@ -128,6 +148,7 @@ public abstract class Property {
      * @param oldShape the shape before the transition
      * @param newShape the shape after the transition
      * @throws IncompatibleLocationException if the value is incompatible with the property location
+     * @since 0.8 or earlier
      */
     public abstract void set(DynamicObject store, Object value, Shape oldShape, Shape newShape) throws IncompatibleLocationException;
 
@@ -141,6 +162,7 @@ public abstract class Property {
      * @param value the value to assign
      * @param oldShape the shape before the transition
      * @param newShape the shape after the transition
+     * @since 0.8 or earlier
      */
     public abstract void setGeneric(DynamicObject store, Object value, Shape oldShape, Shape newShape);
 
@@ -154,16 +176,21 @@ public abstract class Property {
      * @param value the value to assign
      * @param oldShape the shape before the transition
      * @param newShape the shape after the transition
+     * @since 0.8 or earlier
      */
     public abstract void setSafe(DynamicObject store, Object value, Shape oldShape, Shape newShape);
 
     /**
      * Returns {@code true} if this property and some other property have the same key and flags.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract boolean isSame(Property other);
 
     /**
      * Get the property location.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract Location getLocation();
 
@@ -171,15 +198,20 @@ public abstract class Property {
      * Is this property hidden from iteration.
      *
      * @see HiddenKey
+     * @since 0.8 or earlier
      */
     public abstract boolean isHidden();
 
+    /** @since 0.8 or earlier */
     public abstract boolean isShadow();
 
     /**
      * Create a copy of the property with the given flags.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract Property copyWithFlags(int newFlags);
 
+    /** @since 0.8 or earlier */
     public abstract Property copyWithRelocatable(boolean newRelocatable);
 }

--- a/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/Shape.java
+++ b/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/Shape.java
@@ -39,13 +39,23 @@ import java.util.List;
  * @see DynamicObject
  * @see Property
  * @see Location
+ * @since 0.8 or earlier
  */
 public abstract class Shape {
+    /**
+     * Constructor for subclasses.
+     * 
+     * @since 0.8 or earlier
+     */
+    protected Shape() {
+    }
+
     /**
      * Get a property entry by key.
      *
      * @param key the identifier to look up
      * @return a Property object, or null if not found
+     * @since 0.8 or earlier
      */
     public abstract Property getProperty(Object key);
 
@@ -54,6 +64,7 @@ public abstract class Shape {
      *
      * @param property the property to add
      * @return the new Shape
+     * @since 0.8 or earlier
      */
     public abstract Shape addProperty(Property property);
 
@@ -61,6 +72,7 @@ public abstract class Shape {
      * Add or change property in the map, yielding a new or cached Shape object.
      *
      * @return the shape after defining the property
+     * @since 0.8 or earlier
      */
     public abstract Shape defineProperty(Object key, Object value, int flags);
 
@@ -68,11 +80,14 @@ public abstract class Shape {
      * Add or change property in the map, yielding a new or cached Shape object.
      *
      * @return the shape after defining the property
+     * @since 0.8 or earlier
      */
     public abstract Shape defineProperty(Object key, Object value, int flags, LocationFactory locationFactory);
 
     /**
      * An {@link Iterable} over the shape's properties in insertion order.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract Iterable<Property> getProperties();
 
@@ -80,6 +95,7 @@ public abstract class Shape {
      * Get a list of properties that this Shape stores.
      *
      * @return list of properties
+     * @since 0.8 or earlier
      */
     public abstract List<Property> getPropertyList(Pred<Property> filter);
 
@@ -87,6 +103,7 @@ public abstract class Shape {
      * Get a list of all properties that this Shape stores.
      *
      * @return list of properties
+     * @since 0.8 or earlier
      */
     public abstract List<Property> getPropertyList();
 
@@ -95,148 +112,205 @@ public abstract class Shape {
      *
      * @param ascending desired order ({@code true} for insertion order, {@code false} for reverse
      *            insertion order)
+     * @since 0.8 or earlier
      */
     public abstract List<Property> getPropertyListInternal(boolean ascending);
 
     /**
      * Get a filtered list of property keys in insertion order.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract List<Object> getKeyList(Pred<Property> filter);
 
     /**
      * Get a list of all property keys in insertion order.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract List<Object> getKeyList();
 
     /**
      * Get all property keys in insertion order.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract Iterable<Object> getKeys();
 
     /**
      * Get an assumption that the shape is valid.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract Assumption getValidAssumption();
 
     /**
      * Check whether this shape is valid.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract boolean isValid();
 
     /**
      * Get an assumption that the shape is a leaf.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract Assumption getLeafAssumption();
 
     /**
      * Check whether this shape is a leaf in the transition graph, i.e. transitionless.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract boolean isLeaf();
 
     /**
      * @return the parent shape or {@code null} if none.
+     * @since 0.8 or earlier
      */
     public abstract Shape getParent();
 
     /**
      * Check whether the shape has a property with the given key.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract boolean hasProperty(Object key);
 
     /**
      * Remove the given property from the shape.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract Shape removeProperty(Property property);
 
     /**
      * Replace a property in the shape.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract Shape replaceProperty(Property oldProperty, Property newProperty);
 
     /**
      * Get the last added property.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract Property getLastProperty();
 
+    /** @since 0.8 or earlier */
     public abstract int getId();
 
     /**
      * Append the property, relocating it to the next allocated location.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract Shape append(Property oldProperty);
 
     /**
      * Obtain an {@link Allocator} instance for the purpose of allocating locations.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract Allocator allocator();
 
     /**
      * Get number of properties in this shape.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract int getPropertyCount();
 
     /**
      * Get the shape's operations.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract ObjectType getObjectType();
 
     /**
      * Get the root shape.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract Shape getRoot();
 
     /**
      * Check whether this shape is identical to the given shape.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract boolean check(DynamicObject subject);
 
     /**
      * Get the shape's layout.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract Layout getLayout();
 
     /**
      * Get the shape's custom data.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract Object getData();
 
     /**
      * Get the shape's shared data.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract Object getSharedData();
 
     /**
      * Query whether the shape has a transition with the given key.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract boolean hasTransitionWithKey(Object key);
 
     /**
      * Clone off a separate shape with new shared data.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract Shape createSeparateShape(Object sharedData);
 
     /**
      * Change the shape's type, yielding a new shape.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract Shape changeType(ObjectType newOps);
 
     /**
      * Reserve the primitive extension array field.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract Shape reservePrimitiveExtensionArray();
 
     /**
      * Create a new {@link DynamicObject} instance with this shape.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract DynamicObject newInstance();
 
     /**
      * Create a {@link DynamicObjectFactory} for creating instances of this shape.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract DynamicObjectFactory createFactory();
 
     /**
      * Get mutex object shared by related shapes, i.e. shapes with a common root.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract Object getMutex();
 
@@ -245,6 +319,7 @@ public abstract class Shape {
      *
      * @param other Shape to compare to
      * @return true if one shape is an upcast of the other, or the Shapes are equal
+     * @since 0.8 or earlier
      */
     public abstract boolean isRelated(Shape other);
 
@@ -253,19 +328,30 @@ public abstract class Shape {
      * store at least the values of both shapes.
      *
      * @return this, other, or a new shape that is compatible with both shapes
+     * @since 0.8 or earlier
      */
     public abstract Shape tryMerge(Shape other);
 
     /**
      * Utility class to allocate locations in an object layout.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract static class Allocator {
+        /**
+         * @since 0.8 or earlier
+         */
+        protected Allocator() {
+        }
+
+        /** @since 0.8 or earlier */
         protected abstract Location locationForValue(Object value, boolean useFinal, boolean nonNull);
 
         /**
          * Create a new location compatible with the given initial value.
          *
          * @param value the initial value this location is going to be assigned
+         * @since 0.8 or earlier
          */
         public final Location locationForValue(Object value) {
             return locationForValue(value, false, value != null);
@@ -276,18 +362,21 @@ public abstract class Shape {
          *
          * @param value the initial value this location is going to be assigned
          * @param modifiers additional restrictions and semantics
+         * @since 0.8 or earlier
          */
         public final Location locationForValue(Object value, EnumSet<LocationModifier> modifiers) {
             assert value != null || !modifiers.contains(LocationModifier.NonNull);
             return locationForValue(value, modifiers.contains(LocationModifier.Final), modifiers.contains(LocationModifier.NonNull));
         }
 
+        /** @since 0.8 or earlier */
         protected abstract Location locationForType(Class<?> type, boolean useFinal, boolean nonNull);
 
         /**
          * Create a new location for a fixed type. It can only be assigned to values of this type.
          *
          * @param type the Java type this location must be compatible with (may be primitive)
+         * @since 0.8 or earlier
          */
         public final Location locationForType(Class<?> type) {
             return locationForType(type, false, false);
@@ -298,6 +387,7 @@ public abstract class Shape {
          *
          * @param type the Java type this location must be compatible with (may be primitive)
          * @param modifiers additional restrictions and semantics
+         * @since 0.8 or earlier
          */
         public final Location locationForType(Class<?> type, EnumSet<LocationModifier> modifiers) {
             return locationForType(type, modifiers.contains(LocationModifier.Final), modifiers.contains(LocationModifier.NonNull));
@@ -306,23 +396,31 @@ public abstract class Shape {
         /**
          * Creates a new location from a constant value. The value is stored in the shape rather
          * than in the object.
+         * 
+         * @since 0.8 or earlier
          */
         public abstract Location constantLocation(Object value);
 
         /**
          * Creates a new declared location with a default value. A declared location only assumes a
          * type after the first set (initialization).
+         * 
+         * @since 0.8 or earlier
          */
         public abstract Location declaredLocation(Object value);
 
         /**
          * Reserves space for the given location, so that it will not be available to subsequently
          * allocated locations.
+         * 
+         * @since 0.8 or earlier
          */
         public abstract Allocator addLocation(Location location);
 
         /**
          * Creates an copy of this allocator state.
+         * 
+         * @since 0.8 or earlier
          */
         public abstract Allocator copy();
     }
@@ -333,6 +431,7 @@ public abstract class Shape {
      * For Java 7 compatibility (equivalent to Predicate).
      *
      * @param <T> the type of the input to the predicate
+     * @since 0.8 or earlier
      */
     public interface Pred<T> {
         /**
@@ -340,6 +439,7 @@ public abstract class Shape {
          *
          * @param t the input argument
          * @return {@code true} if the input argument matches the predicate, otherwise {@code false}
+         * @since 0.8 or earlier
          */
         boolean test(T t);
     }

--- a/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/ShapeListener.java
+++ b/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/ShapeListener.java
@@ -26,12 +26,15 @@ package com.oracle.truffle.api.object;
 
 /**
  * A listener to be notified of property transitions.
+ * 
+ * @since 0.8 or earlier
  */
 public interface ShapeListener {
     /**
      * Called when a property is added, removed, or replaced.
      *
      * @param key identifier of the property
+     * @since 0.8 or earlier
      */
     void onPropertyTransition(Object key);
 }

--- a/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/TypedLocation.java
+++ b/truffle/com.oracle.truffle.api.object/src/com/oracle/truffle/api/object/TypedLocation.java
@@ -26,12 +26,15 @@ package com.oracle.truffle.api.object;
 
 /**
  * A location that can store a value of a particular type.
+ * 
+ * @since 0.8 or earlier
  */
 public interface TypedLocation {
     /**
      * Get object value as object at this location in store.
      *
      * @param shape the current shape of the object, which must contain this location
+     * @since 0.8 or earlier
      */
     Object get(DynamicObject store, Shape shape);
 
@@ -41,6 +44,7 @@ public interface TypedLocation {
      *
      * @param condition the result of a shape check or {@code false}
      * @see #get(DynamicObject, Shape)
+     * @since 0.8 or earlier
      */
     Object get(DynamicObject store, boolean condition);
 
@@ -49,6 +53,7 @@ public interface TypedLocation {
      *
      * @throws IncompatibleLocationException for storage type invalidations
      * @throws FinalLocationException for effectively final fields
+     * @since 0.8 or earlier
      */
     void set(DynamicObject store, Object value) throws IncompatibleLocationException, FinalLocationException;
 
@@ -58,6 +63,7 @@ public interface TypedLocation {
      * @param shape the current shape of the storage object
      * @throws IncompatibleLocationException for storage type invalidations
      * @throws FinalLocationException for effectively final fields
+     * @since 0.8 or earlier
      */
     void set(DynamicObject store, Object value, Shape shape) throws IncompatibleLocationException, FinalLocationException;
 
@@ -67,11 +73,14 @@ public interface TypedLocation {
      * @param oldShape the shape before the transition
      * @param newShape new shape after the transition
      * @throws IncompatibleLocationException if value is of non-assignable type
+     * @since 0.8 or earlier
      */
     void set(DynamicObject store, Object value, Shape oldShape, Shape newShape) throws IncompatibleLocationException;
 
     /**
      * The type of this location.
+     * 
+     * @since 0.8 or earlier
      */
     Class<?> getType();
 }

--- a/truffle/com.oracle.truffle.api.profiles/src/com/oracle/truffle/api/profiles/BranchProfile.java
+++ b/truffle/com.oracle.truffle.api.profiles/src/com/oracle/truffle/api/profiles/BranchProfile.java
@@ -41,6 +41,7 @@ import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
  * {@inheritDoc}
  *
  * @see BranchProfile#enter()
+ * @since 0.10
  */
 public abstract class BranchProfile extends Profile {
 
@@ -49,17 +50,22 @@ public abstract class BranchProfile extends Profile {
 
     /**
      * Call when an unlikely branch is entered.
+     * 
+     * @since 0.10
      */
     public abstract void enter();
 
     /**
      * @deprecated it is not reliable when profiling is turned off.
+     * @since 0.10
      */
     @Deprecated
     public abstract boolean isVisited();
 
     /**
      * Call to create a new instance of a branch profile.
+     * 
+     * @since 0.10
      */
     public static BranchProfile create() {
         if (Profile.isProfilingEnabled()) {

--- a/truffle/com.oracle.truffle.api.profiles/src/com/oracle/truffle/api/profiles/ByteValueProfile.java
+++ b/truffle/com.oracle.truffle.api.profiles/src/com/oracle/truffle/api/profiles/ByteValueProfile.java
@@ -43,18 +43,21 @@ import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
  *
  * @see #createIdentityProfile()
  * @see ValueProfile
+ * @since 0.10
  */
 public abstract class ByteValueProfile extends Profile {
 
     ByteValueProfile() {
     }
 
+    /** @since 0.10 */
     public abstract byte profile(byte value);
 
     /**
      * Returns a value profile that profiles the exact value of a <code>byte</code>.
      *
      * @see ByteValueProfile
+     * @since 0.10
      */
     public static ByteValueProfile createIdentityProfile() {
         if (Profile.isProfilingEnabled()) {

--- a/truffle/com.oracle.truffle.api.profiles/src/com/oracle/truffle/api/profiles/ConditionProfile.java
+++ b/truffle/com.oracle.truffle.api.profiles/src/com/oracle/truffle/api/profiles/ConditionProfile.java
@@ -37,9 +37,9 @@ import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
  *
  * <pre>
  * class AbsoluteNode extends Node {
- *
+ * 
  *     final ConditionProfile greaterZeroProfile = ConditionProfile.create{Binary,Counting}Profile();
- *
+ * 
  *     void execute(int value) {
  *         if (greaterZeroProfile.profile(value >= 0)) {
  *             return value;
@@ -55,12 +55,14 @@ import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
  * @see #createBinaryProfile()
  * @see #createCountingProfile()
  * @see LoopConditionProfile
+ * @since 0.10
  */
 public abstract class ConditionProfile extends Profile {
 
     ConditionProfile() {
     }
 
+    /** @since 0.10 */
     public abstract boolean profile(boolean value);
 
     /**
@@ -73,6 +75,7 @@ public abstract class ConditionProfile extends Profile {
      *
      * @see ConditionProfile
      * @see #createBinaryProfile()
+     * @since 0.10
      */
     public static ConditionProfile createCountingProfile() {
         if (Profile.isProfilingEnabled()) {
@@ -89,6 +92,7 @@ public abstract class ConditionProfile extends Profile {
      *
      * @see ConditionProfile
      * @see ConditionProfile#createCountingProfile()
+     * @since 0.10
      */
     public static ConditionProfile createBinaryProfile() {
         if (Profile.isProfilingEnabled()) {

--- a/truffle/com.oracle.truffle.api.profiles/src/com/oracle/truffle/api/profiles/DoubleValueProfile.java
+++ b/truffle/com.oracle.truffle.api.profiles/src/com/oracle/truffle/api/profiles/DoubleValueProfile.java
@@ -41,9 +41,9 @@ import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
  *
  * <pre>
  * class SampleNode extends Node {
- *
+ * 
  *     final DoubleValueProfile profile = DoubleValueProfile.createRawIdentityProfile();
- *
+ * 
  *     double execute(double input) {
  *         double profiledValue = profile.profile(input);
  *         // compiler may know now more about profiledValue
@@ -58,12 +58,14 @@ import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
  *
  * @see #createRawIdentityProfile()
  * @see ValueProfile
+ * @since 0.10
  */
 public abstract class DoubleValueProfile extends Profile {
 
     DoubleValueProfile() {
     }
 
+    /** @since 0.10 */
     public abstract double profile(double value);
 
     /**
@@ -71,6 +73,7 @@ public abstract class DoubleValueProfile extends Profile {
      * {@link Double#doubleToRawLongBits(double)}.
      *
      * @see IntValueProfile
+     * @since 0.10
      */
     public static DoubleValueProfile createRawIdentityProfile() {
         if (Profile.isProfilingEnabled()) {

--- a/truffle/com.oracle.truffle.api.profiles/src/com/oracle/truffle/api/profiles/FloatValueProfile.java
+++ b/truffle/com.oracle.truffle.api.profiles/src/com/oracle/truffle/api/profiles/FloatValueProfile.java
@@ -58,12 +58,14 @@ import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
  *
  * @see #createRawIdentityProfile()
  * @see ValueProfile
+ * @since 0.10
  */
 public abstract class FloatValueProfile extends Profile {
 
     FloatValueProfile() {
     }
 
+    /** @since 0.10 */
     public abstract float profile(float value);
 
     /**
@@ -71,6 +73,7 @@ public abstract class FloatValueProfile extends Profile {
      * {@link Float#floatToRawIntBits(float)}.
      *
      * @see IntValueProfile
+     * @since 0.10
      */
     public static FloatValueProfile createRawIdentityProfile() {
         if (Profile.isProfilingEnabled()) {

--- a/truffle/com.oracle.truffle.api.profiles/src/com/oracle/truffle/api/profiles/IntValueProfile.java
+++ b/truffle/com.oracle.truffle.api.profiles/src/com/oracle/truffle/api/profiles/IntValueProfile.java
@@ -41,9 +41,9 @@ import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
  *
  * <pre>
  * class SampleNode extends Node {
- *
+ * 
  *     final IntValueProfile profile = IntValueProfile.createIdentityProfile();
- *
+ * 
  *     int execute(int input) {
  *         int profiledValue = profile.profile(input);
  *         // compiler may know now more about profiledValue
@@ -58,18 +58,21 @@ import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
  *
  * @see #createIdentityProfile()
  * @see ValueProfile
+ * @since 0.10
  */
 public abstract class IntValueProfile extends Profile {
 
     IntValueProfile() {
     }
 
+    /** @since 0.10 */
     public abstract int profile(int value);
 
     /**
      * Returns a value profile that profiles the exact value of an <code>int</code>.
      *
      * @see IntValueProfile
+     * @since 0.10
      */
     public static IntValueProfile createIdentityProfile() {
         if (Profile.isProfilingEnabled()) {

--- a/truffle/com.oracle.truffle.api.profiles/src/com/oracle/truffle/api/profiles/LongValueProfile.java
+++ b/truffle/com.oracle.truffle.api.profiles/src/com/oracle/truffle/api/profiles/LongValueProfile.java
@@ -41,9 +41,9 @@ import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
  *
  * <pre>
  * class SampleNode extends Node {
- *
+ * 
  *     final LongValueProfile profile = LongValueProfile.createIdentityProfile();
- *
+ * 
  *     long execute(long input) {
  *         long profiledValue = profile.profile(input);
  *         // compiler may know now more about profiledValue
@@ -57,18 +57,21 @@ import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
  *
  * @see #createIdentityProfile()
  * @see ValueProfile
+ * @since 0.10
  */
 public abstract class LongValueProfile extends Profile {
 
     LongValueProfile() {
     }
 
+    /** @since 0.10 */
     public abstract long profile(long value);
 
     /**
      * Returns a value profile that profiles the exact value of an <code>long</code>.
      *
      * @see LongValueProfile
+     * @since 0.10
      */
     public static LongValueProfile createIdentityProfile() {
         if (Profile.isProfilingEnabled()) {

--- a/truffle/com.oracle.truffle.api.profiles/src/com/oracle/truffle/api/profiles/LoopConditionProfile.java
+++ b/truffle/com.oracle.truffle.api.profiles/src/com/oracle/truffle/api/profiles/LoopConditionProfile.java
@@ -84,12 +84,14 @@ import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
  * @see #createBinaryProfile()
  * @see #createCountingProfile()
  * @see LoopConditionProfile
+ * @since 0.10
  */
 public abstract class LoopConditionProfile extends ConditionProfile {
 
     LoopConditionProfile() {
     }
 
+    /** @since 0.10 */
     @Override
     public abstract boolean profile(boolean value);
 
@@ -98,6 +100,7 @@ public abstract class LoopConditionProfile extends ConditionProfile {
      * see {@link LoopConditionProfile} for an usage example.
      *
      * @see #inject(boolean)
+     * @since 0.10
      */
     public abstract void profileCounted(long length);
 
@@ -106,6 +109,7 @@ public abstract class LoopConditionProfile extends ConditionProfile {
      * see {@link LoopConditionProfile} for an usage example.
      *
      * @see #inject(boolean)
+     * @since 0.10
      */
     public abstract boolean inject(boolean condition);
 
@@ -115,6 +119,7 @@ public abstract class LoopConditionProfile extends ConditionProfile {
      * profiles are intended to be used for loop conditions.
      *
      * @see LoopConditionProfile
+     * @since 0.10
      */
     public static LoopConditionProfile createCountingProfile() {
         if (Profile.isProfilingEnabled()) {

--- a/truffle/com.oracle.truffle.api.profiles/src/com/oracle/truffle/api/profiles/PrimitiveValueProfile.java
+++ b/truffle/com.oracle.truffle.api.profiles/src/com/oracle/truffle/api/profiles/PrimitiveValueProfile.java
@@ -39,34 +39,47 @@ import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
  * </p>
  *
  * {@inheritDoc}
+ * 
+ * @since 0.10
  */
 public abstract class PrimitiveValueProfile extends ValueProfile {
 
     PrimitiveValueProfile() {
     }
 
+    /** @since 0.10 */
     @Override
     public abstract <T> T profile(T value);
 
+    /** @since 0.10 */
     public abstract byte profile(byte value);
 
+    /** @since 0.10 */
     public abstract short profile(short value);
 
+    /** @since 0.10 */
     public abstract int profile(int value);
 
+    /** @since 0.10 */
     public abstract long profile(long value);
 
+    /** @since 0.10 */
     public abstract float profile(float value);
 
+    /** @since 0.10 */
     public abstract double profile(double value);
 
+    /** @since 0.10 */
     public abstract boolean profile(boolean value);
 
+    /** @since 0.10 */
     public abstract char profile(char value);
 
     /**
      * Returns a {@link PrimitiveValueProfile} that speculates on the primitive equality or object
      * identity of a value.
+     * 
+     * @since 0.10
      */
     public static PrimitiveValueProfile createEqualityProfile() {
         if (Profile.isProfilingEnabled()) {
@@ -78,6 +91,7 @@ public abstract class PrimitiveValueProfile extends ValueProfile {
 
     /**
      * @deprecated going to get removed without replacement
+     * @since 0.10
      */
     @Deprecated
     public static boolean exactCompare(float a, float b) {
@@ -90,6 +104,7 @@ public abstract class PrimitiveValueProfile extends ValueProfile {
 
     /**
      * @deprecated going to get removed without replacement
+     * @since 0.10
      */
     @Deprecated
     public static boolean exactCompare(double a, double b) {

--- a/truffle/com.oracle.truffle.api.profiles/src/com/oracle/truffle/api/profiles/Profile.java
+++ b/truffle/com.oracle.truffle.api.profiles/src/com/oracle/truffle/api/profiles/Profile.java
@@ -89,6 +89,7 @@ import com.oracle.truffle.api.nodes.RootNode;
  * </p>
  *
  * @see Assumption
+ * @since 0.10
  */
 public abstract class Profile extends NodeCloneable {
     static boolean isProfilingEnabled() {

--- a/truffle/com.oracle.truffle.api.profiles/src/com/oracle/truffle/api/profiles/ValueProfile.java
+++ b/truffle/com.oracle.truffle.api.profiles/src/com/oracle/truffle/api/profiles/ValueProfile.java
@@ -46,9 +46,9 @@ import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
  *
  * <pre>
  * class SampleNode extends Node {
- *
+ * 
  * final ValueProfile profile = ValueProfile.create{Identity,Class}Profile();
- *
+ * 
  *     Object execute(Object input) {
  *         Object profiledValue = profile.profile(input);
  *         // compiler may know now more about profiledValue
@@ -63,12 +63,14 @@ import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
  *
  * @see #createIdentityProfile()
  * @see #createClassProfile()
+ * @since 0.10
  */
 public abstract class ValueProfile extends Profile {
 
     ValueProfile() {
     }
 
+    /** @since 0.10 */
     public abstract <T> T profile(T value);
 
     /**
@@ -89,6 +91,7 @@ public abstract class ValueProfile extends Profile {
      * </P>
      *
      * @see ValueProfile usage example
+     * @since 0.10
      */
     public static ValueProfile createClassProfile() {
         if (Profile.isProfilingEnabled()) {
@@ -109,6 +112,8 @@ public abstract class ValueProfile extends Profile {
      * object identity. If two identities have been seen on a single profile instance then this
      * profile will transition to a generic state with no overhead.
      * </p>
+     * 
+     * @since 0.10
      */
     public static ValueProfile createIdentityProfile() {
         if (Profile.isProfilingEnabled()) {
@@ -132,6 +137,8 @@ public abstract class ValueProfile extends Profile {
      * seen on a single profile instance then this profile will transition to a generic state with
      * no overhead.
      * </p>
+     * 
+     * @since 0.10
      */
     public static ValueProfile createEqualityProfile() {
         if (Profile.isProfilingEnabled()) {

--- a/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/EventConsumer.java
+++ b/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/EventConsumer.java
@@ -35,6 +35,7 @@ import com.oracle.truffle.api.TruffleLanguage;
  * Truffle language}s.
  *
  * @param <Event> type of event to observe and handle
+ * @since 0.9
  */
 public abstract class EventConsumer<Event> {
     final Class<Event> type;
@@ -43,6 +44,7 @@ public abstract class EventConsumer<Event> {
      * Creates new handler for specified event type.
      *
      * @param eventType type of events to handle
+     * @since 0.9
      */
     public EventConsumer(Class<Event> eventType) {
         this.type = eventType;
@@ -52,6 +54,7 @@ public abstract class EventConsumer<Event> {
      * Called by the {@link PolyglotEngine} when event of requested type appears.
      *
      * @param event the instance of an event of the request type
+     * @since 0.9
      */
     protected abstract void on(Event event);
 }

--- a/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/IncompleteSourceException.java
+++ b/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/IncompleteSourceException.java
@@ -4,14 +4,17 @@ import java.io.IOException;
 
 /**
  * Indicates that the provided source was incomplete and requires further text to be executed.
+ * 
+ * @since 0.9
  */
 @SuppressWarnings("serial")
 public class IncompleteSourceException extends IOException {
-
+    /** @since 0.9 */
     public IncompleteSourceException() {
         super();
     }
 
+    /** @since 0.9 */
     public IncompleteSourceException(Throwable cause) {
         super(cause);
     }

--- a/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotEngine.java
+++ b/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotEngine.java
@@ -99,6 +99,8 @@ import com.oracle.truffle.api.source.Source;
  * {@link Builder#build() created} by and checks that all subsequent calls are coming from the same
  * thread. There is 1:1 mapping between {@link PolyglotEngine} and a thread that can tell it what to
  * do.
+ * 
+ * @since 0.9
  */
 @SuppressWarnings("rawtypes")
 public class PolyglotEngine {
@@ -214,6 +216,7 @@ public class PolyglotEngine {
      * {@link #eval(com.oracle.truffle.api.source.Source)} method.
      *
      * @return new builder to create isolated polyglot engine with pre-registered languages
+     * @since 0.10
      */
     public static PolyglotEngine.Builder newBuilder() {
         // making Builder non-static inner class is a
@@ -226,6 +229,7 @@ public class PolyglotEngine {
     /**
      * @return new builder
      * @deprecated use {@link #newBuilder()}
+     * @since 0.9
      */
     @Deprecated
     public static PolyglotEngine.Builder buildNew() {
@@ -243,6 +247,8 @@ public class PolyglotEngine {
      *     .{@link Builder#setIn(java.io.InputStream) setIn}({@link InputStream yourInput})
      *     .{@link Builder#build() build()};
      * </pre>
+     * 
+     * @since 0.9
      */
     public class Builder {
         private OutputStream out;
@@ -262,6 +268,7 @@ public class PolyglotEngine {
          *
          * @param os the stream to use as output
          * @return instance of this builder
+         * @since 0.9
          */
         public Builder setOut(OutputStream os) {
             out = os;
@@ -274,6 +281,7 @@ public class PolyglotEngine {
          *
          * @param os the stream to use as output
          * @return instance of this builder
+         * @since 0.9
          */
         public Builder setErr(OutputStream os) {
             err = os;
@@ -286,6 +294,7 @@ public class PolyglotEngine {
          *
          * @param is the stream to use as input
          * @return instance of this builder
+         * @since 0.9
          */
         public Builder setIn(InputStream is) {
             in = is;
@@ -298,6 +307,7 @@ public class PolyglotEngine {
          *
          * @param handler the handler to register
          * @return instance of this builder
+         * @since 0.9
          */
         public Builder onEvent(EventConsumer<?> handler) {
             Objects.requireNonNull(handler);
@@ -323,6 +333,7 @@ public class PolyglotEngine {
          * @param key to identify a language-specific configuration element
          * @param value to parameterize initial state of a language
          * @return instance of this builder
+         * @since 0.11
          */
         public Builder config(String mimeType, String key, Object value) {
             if (this.arguments == null) {
@@ -349,6 +360,7 @@ public class PolyglotEngine {
          * @see PolyglotEngine#findGlobalSymbol(java.lang.String)
          * @throws IllegalArgumentException if the object isn't of primitive type and cannot be
          *             converted to {@link TruffleObject}
+         * @since 0.9
          */
         public Builder globalSymbol(String name, Object obj) {
             final Object truffleReady;
@@ -379,6 +391,7 @@ public class PolyglotEngine {
          * @param executor the executor to use for internal execution inside the {@link #build() to
          *            be created} {@link PolyglotEngine}
          * @return instance of this builder
+         * @since 0.9
          */
         @SuppressWarnings("hiding")
         public Builder executor(Executor executor) {
@@ -391,6 +404,7 @@ public class PolyglotEngine {
          * from values passed into configuration methods in this class.
          *
          * @return new, isolated virtual machine with pre-registered languages
+         * @since 0.9
          */
         public PolyglotEngine build() {
             assertNoTruffle();
@@ -412,6 +426,7 @@ public class PolyglotEngine {
      *
      * @return an immutable map with keys being MIME types and values the {@link Language
      *         descriptions} of associated languages
+     * @since 0.9
      */
     public Map<String, ? extends Language> getLanguages() {
         return Collections.unmodifiableMap(langs);
@@ -422,6 +437,7 @@ public class PolyglotEngine {
      * instruments are enabled automatically at startup.
      *
      * @return the set of instruments
+     * @since 0.9
      */
     public Map<String, Instrument> getInstruments() {
         return instruments;
@@ -435,6 +451,7 @@ public class PolyglotEngine {
      * @param source code snippet to execute
      * @return a {@link Value} object that holds result of an execution, never <code>null</code>
      * @throws IOException thrown to signal errors while processing the code
+     * @since 0.9
      */
     public Value eval(Source source) throws IOException {
         assertNoTruffle();
@@ -455,6 +472,8 @@ public class PolyglotEngine {
      * <p>
      * Calling any other method of this class after the dispose has been done yields an
      * {@link IllegalStateException}.
+     * 
+     * @since 0.9
      */
     public void dispose() {
         checkThread();
@@ -581,6 +600,7 @@ public class PolyglotEngine {
      *
      * @param globalName the name of the symbol to find
      * @return found symbol or <code>null</code> if it has not been found
+     * @since 0.9
      */
     public Value findGlobalSymbol(final String globalName) {
         checkThread();
@@ -678,6 +698,8 @@ public class PolyglotEngine {
      * {@link Builder#executor(java.util.concurrent.Executor) asynchronous execution}, the
      * {@link Value} represents a future - i.e., it is returned immediately, leaving the execution
      * running on behind.
+     * 
+     * @since 0.9
      */
     public class Value {
         private final TruffleLanguage<?>[] language;
@@ -707,6 +729,7 @@ public class PolyglotEngine {
          *
          * @return the object or <code>null</code>
          * @throws IOException in case it is not possible to obtain the value of the object
+         * @since 0.9
          */
         public Object get() throws IOException {
             assertNoTruffle();
@@ -732,6 +755,7 @@ public class PolyglotEngine {
          * @return instance of the view wrapping the object of this symbol
          * @throws IOException in case it is not possible to obtain the value of the object
          * @throws ClassCastException if the value cannot be converted to desired view
+         * @since 0.9
          */
         public <T> T as(final Class<T> representation) throws IOException {
             assertNoTruffle();
@@ -771,6 +795,7 @@ public class PolyglotEngine {
          * @return symbol wrapper around the value returned by invoking the symbol, never
          *         <code>null</code>
          * @throws IOException signals problem during execution
+         * @since 0.9
          */
         @Deprecated
         public Value invoke(final Object thiz, final Object... args) throws IOException {
@@ -793,6 +818,7 @@ public class PolyglotEngine {
          * @return symbol wrapper around the value returned by invoking the symbol, never
          *         <code>null</code>
          * @throws IOException signals problem during execution
+         * @since 0.9
          */
         public Value execute(final Object... args) throws IOException {
             assertNoTruffle();
@@ -827,6 +853,7 @@ public class PolyglotEngine {
             return compute.get();
         }
 
+        /** @since 0.9 */
         @Override
         public String toString() {
             return "PolyglotEngine.Value[" + compute + "]";
@@ -839,6 +866,7 @@ public class PolyglotEngine {
      * {@link Instrument#setEnabled(boolean)} enable/disable a given instrument.
      *
      * @see PolyglotEngine#getInstruments()
+     * @since 0.9
      */
     public final class Instrument {
 
@@ -852,6 +880,7 @@ public class PolyglotEngine {
 
         /**
          * @return the id of the instrument
+         * @since 0.9
          */
         public String getId() {
             return info.getId();
@@ -859,6 +888,7 @@ public class PolyglotEngine {
 
         /**
          * @return a human readable name of the installed instrument.
+         * @since 0.9
          */
         public String getName() {
             return info.getName();
@@ -866,6 +896,7 @@ public class PolyglotEngine {
 
         /**
          * @return the version of the installed instrument.
+         * @since 0.9
          */
         public String getVersion() {
             return info.getVersion();
@@ -877,6 +908,7 @@ public class PolyglotEngine {
 
         /**
          * @return <code>true</code> if the underlying instrument is enabled else <code>false</code>
+         * @since 0.9
          */
         public boolean isEnabled() {
             return enabled;
@@ -890,6 +922,7 @@ public class PolyglotEngine {
          * @param type class of the service that is being requested
          * @return instance of requested type, or <code>null</code> if no such service is available
          *         for the instrument
+         * @since 0.9
          */
         public <T> T lookup(Class<T> type) {
             return SPI.getInstrumentationHandlerService(instrumentationHandler, this, type);
@@ -899,6 +932,7 @@ public class PolyglotEngine {
          * Enables/disables the installed instrument in the engine.
          *
          * @param enabled <code>true</code> to enable <code>false</code> to disable
+         * @since 0.9
          */
         public void setEnabled(final boolean enabled) {
             checkThread();
@@ -930,6 +964,7 @@ public class PolyglotEngine {
             }
         }
 
+        /** @since 0.9 */
         @Override
         public String toString() {
             return "Instrument [id=" + getId() + ", name=" + getName() + ", version=" + getVersion() + ", enabled=" + enabled + "]";
@@ -945,6 +980,8 @@ public class PolyglotEngine {
      * of supported {@link #getMimeTypes() MIME types} for each language. The actual language
      * implementation is not initialized until
      * {@link PolyglotEngine#eval(com.oracle.truffle.api.source.Source) a code is evaluated} in it.
+     * 
+     * @since 0.9
      */
     public class Language {
         private final Map<Source, CallTarget> cache;
@@ -960,6 +997,7 @@ public class PolyglotEngine {
          * MIME types recognized by the language.
          *
          * @return returns immutable set of recognized MIME types
+         * @since 0.9
          */
         public Set<String> getMimeTypes() {
             return info.getMimeTypes();
@@ -969,6 +1007,7 @@ public class PolyglotEngine {
          * Human readable name of the language. Think of C, Ruby, JS, etc.
          *
          * @return string giving the language a name
+         * @since 0.9
          */
         public String getName() {
             return info.getName();
@@ -978,6 +1017,7 @@ public class PolyglotEngine {
          * Name of the language version.
          *
          * @return string specifying the language version
+         * @since 0.9
          */
         public String getVersion() {
             return info.getVersion();
@@ -990,6 +1030,7 @@ public class PolyglotEngine {
          * @param source code snippet to execute
          * @return a {@link Value} object that holds result of an execution, never <code>null</code>
          * @throws IOException thrown to signal errors while processing the code
+         * @since 0.9
          */
         public Value eval(Source source) throws IOException {
             assertNoTruffle();
@@ -1006,6 +1047,7 @@ public class PolyglotEngine {
          *
          * @return the global object or <code>null</code> if the language does not support such
          *         concept
+         * @since 0.9
          */
         @SuppressWarnings("try")
         public Value getGlobalObject() {
@@ -1045,6 +1087,7 @@ public class PolyglotEngine {
             return env;
         }
 
+        /** @since 0.9 */
         @Override
         public String toString() {
             return "[" + getName() + "@ " + getVersion() + " for " + getMimeTypes() + "]";

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/Assumption.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/Assumption.java
@@ -38,6 +38,8 @@ import com.oracle.truffle.api.nodes.Node;
  *
  * All instances of classes implementing {@code Assumption} must be held in {@code final} fields for
  * compiler optimizations to take effect.
+ * 
+ * @since 0.8 or earlier
  */
 public interface Assumption {
 
@@ -48,6 +50,7 @@ public interface Assumption {
      * {@link Node#replace(Node)}) with a node that no longer relies on the assumption.
      *
      * @throws InvalidAssumptionException If the assumption is no longer valid.
+     * @since 0.8 or earlier
      */
     void check() throws InvalidAssumptionException;
 
@@ -55,11 +58,14 @@ public interface Assumption {
      * Checks whether the assumption is still valid.
      *
      * @return a boolean value indicating the validity of the assumption
+     * @since 0.8 or earlier
      */
     boolean isValid();
 
     /**
      * Invalidates this assumption. Performs no operation, if the assumption is already invalid.
+     * 
+     * @since 0.8 or earlier
      */
     void invalidate();
 
@@ -67,6 +73,7 @@ public interface Assumption {
      * A name for the assumption that is used for debug output.
      *
      * @return the name of the assumption
+     * @since 0.8 or earlier
      */
     String getName();
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/CallTarget.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/CallTarget.java
@@ -26,6 +26,8 @@ package com.oracle.truffle.api;
 
 /**
  * Represents the target of a call.
+ * 
+ * @since 0.8 or earlier
  */
 public interface CallTarget {
 
@@ -34,6 +36,7 @@ public interface CallTarget {
      *
      * @param arguments passed arguments as an object array
      * @return the return result of the call
+     * @since 0.8 or earlier
      */
     Object call(Object... arguments);
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/CompilerAsserts.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/CompilerAsserts.java
@@ -30,6 +30,7 @@ package com.oracle.truffle.api;
  * code generation and the Truffle compiler produces for failing assertions a stack trace that
  * identifies the code position of the assertion in the context of the current compilation.
  *
+ * @since 0.8 or earlier
  */
 public final class CompilerAsserts {
     private CompilerAsserts() {
@@ -40,6 +41,8 @@ public final class CompilerAsserts {
      * for exceptional code paths or rare code paths that should never be included in a compilation
      * unit. See {@link CompilerDirectives#transferToInterpreter()} for the corresponding compiler
      * directive.
+     * 
+     * @since 0.8 or earlier
      */
     public static void neverPartOfCompilation() {
     }
@@ -51,6 +54,7 @@ public final class CompilerAsserts {
      * directive.
      *
      * @param message text associated with the bailout exception
+     * @since 0.8 or earlier
      */
     public static void neverPartOfCompilation(String message) {
     }
@@ -59,6 +63,7 @@ public final class CompilerAsserts {
      * Assertion that the corresponding value is reduced to a constant during compilation.
      *
      * @param value the value that must be constant during compilation
+     * @since 0.8 or earlier
      */
     public static <T> void compilationConstant(Object value) {
         if (!CompilerDirectives.isCompilationConstant(value)) {
@@ -71,6 +76,7 @@ public final class CompilerAsserts {
      * evaluation phase.
      *
      * @param value the value that must be constant during compilation
+     * @since 0.8 or earlier
      */
     public static <T> void partialEvaluationConstant(Object value) {
     }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/CompilerDirectives.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/CompilerDirectives.java
@@ -34,18 +34,32 @@ import java.util.concurrent.Callable;
 /**
  * Directives that influence the optimizations of the Truffle compiler. All of the operations have
  * no effect when executed in the Truffle interpreter.
+ * 
+ * @since 0.8 or earlier
  */
 public final class CompilerDirectives {
+    /**
+     * @deprecated accidentally public - don't use
+     * @since 0.8 or earlier
+     */
+    @Deprecated
+    public CompilerDirectives() {
+    }
 
+    /** @since 0.8 or earlier */
     public static final double LIKELY_PROBABILITY = 0.75;
+    /** @since 0.8 or earlier */
     public static final double UNLIKELY_PROBABILITY = 1.0 - LIKELY_PROBABILITY;
-
+    /** @since 0.8 or earlier */
     public static final double SLOWPATH_PROBABILITY = 0.0001;
+    /** @since 0.8 or earlier */
     public static final double FASTPATH_PROBABILITY = 1.0 - SLOWPATH_PROBABILITY;
 
     /**
      * Directive for the compiler to discontinue compilation at this code position and instead
      * insert a transfer to the interpreter.
+     * 
+     * @since 0.8 or earlier
      */
     public static void transferToInterpreter() {
         if (inInterpreter()) {
@@ -56,6 +70,8 @@ public final class CompilerDirectives {
     /**
      * Directive for the compiler to discontinue compilation at this code position and instead
      * insert a transfer to the interpreter, invalidating the currently executing machine code.
+     * 
+     * @since 0.8 or earlier
      */
     public static void transferToInterpreterAndInvalidate() {
         if (inInterpreter()) {
@@ -67,6 +83,7 @@ public final class CompilerDirectives {
      * Returns a boolean value indicating whether the method is executed in the interpreter.
      *
      * @return {@code true} when executed in the interpreter, {@code false} in compiled code.
+     * @since 0.8 or earlier
      */
     public static boolean inInterpreter() {
         return true;
@@ -76,6 +93,7 @@ public final class CompilerDirectives {
      * Returns a boolean value indicating whether the method is executed in the compiled code.
      *
      * @return {@code false} when executed in the interpreter, {@code true} in compiled code.
+     * @since 0.8 or earlier
      */
     public static boolean inCompiledCode() {
         return false;
@@ -95,6 +113,7 @@ public final class CompilerDirectives {
      * @param value
      * @return {@code true} when given value is seen as compilation constant, {@code false} if not
      *         compilation constant.
+     * @since 0.8 or earlier
      */
     public static boolean isCompilationConstant(Object value) {
         return CompilerDirectives.inInterpreter();
@@ -108,6 +127,7 @@ public final class CompilerDirectives {
      * @param value
      * @return {@code true} when given value is seen as compilation constant, {@code false} if not
      *         compilation constant.
+     * @since 0.8 or earlier
      */
     public static boolean isPartialEvaluationConstant(Object value) {
         return CompilerDirectives.inInterpreter();
@@ -118,6 +138,7 @@ public final class CompilerDirectives {
      * and ignored in the compiled code.
      *
      * @param runnable the closure that should only be executed in the interpreter
+     * @since 0.8 or earlier
      */
     public static void interpreterOnly(Runnable runnable) {
         runnable.run();
@@ -130,6 +151,7 @@ public final class CompilerDirectives {
      * @param callable the closure that should only be executed in the interpreter
      * @return the result of executing the closure in the interpreter and null in the compiled code
      * @throws Exception If the closure throws an exception when executed in the interpreter.
+     * @since 0.8 or earlier
      */
     public static <T> T interpreterOnly(Callable<T> callable) throws Exception {
         return callable.call();
@@ -164,6 +186,7 @@ public final class CompilerDirectives {
      * {@link #FASTPATH_PROBABILITY} ).
      *
      * @param probability the probability value between 0.0 and 1.0 that should be injected
+     * @since 0.8 or earlier
      */
     public static boolean injectBranchProbability(double probability, boolean condition) {
         assert probability >= 0.0 && probability <= 1.0;
@@ -174,6 +197,7 @@ public final class CompilerDirectives {
      * Bails out of a compilation (e.g., for guest language features that should never be compiled).
      *
      * @param reason the reason for the bailout
+     * @since 0.8 or earlier
      */
     public static void bailout(String reason) {
     }
@@ -182,6 +206,8 @@ public final class CompilerDirectives {
      * Marks fields that should be considered final for a Truffle compilation although they are not
      * final while executing in the interpreter. If the field type is an array type, the compiler
      * considers reads with a constant index as constants.
+     * 
+     * @since 0.8 or earlier
      */
     @Retention(RetentionPolicy.RUNTIME)
     @Target({ElementType.FIELD})
@@ -190,6 +216,8 @@ public final class CompilerDirectives {
 
     /**
      * Marks a method that it is considered as a boundary for Truffle partial evaluation.
+     * 
+     * @since 0.8 or earlier
      */
     @Retention(RetentionPolicy.RUNTIME)
     @Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
@@ -203,6 +231,8 @@ public final class CompilerDirectives {
     /**
      * Marks classes as value types. Reference comparisons (==) between instances of those classes
      * have undefined semantics and can either return true or false.
+     * 
+     * @since 0.8 or earlier
      */
     @Retention(RetentionPolicy.RUNTIME)
     @Target({ElementType.TYPE})
@@ -214,6 +244,7 @@ public final class CompilerDirectives {
      * point of this call.
      *
      * @param obj the object to exclude from Escape Analysis
+     * @since 0.8 or earlier
      */
     public static void materialize(Object obj) {
     }
@@ -221,12 +252,16 @@ public final class CompilerDirectives {
     /**
      * Ensures that the given object will be virtual (escape analyzed) at all points that are
      * dominated by the current position.
+     * 
+     * @since 0.8 or earlier
      */
     public static void ensureVirtualized(@SuppressWarnings("unused") Object object) {
     }
 
     /**
      * Ensures that the given object will be virtual at the current position.
+     * 
+     * @since 0.8 or earlier
      */
     public static void ensureVirtualizedHere(@SuppressWarnings("unused") Object object) {
     }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/CompilerOptions.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/CompilerOptions.java
@@ -30,11 +30,14 @@ import com.oracle.truffle.api.nodes.RootNode;
  * Allows options to be set to control the compilation of a specific {@link RootNode}, without
  * creating a dependency on the specific compiler used. Options can be tested for support before
  * setting.
+ * 
+ * @since 0.8 or earlier
  */
 public interface CompilerOptions {
-
+    /** @since 0.8 or earlier */
     boolean supportsOption(String name);
 
+    /** @since 0.8 or earlier */
     void setOption(String name, Object value);
 
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/ExactMath.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/ExactMath.java
@@ -28,9 +28,19 @@ package com.oracle.truffle.api;
  * This class contains methods that will be part of java.lang.Math starting with JDK 8. Until JDK 8
  * is release, we duplicate them here because they are generally useful for dynamic language
  * implementations.
+ * 
+ * @since 0.8 or earlier
  */
 public class ExactMath {
+    /**
+     * @deprecated accidentally public - don't use
+     * @since 0.8 or earlier
+     */
+    @Deprecated
+    public ExactMath() {
+    }
 
+    /** @since 0.8 or earlier */
     public static int addExact(int x, int y) {
         int r = x + y;
         // HD 2-12 Overflow iff both arguments have the opposite sign of the result
@@ -40,6 +50,7 @@ public class ExactMath {
         return r;
     }
 
+    /** @since 0.8 or earlier */
     public static long addExact(long x, long y) {
         long r = x + y;
         // HD 2-12 Overflow iff both arguments have the opposite sign of the result
@@ -49,6 +60,7 @@ public class ExactMath {
         return r;
     }
 
+    /** @since 0.8 or earlier */
     public static int subtractExact(int x, int y) {
         int r = x - y;
         // HD 2-12 Overflow iff the arguments have different signs and
@@ -59,6 +71,7 @@ public class ExactMath {
         return r;
     }
 
+    /** @since 0.8 or earlier */
     public static long subtractExact(long x, long y) {
         long r = x - y;
         // HD 2-12 Overflow iff the arguments have different signs and
@@ -69,6 +82,7 @@ public class ExactMath {
         return r;
     }
 
+    /** @since 0.8 or earlier */
     public static int multiplyExact(int x, int y) {
         long r = (long) x * (long) y;
         if ((int) r != r) {
@@ -77,6 +91,7 @@ public class ExactMath {
         return (int) r;
     }
 
+    /** @since 0.8 or earlier */
     public static long multiplyExact(long x, long y) {
         long r = x * y;
         long ax = Math.abs(x);
@@ -92,11 +107,13 @@ public class ExactMath {
         return r;
     }
 
+    /** @since 0.8 or earlier */
     public static int multiplyHigh(int x, int y) {
         long r = (long) x * (long) y;
         return (int) (r >> 32);
     }
 
+    /** @since 0.8 or earlier */
     public static int multiplyHighUnsigned(int x, int y) {
         long xl = x & 0xFFFFFFFFL;
         long yl = y & 0xFFFFFFFFL;
@@ -104,6 +121,7 @@ public class ExactMath {
         return (int) (r >> 32);
     }
 
+    /** @since 0.8 or earlier */
     public static long multiplyHigh(long x, long y) {
         // Checkstyle: stop
         long x0, y0, z0;
@@ -125,6 +143,7 @@ public class ExactMath {
         return x1 * y1 + z2 + (z1 >> 32);
     }
 
+    /** @since 0.8 or earlier */
     public static long multiplyHighUnsigned(long x, long y) {
         // Checkstyle: stop
         long x0, y0, z0;

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/ExecutionContext.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/ExecutionContext.java
@@ -29,14 +29,18 @@ import com.oracle.truffle.api.impl.DefaultCompilerOptions;
 /**
  * Access to information and basic services in the runtime context for a Truffle-implemented guest
  * language.
+ * 
+ * @since 0.8 or earlier
  */
 public abstract class ExecutionContext {
-
+    /** @since 0.8 or earlier */
     protected ExecutionContext() {
     }
 
     /**
      * Get compiler options specific to this <code>ExecutionContext</code>.
+     * 
+     * @since 0.8 or earlier
      */
     public CompilerOptions getCompilerOptions() {
         return DefaultCompilerOptions.INSTANCE;

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/KillException.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/KillException.java
@@ -28,7 +28,17 @@ import com.oracle.truffle.api.nodes.ControlFlowException;
 
 /**
  * Controls breaking out of an execution context, such as a shell or eval.
+ * 
+ * @since 0.8 or earlier
  */
 public final class KillException extends ControlFlowException {
     private static final long serialVersionUID = -8638020836970813894L;
+
+    /**
+     * Default constructor.
+     * 
+     * @since 0.8 or earlier
+     */
+    public KillException() {
+    }
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/LoopCountReceiver.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/LoopCountReceiver.java
@@ -27,8 +27,10 @@ package com.oracle.truffle.api;
 /**
  * Accepts the execution count of a loop that is a child of this node. The optimization heuristics
  * can use the loop count to guide compilation and inlining.
+ * 
+ * @since 0.8 or earlier
  */
 public interface LoopCountReceiver {
-
+    /** @since 0.8 or earlier */
     void reportLoopCount(int count);
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/OptimizationFailedException.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/OptimizationFailedException.java
@@ -24,15 +24,18 @@
  */
 package com.oracle.truffle.api;
 
+/** @since 0.8 or earlier */
 public class OptimizationFailedException extends RuntimeException {
 
     private final RootCallTarget callTarget;
 
+    /** @since 0.8 or earlier */
     public OptimizationFailedException(Throwable cause, RootCallTarget callTarget) {
         super(cause);
         this.callTarget = callTarget;
     }
 
+    /** @since 0.8 or earlier */
     public RootCallTarget getCallTarget() {
         return callTarget;
     }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/QuitException.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/QuitException.java
@@ -28,7 +28,17 @@ import com.oracle.truffle.api.nodes.ControlFlowException;
 
 /**
  * Controls breaking out of all executions and ending Truffle execution.
+ * 
+ * @since 0.8 or earlier
  */
 public final class QuitException extends ControlFlowException {
     private static final long serialVersionUID = -7101931337099807445L;
+
+    /**
+     * Default constructor.
+     * 
+     * @since 0.8 or earlier
+     */
+    public QuitException() {
+    }
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/ReplaceObserver.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/ReplaceObserver.java
@@ -28,6 +28,8 @@ import com.oracle.truffle.api.nodes.Node;
 
 /**
  * An observer that is notified whenever a child node is replaced.
+ * 
+ * @since 0.8 or earlier
  */
 public interface ReplaceObserver {
 
@@ -35,6 +37,8 @@ public interface ReplaceObserver {
      * Returns <code>true</code> if the event is consumed and no parent nodes should be notified by
      * for replaces. Returns <code>false</code> if the parent {@link Node} or {@link CallTarget}
      * should get notified.
+     * 
+     * @since 0.8 or earlier
      */
     boolean nodeReplaced(Node oldNode, Node newNode, CharSequence reason);
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/RootCallTarget.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/RootCallTarget.java
@@ -29,8 +29,10 @@ import com.oracle.truffle.api.nodes.RootNode;
 /**
  * Represents the target of a call to a {@link RootNode}, i.e., to another tree of nodes. Instances
  * of this class can be created using {@link TruffleRuntime#createCallTarget(RootNode)}.
+ * 
+ * @since 0.8 or earlier
  */
 public interface RootCallTarget extends CallTarget {
-
+    /** @since 0.8 or earlier */
     RootNode getRootNode();
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/Truffle.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/Truffle.java
@@ -31,13 +31,24 @@ import java.security.PrivilegedAction;
 
 /**
  * Class for obtaining the Truffle runtime singleton object of this virtual machine.
+ * 
+ * @since 0.8 or earlier
  */
 public class Truffle {
+    /**
+     * @deprecated Accidentally public - don't use.
+     * @since 0.8 or earlier
+     */
+    @Deprecated
+    public Truffle() {
+    }
 
     private static final TruffleRuntime RUNTIME = initRuntime();
 
     /**
      * Gets the singleton {@link TruffleRuntime} object.
+     * 
+     * @since 0.8 or earlier
      */
     public static TruffleRuntime getRuntime() {
         return RUNTIME;

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
@@ -66,11 +66,14 @@ import java.util.Set;
  * @param <C> internal state of the language associated with every thread that is executing program
  *            {@link #parse(com.oracle.truffle.api.source.Source, com.oracle.truffle.api.nodes.Node, java.lang.String...)
  *            parsed} by the language
+ * @since 0.8 or earlier
  */
 @SuppressWarnings({"javadoc"})
 public abstract class TruffleLanguage<C> {
     /**
      * Constructor to be called by subclasses.
+     * 
+     * @since 0.8 or earlier
      */
     protected TruffleLanguage() {
     }
@@ -82,6 +85,8 @@ public abstract class TruffleLanguage<C> {
      * <em>one JAR drop to the class path</em> away from your users. Once they include your JAR in
      * their application, your language will be available to the
      * {@link com.oracle.truffle.api.vm.PolyglotEngine Truffle virtual machine}.
+     * 
+     * @since 0.8 or earlier
      */
     @Retention(RetentionPolicy.SOURCE)
     @Target(ElementType.TYPE)
@@ -138,6 +143,7 @@ public abstract class TruffleLanguage<C> {
      *
      * @param env the environment the language is supposed to operate in
      * @return internal data of the language in given environment
+     * @since 0.8 or earlier
      */
     protected abstract C createContext(Env env);
 
@@ -150,6 +156,7 @@ public abstract class TruffleLanguage<C> {
      *
      * @param context the context {@link #createContext(com.oracle.truffle.api.TruffleLanguage.Env)
      *            created by the language}
+     * @since 0.8 or earlier
      */
     protected void disposeContext(C context) {
     }
@@ -174,6 +181,7 @@ public abstract class TruffleLanguage<C> {
      * @throws IOException thrown when I/O or parsing goes wrong. Here-in thrown exception is
      *             propagate to the user who called one of <code>eval</code> methods of
      *             {@link com.oracle.truffle.api.vm.PolyglotEngine}
+     * @since 0.8 or earlier
      */
     protected abstract CallTarget parse(Source code, Node context, String... argumentNames) throws IOException;
 
@@ -201,6 +209,7 @@ public abstract class TruffleLanguage<C> {
      *            the explicitly exported ones?
      * @return an exported object or <code>null</code>, if the symbol does not represent anything
      *         meaningful in this language
+     * @since 0.8 or earlier
      */
     protected abstract Object findExportedSymbol(C context, String globalName, boolean onlyExplicit);
 
@@ -213,6 +222,7 @@ public abstract class TruffleLanguage<C> {
      *
      * @param context context to find the language global in
      * @return the global object or <code>null</code> if the language does not support such concept
+     * @since 0.8 or earlier
      */
     protected abstract Object getLanguageGlobal(C context);
 
@@ -221,11 +231,14 @@ public abstract class TruffleLanguage<C> {
      *
      * @param object the object to check
      * @return <code>true</code> if this language can deal with such object in native way
+     * @since 0.8 or earlier
      */
     protected abstract boolean isObjectOfLanguage(Object object);
 
     /**
      * Gets visualization services for language-specific information.
+     * 
+     * @since 0.8 or earlier
      */
     @Deprecated
     protected Visualizer getVisualizer() {
@@ -239,6 +252,7 @@ public abstract class TruffleLanguage<C> {
      * <b>Note:</b> instrumentation requires a appropriate {@link WrapperNode}
      * 
      * @see WrapperNode
+     * @since 0.8 or earlier
      */
     protected boolean isInstrumentable(@SuppressWarnings("unused") Node node) {
         return false;
@@ -254,6 +268,7 @@ public abstract class TruffleLanguage<C> {
      * </ol>
      *
      * @return an appropriately typed {@link WrapperNode}
+     * @since 0.8 or earlier
      */
     protected WrapperNode createWrapperNode(@SuppressWarnings("unused") Node node) {
         throw new UnsupportedOperationException();
@@ -267,6 +282,7 @@ public abstract class TruffleLanguage<C> {
      * @param mFrame frame where execution halted, {@code null} if no execution context
      * @return result of running the code in the context, or at top level if no execution context.
      * @throws IOException if the evaluation cannot be performed
+     * @since 0.8 or earlier
      */
     protected abstract Object evalInContext(Source source, Node node, MaterializedFrame mFrame) throws IOException;
 
@@ -282,6 +298,7 @@ public abstract class TruffleLanguage<C> {
      * @param value the value to convert. Either primitive type or
      *            {@link com.oracle.truffle.api.interop.TruffleObject}
      * @return textual representation of the value in this language
+     * @since 0.8 or earlier
      */
     protected String toString(C context, Object value) {
         return Objects.toString(value);
@@ -294,6 +311,7 @@ public abstract class TruffleLanguage<C> {
      *
      * @return node to be inserted into program to effectively find out current execution context
      *         for this language
+     * @since 0.8 or earlier
      */
     @SuppressWarnings({"rawtypes", "unchecked"})
     protected final Node createFindContextNode() {
@@ -313,6 +331,7 @@ public abstract class TruffleLanguage<C> {
      *         beginning of the language execution
      * @throws ClassCastException if the node has not been created by <code>this</code>.
      *             {@link #createFindContextNode()} method.
+     * @since 0.8 or earlier
      */
     @SuppressWarnings({"rawtypes", "unchecked"})
     protected final C findContext(Node n) {
@@ -357,6 +376,8 @@ public abstract class TruffleLanguage<C> {
      * {@link TruffleLanguage} receives instance of the environment before any code is executed upon
      * it. The environment has knowledge of all active languages and can exchange symbols between
      * them.
+     * 
+     * @since 0.8 or earlier
      */
     public static final class Env {
         private final Object vm;
@@ -391,6 +412,7 @@ public abstract class TruffleLanguage<C> {
          *
          * @param globalName the name of the symbol to search for
          * @return object representing the symbol or <code>null</code>
+         * @since 0.8 or earlier
          */
         public Object importSymbol(String globalName) {
             return API.importSymbol(vm, lang, globalName);
@@ -404,6 +426,7 @@ public abstract class TruffleLanguage<C> {
          * @see #parse(Source, String...)
          *
          * @return a boolean that indicates if the MIME type is supported
+         * @since 0.11
          */
         public boolean isMimeTypeSupported(String mimeType) {
             return API.isMimeTypeSupported(vm, mimeType);
@@ -422,6 +445,7 @@ public abstract class TruffleLanguage<C> {
          *            that can be referenced from the source
          * @return the call target representing the parsed result
          * @throws IOException if the parsing or evaluation fails for some reason
+         * @since 0.8 or earlier
          */
         public CallTarget parse(Source source, String... argumentNames) throws IOException {
             TruffleLanguage<?> language = API.findLanguageImpl(vm, null, source.getMimeType());
@@ -433,6 +457,7 @@ public abstract class TruffleLanguage<C> {
          * being executed in.
          *
          * @return reader, never <code>null</code>
+         * @since 0.8 or earlier
          */
         public InputStream in() {
             return in;
@@ -443,6 +468,7 @@ public abstract class TruffleLanguage<C> {
          * is being executed in.
          *
          * @return writer, never <code>null</code>
+         * @since 0.8 or earlier
          */
         public OutputStream out() {
             return out;
@@ -453,11 +479,13 @@ public abstract class TruffleLanguage<C> {
          * is being executed in.
          *
          * @return writer, never <code>null</code>
+         * @since 0.8 or earlier
          */
         public OutputStream err() {
             return err;
         }
 
+        /** @since 0.8 or earlier */
         public Instrumenter instrumenter() {
             return instrumenter;
         }
@@ -474,6 +502,7 @@ public abstract class TruffleLanguage<C> {
          * @param <T> type of requested service
          * @param type class of requested service
          * @return instance of T or <code>null</code> if there is no such service available
+         * @since 0.12
          */
         public <T> T lookup(Class<T> type) {
             for (Object obj : services) {
@@ -509,6 +538,7 @@ public abstract class TruffleLanguage<C> {
          * {@codesnippet config.read}
          *
          * @return read-only view of configuration options for this language
+         * @since 0.11
          */
         public Map<String, Object> getConfig() {
             return config;

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleOptions.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleOptions.java
@@ -32,6 +32,8 @@ import com.oracle.truffle.api.nodes.NodeInfo;
 
 /**
  * Class containing general Truffle options.
+ * 
+ * @since 0.8 or earlier
  */
 public final class TruffleOptions {
     private TruffleOptions() {
@@ -41,6 +43,8 @@ public final class TruffleOptions {
      * Enables/disables the rewriting of traces in the Truffle runtime to stdout.
      * <p>
      * Can be set with {@code -Dtruffle.TraceRewrites=true}.
+     * 
+     * @since 0.8 or earlier
      */
     public static final boolean TraceRewrites;
 
@@ -49,6 +53,8 @@ public final class TruffleOptions {
      * for rewriting nodes.
      * <p>
      * Can be set with {@code -Dtruffle.DetailedRewriteReasons=true}.
+     * 
+     * @since 0.8 or earlier
      */
     public static final boolean DetailedRewriteReasons;
 
@@ -57,6 +63,8 @@ public final class TruffleOptions {
      * target class hierarchy.
      * <p>
      * Can be set with {@code -Dtruffle.TraceRewritesFilterClass=name}.
+     * 
+     * @since 0.8 or earlier
      */
     public static final String TraceRewritesFilterClass;
 
@@ -66,6 +74,8 @@ public final class TruffleOptions {
      * <p>
      * Can be set with
      * {@code -Dtruffle.TraceRewritesFilterFromCost=NONE|MONOMORPHIC|POLYMORPHIC|MEGAMORPHIC}.
+     * 
+     * @since 0.8 or earlier
      */
     public static final NodeCost TraceRewritesFilterFromCost;
 
@@ -75,6 +85,8 @@ public final class TruffleOptions {
      * <p>
      * Can be set with
      * {@code -Dtruffle.TraceRewritesFilterToKind=UNINITIALIZED|SPECIALIZED|POLYMORPHIC|GENERIC}.
+     * 
+     * @since 0.8 or earlier
      */
     public static final NodeCost TraceRewritesFilterToCost;
 
@@ -82,11 +94,15 @@ public final class TruffleOptions {
      * Enables the dumping of Node creations and AST rewrites in JSON format.
      * <p>
      * Can be set with {@code -Dtruffle.TraceASTJSON=true}.
+     * 
+     * @since 0.8 or earlier
      */
     public static final boolean TraceASTJSON;
 
     /**
      * Forces ahead-of-time initialization.
+     * 
+     * @since 0.8 or earlier
      */
     public static final boolean AOT;
 

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleRuntime.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleRuntime.java
@@ -41,6 +41,8 @@ import com.oracle.truffle.api.nodes.RootNode;
 /**
  * Interface representing a Truffle runtime object. The runtime is responsible for creating call
  * targets and performing optimizations for them.
+ * 
+ * @since 0.8 or earlier
  */
 public interface TruffleRuntime {
 
@@ -48,6 +50,7 @@ public interface TruffleRuntime {
      * Name describing this runtime implementation for debugging purposes.
      *
      * @return the name as a String
+     * @since 0.8 or earlier
      */
     String getName();
 
@@ -58,6 +61,7 @@ public interface TruffleRuntime {
      *            {@link RootNode#execute(com.oracle.truffle.api.frame.VirtualFrame)} method
      *            represents the entry point
      * @return the new call target object
+     * @since 0.8 or earlier
      */
     RootCallTarget createCallTarget(RootNode rootNode);
 
@@ -66,6 +70,7 @@ public interface TruffleRuntime {
      *
      * @param target the direct {@link CallTarget} to call
      * @return the new call node
+     * @since 0.8 or earlier
      */
     DirectCallNode createDirectCallNode(CallTarget target);
 
@@ -75,6 +80,7 @@ public interface TruffleRuntime {
      * replacement for loops.
      *
      * @see LoopNode usage example
+     * @since 0.8 or earlier
      */
     LoopNode createLoopNode(RepeatingNode body);
 
@@ -82,6 +88,7 @@ public interface TruffleRuntime {
      * Creates a new runtime specific version of {@link IndirectCallNode}.
      *
      * @return the new call node
+     * @since 0.8 or earlier
      */
     IndirectCallNode createIndirectCallNode();
 
@@ -89,6 +96,7 @@ public interface TruffleRuntime {
      * Creates a new assumption object that can be checked and invalidated.
      *
      * @return the newly created assumption object
+     * @since 0.8 or earlier
      */
     Assumption createAssumption();
 
@@ -97,6 +105,7 @@ public interface TruffleRuntime {
      *
      * @param name the name for the new assumption
      * @return the newly created assumption object
+     * @since 0.8 or earlier
      */
     Assumption createAssumption(String name);
 
@@ -105,6 +114,7 @@ public interface TruffleRuntime {
      * optimizable by the runtime.
      *
      * @return the newly created virtual frame object
+     * @since 0.8 or earlier
      */
     VirtualFrame createVirtualFrame(Object[] arguments, FrameDescriptor frameDescriptor);
 
@@ -112,6 +122,7 @@ public interface TruffleRuntime {
      * Creates a new materialized frame object that can be used to store values.
      *
      * @return the newly created materialized frame object
+     * @since 0.8 or earlier
      */
     MaterializedFrame createMaterializedFrame(Object[] arguments);
 
@@ -121,6 +132,7 @@ public interface TruffleRuntime {
      *
      * @param frameDescriptor the frame descriptor describing this frame's values
      * @return the newly created materialized frame object
+     * @since 0.8 or earlier
      */
     MaterializedFrame createMaterializedFrame(Object[] arguments, FrameDescriptor frameDescriptor);
 
@@ -129,6 +141,7 @@ public interface TruffleRuntime {
      * runtime.
      *
      * @return the newly created compiler options object
+     * @since 0.8 or earlier
      */
     CompilerOptions createCompilerOptions();
 
@@ -144,18 +157,23 @@ public interface TruffleRuntime {
      * @param visitor the visitor that is called for every matching frame.
      * @return the last result returned by the visitor (which is non-null to indicate that iteration
      *         should stop), or null if the whole stack was iterated.
+     * @since 0.8 or earlier
      */
     <T> T iterateFrames(FrameInstanceVisitor<T> visitor);
 
     /**
      * Accesses the caller frame. This is a convenience method that returns the first frame that is
      * passed to the visitor of {@link #iterateFrames}.
+     * 
+     * @since 0.8 or earlier
      */
     FrameInstance getCallerFrame();
 
     /**
      * Accesses the current frame, i.e., the frame of the closest {@link CallTarget}. It is
      * important to note that this {@link FrameInstance} supports only slow path access.
+     * 
+     * @since 0.8 or earlier
      */
     FrameInstance getCurrentFrame();
 
@@ -164,17 +182,22 @@ public interface TruffleRuntime {
      *
      * @param capability the type of the interface representing the capability
      * @return an implementation of the capability or {@code null} if the runtime does not offer it
+     * @since 0.8 or earlier
      */
     <T> T getCapability(Class<T> capability);
 
     /**
      * Returns a list of all still referenced {@link RootCallTarget} instances that were created
      * using {@link #createCallTarget(RootNode)}.
+     * 
+     * @since 0.8 or earlier
      */
     Collection<RootCallTarget> getCallTargets();
 
     /**
      * Internal API method. Do not use.
+     * 
+     * @since 0.8 or earlier
      */
     void notifyTransferToInterpreter();
 
@@ -184,6 +207,8 @@ public interface TruffleRuntime {
      * profiles in the {@link com.oracle.truffle.api.utilities} package are returning void
      * implementations. If it returns <code>true</code> then all implementations gather profilinig
      * information.
+     * 
+     * @since 0.8 or earlier
      */
     boolean isProfilingEnabled();
 

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleRuntimeAccess.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleRuntimeAccess.java
@@ -26,11 +26,15 @@ package com.oracle.truffle.api;
 
 /**
  * A service that provides access to a {@link TruffleRuntime} implementation.
+ * 
+ * @since 0.8 or earlier
  */
 public interface TruffleRuntimeAccess {
 
     /**
      * Gets the {@link TruffleRuntime} implementation available via this access object.
+     * 
+     * @since 0.8 or earlier
      */
     TruffleRuntime getRuntime();
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TypedObject.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TypedObject.java
@@ -24,8 +24,9 @@
  */
 package com.oracle.truffle.api;
 
+/** @since 0.8 or earlier */
 public interface TypedObject {
-
+    /** @since 0.8 or earlier */
     Object getTypeIdentifier();
 
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/Frame.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/Frame.java
@@ -27,11 +27,14 @@ package com.oracle.truffle.api.frame;
 /**
  * Represents a frame containing values of local variables of the guest language. Instances of this
  * type must not be stored in a field or cast to {@link java.lang.Object}.
+ * 
+ * @since 0.8 or earlier
  */
 public interface Frame {
 
     /**
      * @return the object describing the layout of this frame
+     * @since 0.8 or earlier
      */
     FrameDescriptor getFrameDescriptor();
 
@@ -40,6 +43,7 @@ public interface Frame {
      * is never null.
      *
      * @return the arguments used when calling this method
+     * @since 0.8 or earlier
      */
     Object[] getArguments();
 
@@ -48,6 +52,7 @@ public interface Frame {
      *
      * @param slot the slot of the local variable
      * @return the current value of the local variable
+     * @since 0.8 or earlier
      */
     Object getObject(FrameSlot slot) throws FrameSlotTypeException;
 
@@ -56,6 +61,7 @@ public interface Frame {
      *
      * @param slot the slot of the local variable
      * @param value the new value of the local variable
+     * @since 0.8 or earlier
      */
     void setObject(FrameSlot slot, Object value);
 
@@ -65,6 +71,7 @@ public interface Frame {
      * @param slot the slot of the local variable
      * @return the current value of the local variable
      * @throws FrameSlotTypeException
+     * @since 0.8 or earlier
      */
     byte getByte(FrameSlot slot) throws FrameSlotTypeException;
 
@@ -74,7 +81,7 @@ public interface Frame {
      * @param slot the slot of the local variable
      * @param value the new value of the local variable
      */
-
+    /** @since 0.8 or earlier */
     void setByte(FrameSlot slot, byte value);
 
     /**
@@ -82,6 +89,7 @@ public interface Frame {
      *
      * @param slot the slot of the local variable
      * @return the current value of the local variable
+     * @since 0.8 or earlier
      */
     boolean getBoolean(FrameSlot slot) throws FrameSlotTypeException;
 
@@ -90,6 +98,7 @@ public interface Frame {
      *
      * @param slot the slot of the local variable
      * @param value the new value of the local variable
+     * @since 0.8 or earlier
      */
     void setBoolean(FrameSlot slot, boolean value);
 
@@ -98,6 +107,7 @@ public interface Frame {
      *
      * @param slot the slot of the local variable
      * @return the current value of the local variable
+     * @since 0.8 or earlier
      */
     int getInt(FrameSlot slot) throws FrameSlotTypeException;
 
@@ -106,6 +116,7 @@ public interface Frame {
      *
      * @param slot the slot of the local variable
      * @param value the new value of the local variable
+     * @since 0.8 or earlier
      */
     void setInt(FrameSlot slot, int value);
 
@@ -114,6 +125,7 @@ public interface Frame {
      *
      * @param slot the slot of the local variable
      * @return the current value of the local variable
+     * @since 0.8 or earlier
      */
     long getLong(FrameSlot slot) throws FrameSlotTypeException;
 
@@ -122,6 +134,7 @@ public interface Frame {
      *
      * @param slot the slot of the local variable
      * @param value the new value of the local variable
+     * @since 0.8 or earlier
      */
     void setLong(FrameSlot slot, long value);
 
@@ -130,6 +143,7 @@ public interface Frame {
      *
      * @param slot the slot of the local variable
      * @return the current value of the local variable
+     * @since 0.8 or earlier
      */
     float getFloat(FrameSlot slot) throws FrameSlotTypeException;
 
@@ -138,6 +152,7 @@ public interface Frame {
      *
      * @param slot the slot of the local variable
      * @param value the new value of the local variable
+     * @since 0.8 or earlier
      */
     void setFloat(FrameSlot slot, float value);
 
@@ -146,6 +161,7 @@ public interface Frame {
      *
      * @param slot the slot of the local variable
      * @return the current value of the local variable
+     * @since 0.8 or earlier
      */
     double getDouble(FrameSlot slot) throws FrameSlotTypeException;
 
@@ -154,6 +170,7 @@ public interface Frame {
      *
      * @param slot the slot of the local variable
      * @param value the new value of the local variable
+     * @since 0.8 or earlier
      */
     void setDouble(FrameSlot slot, double value);
 
@@ -162,6 +179,7 @@ public interface Frame {
      *
      * @param slot the slot of the local variable
      * @return the current value of the local variable or defaultValue if unset
+     * @since 0.8 or earlier
      */
     Object getValue(FrameSlot slot);
 
@@ -170,41 +188,56 @@ public interface Frame {
      * {@link java.lang.Object}.
      *
      * @return the new materialized frame
+     * @since 0.8 or earlier
      */
     MaterializedFrame materialize();
 
     /**
      * Check whether the given {@link FrameSlot} is of type object.
+     * 
+     * @since 0.8 or earlier
      */
     boolean isObject(FrameSlot slot);
 
     /**
      * Check whether the given {@link FrameSlot} is of type byte.
+     * 
+     * @since 0.8 or earlier
      */
     boolean isByte(FrameSlot slot);
 
     /**
      * Check whether the given {@link FrameSlot} is of type boolean.
+     * 
+     * @since 0.8 or earlier
      */
     boolean isBoolean(FrameSlot slot);
 
     /**
      * Check whether the given {@link FrameSlot} is of type int.
+     * 
+     * @since 0.8 or earlier
      */
     boolean isInt(FrameSlot slot);
 
     /**
      * Check whether the given {@link FrameSlot} is of type long.
+     * 
+     * @since 0.8 or earlier
      */
     boolean isLong(FrameSlot slot);
 
     /**
      * Check whether the given {@link FrameSlot} is of type float.
+     * 
+     * @since 0.8 or earlier
      */
     boolean isFloat(FrameSlot slot);
 
     /**
      * Check whether the given {@link FrameSlot} is of type double.
+     * 
+     * @since 0.8 or earlier
      */
     boolean isDouble(FrameSlot slot);
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/FrameDescriptor.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/FrameDescriptor.java
@@ -37,6 +37,8 @@ import com.oracle.truffle.api.Truffle;
 /**
  * Descriptor of the slots of frame objects. Multiple frame instances are associated with one such
  * descriptor.
+ * 
+ * @since 0.8 or earlier
  */
 public final class FrameDescriptor implements Cloneable {
 
@@ -50,6 +52,8 @@ public final class FrameDescriptor implements Cloneable {
 
     /**
      * Constructs empty descriptor. The {@link #getDefaultValue()} is <code>null</code>.
+     * 
+     * @since 0.8 or earlier
      */
     public FrameDescriptor() {
         this(null);
@@ -59,6 +63,7 @@ public final class FrameDescriptor implements Cloneable {
      * Constructs new descriptor with specified {@link #getDefaultValue()}.
      *
      * @param defaultValue to be returned from {@link #getDefaultValue()}
+     * @since 0.8 or earlier
      */
     public FrameDescriptor(Object defaultValue) {
         CompilerAsserts.neverPartOfCompilation("do not create a FrameDescriptor from compiled code");
@@ -73,6 +78,7 @@ public final class FrameDescriptor implements Cloneable {
      *
      * @return new instance of the descriptor
      * @deprecated
+     * @since 0.8 or earlier
      */
     @Deprecated
     public static FrameDescriptor create() {
@@ -84,6 +90,7 @@ public final class FrameDescriptor implements Cloneable {
      *
      * @return new instance of the descriptor
      * @deprecated
+     * @since 0.8 or earlier
      */
     @Deprecated
     public static FrameDescriptor create(Object defaultValue) {
@@ -98,6 +105,7 @@ public final class FrameDescriptor implements Cloneable {
      *
      * @param identifier key for the slot
      * @return the newly created slot
+     * @since 0.8 or earlier
      */
     public FrameSlot addFrameSlot(Object identifier) {
         return addFrameSlot(identifier, null, FrameSlotKind.Illegal);
@@ -112,6 +120,7 @@ public final class FrameDescriptor implements Cloneable {
      * @param identifier key for the slot
      * @param kind the kind of the new slot
      * @return the newly created slot
+     * @since 0.8 or earlier
      */
     public FrameSlot addFrameSlot(Object identifier, FrameSlotKind kind) {
         return addFrameSlot(identifier, null, kind);
@@ -127,6 +136,7 @@ public final class FrameDescriptor implements Cloneable {
      * @param kind the kind of the new slot
      * @return the newly created slot
      * @throws IllegalArgumentException if a frame slot with the same identifier exists
+     * @since 0.8 or earlier
      */
     public FrameSlot addFrameSlot(Object identifier, Object info, FrameSlotKind kind) {
         CompilerAsserts.neverPartOfCompilation(NEVER_PART_OF_COMPILATION_MESSAGE);
@@ -146,6 +156,7 @@ public final class FrameDescriptor implements Cloneable {
      *
      * @param identifier the key of the slot to search for
      * @return the slot or <code>null</code>
+     * @since 0.8 or earlier
      */
     public FrameSlot findFrameSlot(Object identifier) {
         CompilerAsserts.neverPartOfCompilation(NEVER_PART_OF_COMPILATION_MESSAGE);
@@ -157,6 +168,7 @@ public final class FrameDescriptor implements Cloneable {
      *
      * @param identifier the key of the slot to search for
      * @return the slot
+     * @since 0.8 or earlier
      */
     public FrameSlot findOrAddFrameSlot(Object identifier) {
         FrameSlot result = findFrameSlot(identifier);
@@ -172,6 +184,7 @@ public final class FrameDescriptor implements Cloneable {
      * @param identifier the key of the slot to search for
      * @param kind the kind for the newly created slot
      * @return the found or newly created slot
+     * @since 0.8 or earlier
      */
     public FrameSlot findOrAddFrameSlot(Object identifier, FrameSlotKind kind) {
         FrameSlot result = findFrameSlot(identifier);
@@ -188,6 +201,7 @@ public final class FrameDescriptor implements Cloneable {
      * @param info info for the newly created slot
      * @param kind the kind for the newly created slot
      * @return the found or newly created slot
+     * @since 0.8 or earlier
      */
     public FrameSlot findOrAddFrameSlot(Object identifier, Object info, FrameSlotKind kind) {
         FrameSlot result = findFrameSlot(identifier);
@@ -203,6 +217,7 @@ public final class FrameDescriptor implements Cloneable {
      *
      * @param identifier identifies the slot to remove
      * @throws IllegalArgumentException if no such frame slot exists
+     * @since 0.8 or earlier
      */
     public void removeFrameSlot(Object identifier) {
         CompilerAsserts.neverPartOfCompilation(NEVER_PART_OF_COMPILATION_MESSAGE);
@@ -219,6 +234,7 @@ public final class FrameDescriptor implements Cloneable {
      * Returns number of slots in the descriptor.
      *
      * @return the same value as {@link #getSlots()}.{@link List#size()} would return
+     * @since 0.8 or earlier
      */
     public int getSize() {
         return slots.size();
@@ -228,6 +244,7 @@ public final class FrameDescriptor implements Cloneable {
      * Current set of slots in the descriptor.
      *
      * @return unmodifiable list of {@link FrameSlot}
+     * @since 0.8 or earlier
      */
     public List<? extends FrameSlot> getSlots() {
         return Collections.unmodifiableList(slots);
@@ -237,6 +254,7 @@ public final class FrameDescriptor implements Cloneable {
      * Retrieve the list of all the identifiers associated with this frame descriptor.
      *
      * @return the list of all the identifiers in this frame descriptor
+     * @since 0.8 or earlier
      */
     public Set<Object> getIdentifiers() {
         return Collections.unmodifiableSet(identifierToSlotMap.keySet());
@@ -248,6 +266,7 @@ public final class FrameDescriptor implements Cloneable {
      * but not their {@linkplain FrameSlot#getKind() kind}!
      *
      * @return new instance of a descriptor with copies of values from this one
+     * @since 0.8 or earlier
      */
     public FrameDescriptor copy() {
         FrameDescriptor clonedFrameDescriptor = new FrameDescriptor(this.defaultValue);
@@ -264,6 +283,7 @@ public final class FrameDescriptor implements Cloneable {
      * of the slots it is changed in the original as well as in the shallow copy.
      *
      * @return new instance of a descriptor with copies of values from this one
+     * @since 0.8 or earlier
      */
     public FrameDescriptor shallowCopy() {
         FrameDescriptor clonedFrameDescriptor = new FrameDescriptor(this.defaultValue);
@@ -286,6 +306,7 @@ public final class FrameDescriptor implements Cloneable {
      * associated with compiled code that depends on the internal frame layout.
      *
      * @return an assumption invalidated when a slot is added or removed, or a slot kind changed.
+     * @since 0.8 or earlier
      */
     public Assumption getVersion() {
         return version;
@@ -299,6 +320,7 @@ public final class FrameDescriptor implements Cloneable {
      * Default value for the created slots.
      *
      * @return value provided to {@link #FrameDescriptor(java.lang.Object)}
+     * @since 0.8 or earlier
      */
     public Object getDefaultValue() {
         return defaultValue;
@@ -311,6 +333,7 @@ public final class FrameDescriptor implements Cloneable {
      * @param identifier frame slot identifier
      * @return an assumption that this frame descriptor does not contain a slot with the identifier
      * @throws IllegalArgumentException if the frame descriptor contains a slot with the identifier
+     * @since 0.8 or earlier
      */
     public Assumption getNotInFrameAssumption(Object identifier) {
         if (identifierToSlotMap.containsKey(identifier)) {
@@ -340,6 +363,7 @@ public final class FrameDescriptor implements Cloneable {
         }
     }
 
+    /** @since 0.8 or earlier */
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/FrameInstance.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/FrameInstance.java
@@ -27,20 +27,29 @@ package com.oracle.truffle.api.frame;
 import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.nodes.Node;
 
+/** @since 0.8 or earlier */
 public interface FrameInstance {
-
+    /** @since 0.8 or earlier */
     enum FrameAccess {
+        /** @since 0.8 or earlier */
         NONE,
+        /** @since 0.8 or earlier */
         READ_ONLY,
+        /** @since 0.8 or earlier */
         READ_WRITE,
+        /** @since 0.8 or earlier */
         MATERIALIZE
     }
 
+    /** @since 0.8 or earlier */
     Frame getFrame(FrameAccess access, boolean slowPath);
 
+    /** @since 0.8 or earlier */
     boolean isVirtualFrame();
 
+    /** @since 0.8 or earlier */
     Node getCallNode();
 
+    /** @since 0.8 or earlier */
     CallTarget getCallTarget();
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/FrameInstanceVisitor.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/FrameInstanceVisitor.java
@@ -31,8 +31,10 @@ import com.oracle.truffle.api.TruffleRuntime;
  * {@link #visitFrame} return null to indicate that frame iteration should continue and the next
  * caller frame should be visited; and return any non-null value to indicate that frame iteration
  * should stop.
+ * 
+ * @since 0.8 or earlier
  */
 public interface FrameInstanceVisitor<T> {
-
+    /** @since 0.8 or earlier */
     T visitFrame(FrameInstance frameInstance);
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/FrameSlot.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/FrameSlot.java
@@ -30,6 +30,8 @@ import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 
 /**
  * A slot in a {@link Frame} and {@link FrameDescriptor} that can store a value of a given type.
+ * 
+ * @since 0.8 or earlier
  */
 public final class FrameSlot implements Cloneable {
 
@@ -44,6 +46,7 @@ public final class FrameSlot implements Cloneable {
      *             {@link FrameDescriptor#addFrameSlot(java.lang.Object, java.lang.Object, com.oracle.truffle.api.frame.FrameSlotKind)}
      *             to create new instance of the slot. This method will be made package private in
      *             the future.
+     * @since 0.8 or earlier
      */
     @Deprecated
     public FrameSlot(FrameDescriptor descriptor, Object identifier, Object info, int index, FrameSlotKind kind) {
@@ -63,6 +66,7 @@ public final class FrameSlot implements Cloneable {
      *
      * @return value as specified in {@link FrameDescriptor#addFrameSlot(java.lang.Object)}
      *         parameter
+     * @since 0.8 or earlier
      */
     public Object getIdentifier() {
         return identifier;
@@ -73,6 +77,7 @@ public final class FrameSlot implements Cloneable {
      *
      * @return value as specified as second parameter of
      *         {@link FrameDescriptor#addFrameSlot(java.lang.Object, java.lang.Object, com.oracle.truffle.api.frame.FrameSlotKind)}
+     * @since 0.8 or earlier
      */
     public Object getInfo() {
         return info;
@@ -84,6 +89,7 @@ public final class FrameSlot implements Cloneable {
      * @return position of the slot computed after
      *         {@link FrameDescriptor#addFrameSlot(java.lang.Object, java.lang.Object, com.oracle.truffle.api.frame.FrameSlotKind)
      *         adding} it.
+     * @since 0.8 or earlier
      */
     public int getIndex() {
         return index;
@@ -96,6 +102,7 @@ public final class FrameSlot implements Cloneable {
      * method.
      *
      * @return current kind of this slot
+     * @since 0.8 or earlier
      */
     public FrameSlotKind getKind() {
         return kind;
@@ -107,6 +114,7 @@ public final class FrameSlot implements Cloneable {
      * {@link #getFrameDescriptor() associated descriptor}.
      *
      * @param kind new kind of the slot
+     * @since 0.8 or earlier
      */
     public void setKind(final FrameSlotKind kind) {
         if (this.kind != kind) {
@@ -116,6 +124,7 @@ public final class FrameSlot implements Cloneable {
         }
     }
 
+    /** @since 0.8 or earlier */
     @Override
     public String toString() {
         CompilerAsserts.neverPartOfCompilation("do not call FrameSlot.toString from compiled code");
@@ -127,6 +136,7 @@ public final class FrameSlot implements Cloneable {
      *
      * @return instance of descriptor that {@link FrameDescriptor#addFrameSlot(java.lang.Object)
      *         created} the slot
+     * @since 0.8 or earlier
      */
     public FrameDescriptor getFrameDescriptor() {
         return this.descriptor;

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/FrameSlotKind.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/FrameSlotKind.java
@@ -24,18 +24,28 @@
  */
 package com.oracle.truffle.api.frame;
 
+/** @since 0.8 or earlier */
 public enum FrameSlotKind {
+    /** @since 0.8 or earlier */
     Object,
+    /** @since 0.8 or earlier */
     Illegal,
+    /** @since 0.8 or earlier */
     Long,
+    /** @since 0.8 or earlier */
     Int,
+    /** @since 0.8 or earlier */
     Double,
+    /** @since 0.8 or earlier */
     Float,
+    /** @since 0.8 or earlier */
     Boolean,
+    /** @since 0.8 or earlier */
     Byte;
-
+    /** @since 0.8 or earlier */
     public final byte tag;
 
+    /** @since 0.8 or earlier */
     FrameSlotKind() {
         this.tag = (byte) ordinal();
     }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/FrameSlotTypeException.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/FrameSlotTypeException.java
@@ -28,11 +28,14 @@ import com.oracle.truffle.api.nodes.SlowPathException;
 
 /**
  * Exception thrown if the frame slot type does not match the access type.
+ * 
+ * @since 0.8 or earlier
  */
 public final class FrameSlotTypeException extends SlowPathException {
 
     private static final long serialVersionUID = 6972120475215757452L;
 
+    /** @since 0.8 or earlier */
     public FrameSlotTypeException() {
     }
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/FrameUtil.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/FrameUtil.java
@@ -24,7 +24,16 @@
  */
 package com.oracle.truffle.api.frame;
 
+/** @since 0.8 or earlier */
 public final class FrameUtil {
+    /**
+     * @deprecated accidentally public - don't use
+     * @since 0.8 or earlier
+     */
+    @Deprecated
+    public FrameUtil() {
+    }
+
     /**
      * Read a frame slot that is guaranteed to be of the desired kind (either previously checked by
      * a guard or statically known).
@@ -32,6 +41,7 @@ public final class FrameUtil {
      * @param frameSlot the slot of the variable
      * @throws IllegalStateException if the slot kind does not match
      * @see Frame#getObject(FrameSlot)
+     * @since 0.8 or earlier
      */
     public static Object getObjectSafe(Frame frame, FrameSlot frameSlot) {
         try {
@@ -48,6 +58,7 @@ public final class FrameUtil {
      * @param frameSlot the slot of the variable
      * @throws IllegalStateException if the slot kind does not match
      * @see Frame#getByte(FrameSlot)
+     * @since 0.8 or earlier
      */
     public static byte getByteSafe(Frame frame, FrameSlot frameSlot) {
         try {
@@ -64,6 +75,7 @@ public final class FrameUtil {
      * @param frameSlot the slot of the variable
      * @throws IllegalStateException if the slot kind does not match
      * @see Frame#getBoolean(FrameSlot)
+     * @since 0.8 or earlier
      */
     public static boolean getBooleanSafe(Frame frame, FrameSlot frameSlot) {
         try {
@@ -80,6 +92,7 @@ public final class FrameUtil {
      * @param frameSlot the slot of the variable
      * @throws IllegalStateException if the slot kind does not match
      * @see Frame#getInt(FrameSlot)
+     * @since 0.8 or earlier
      */
     public static int getIntSafe(Frame frame, FrameSlot frameSlot) {
         try {
@@ -96,6 +109,7 @@ public final class FrameUtil {
      * @param frameSlot the slot of the variable
      * @throws IllegalStateException if the slot kind does not match
      * @see Frame#getLong(FrameSlot)
+     * @since 0.8 or earlier
      */
     public static long getLongSafe(Frame frame, FrameSlot frameSlot) {
         try {
@@ -112,6 +126,7 @@ public final class FrameUtil {
      * @param frameSlot the slot of the variable
      * @throws IllegalStateException if the slot kind does not match
      * @see Frame#getDouble(FrameSlot)
+     * @since 0.8 or earlier
      */
     public static double getDoubleSafe(Frame frame, FrameSlot frameSlot) {
         try {
@@ -128,6 +143,7 @@ public final class FrameUtil {
      * @param frameSlot the slot of the variable
      * @throws IllegalStateException if the slot kind does not match
      * @see Frame#getFloat(FrameSlot)
+     * @since 0.8 or earlier
      */
     public static float getFloatSafe(Frame frame, FrameSlot frameSlot) {
         try {

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/MaterializedFrame.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/MaterializedFrame.java
@@ -28,6 +28,8 @@ package com.oracle.truffle.api.frame;
  * Represents a materialized frame containing values of local variables of the guest language. It
  * can be created using the {@link VirtualFrame#materialize()} method. Instances of this type are
  * the only frame instances that may be stored in fields or cast to {@link java.lang.Object}.
+ * 
+ * @since 0.8 or earlier
  */
 public interface MaterializedFrame extends Frame {
 

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/VirtualFrame.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/VirtualFrame.java
@@ -29,6 +29,8 @@ package com.oracle.truffle.api.frame;
  * type must not be stored in a field or cast to {@link java.lang.Object}. If this is necessary, the
  * frame must be explicitly converted into a materialized frame using the
  * {@link VirtualFrame#materialize()} method.
+ * 
+ * @since 0.8 or earlier
  */
 public interface VirtualFrame extends Frame {
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/ASTPrinter.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/ASTPrinter.java
@@ -32,6 +32,8 @@ import java.io.PrintWriter;
  * details chosen to be presented.
  * <p>
  * <strong>WARNING:</strong> this interface is under development and will change substantially.
+ * 
+ * @since 0.8 or earlier
  */
 public interface ASTPrinter {
 
@@ -42,6 +44,7 @@ public interface ASTPrinter {
      * @param node the root node of the display.
      * @param maxDepth the maximum number of levels to print below the root
      * @param markNode a node to mark with a textual arrow prefix, if present.
+     * @since 0.8 or earlier
      */
     void printTree(PrintWriter p, Node node, int maxDepth, Node markNode);
 
@@ -51,6 +54,7 @@ public interface ASTPrinter {
      * @param node the root node of the display.
      * @param maxDepth the maximum number of levels to print below the root
      * @param markNode a node to mark with a textual arrow prefix, if present.
+     * @since 0.8 or earlier
      */
     String printTreeToString(Node node, int maxDepth, Node markNode);
 
@@ -59,12 +63,15 @@ public interface ASTPrinter {
      *
      * @param node the root node of the display.
      * @param maxDepth the maximum number of levels to print below the root
+     * @since 0.8 or earlier
      */
     String printTreeToString(Node node, int maxDepth);
 
     /**
      * Creates a textual display describing a single (non-wrapper) node, including instrumentation
      * status: if Probed, and any tags.
+     * 
+     * @since 0.8 or earlier
      */
     String printNodeWithInstrumentation(Node node);
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/ASTProber.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/ASTProber.java
@@ -31,12 +31,15 @@ import com.oracle.truffle.api.nodes.RootNode;
  * nodes in a (newly created, not yet executed) {@link RootNode}.
  *
  * @see Instrumenter#probe(com.oracle.truffle.api.nodes.Node)
+ * @since 0.8 or earlier
  */
 public interface ASTProber {
 
     /**
      * Walk the root's AST and enable instrumentation at selected nodes by attaching
      * {@linkplain Probe Probes} to them.
+     * 
+     * @since 0.8 or earlier
      */
     void probeAST(Instrumenter instrumenter, RootNode rootNode);
 

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/EvalInstrumentListener.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/EvalInstrumentListener.java
@@ -38,6 +38,7 @@ import com.oracle.truffle.api.source.Source;
  * methods should be coded with Truffle guidelines and cautions in mind.
  *
  * @see Instrumenter
+ * @since 0.8 or earlier
  */
 public interface EvalInstrumentListener {
 
@@ -53,6 +54,7 @@ public interface EvalInstrumentListener {
      * @param node the guest language AST node at which the expression was evaluated
      * @param frame execution frame at the guest-language AST node
      * @param result expression evaluation
+     * @since 0.8 or earlier
      */
     void onExecution(Node node, VirtualFrame frame, Object result);
 
@@ -70,6 +72,7 @@ public interface EvalInstrumentListener {
      *            attached
      * @param frame execution frame at the guest-language AST node
      * @param ex the exception
+     * @since 0.8 or earlier
      */
     void onFailure(Node node, VirtualFrame frame, Exception ex);
 

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/EventHandlerNode.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/EventHandlerNode.java
@@ -30,34 +30,46 @@ import com.oracle.truffle.api.nodes.Node;
 /**
  * An Instrumentation-managed {@link Node} that synchronously propagates notification of AST
  * Execution Events through the {@linkplain Instrumenter Instrumentation Framework} .
+ * 
+ * @since 0.8 or earlier
  */
 public abstract class EventHandlerNode extends Node implements InstrumentationNode {
-
+    /** @since 0.8 or earlier */
     protected EventHandlerNode() {
     }
 
     /**
      * An AST node's execute method is about to be called.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract void enter(Node node, VirtualFrame frame);
 
     /**
      * An AST Node's {@code void}-valued execute method has just returned.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract void returnVoid(Node node, VirtualFrame frame);
 
     /**
      * An AST Node's execute method has just returned a value (boxed if primitive).
+     * 
+     * @since 0.8 or earlier
      */
     public abstract void returnValue(Node node, VirtualFrame frame, Object result);
 
     /**
      * An AST Node's execute method has just thrown an exception.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract void returnExceptional(Node node, VirtualFrame frame, Throwable exception);
 
     /**
      * Gets the {@link Probe} that manages this chain of event handling.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract Probe getProbe();
 

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/Instrument.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/Instrument.java
@@ -36,6 +36,7 @@ package com.oracle.truffle.api.instrument;
  * wiki.openjdk.java.net/display/Graal/Listening+for+Execution+Events</a>
  *
  * @see Instrumenter
+ * @since 0.8 or earlier
  */
 public abstract class Instrument {
 
@@ -52,6 +53,7 @@ public abstract class Instrument {
      * Detaches this from its source of execution events and makes itself unusable.
      *
      * @throws IllegalStateException if this has already been disposed
+     * @since 0.8 or earlier
      */
     public void dispose() throws IllegalStateException {
         if (isDisposed) {
@@ -63,11 +65,14 @@ public abstract class Instrument {
 
     /**
      * Has this been detached from its source of execution events?
+     * 
+     * @since 0.8 or earlier
      */
     public boolean isDisposed() {
         return isDisposed;
     }
 
+    /** @since 0.8 or earlier */
     public final String getInstrumentInfo() {
         return instrumentInfo;
     }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/InstrumentationNode.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/InstrumentationNode.java
@@ -31,11 +31,15 @@ import com.oracle.truffle.api.nodes.Node;
  * {@linkplain Instrumenter Instrumentation Framework} . Such nodes should not be part of any Guest
  * Language execution semantics, and should in general not be visible to ordinary Instrumentation
  * clients.
+ * 
+ * @since 0.8 or earlier
  */
 public interface InstrumentationNode {
 
     /**
      * A short description of the particular role played by the node, intended to support debugging.
+     * 
+     * @since 0.8 or earlier
      */
     String instrumentationInfo();
 

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/Instrumenter.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/Instrumenter.java
@@ -91,6 +91,8 @@ import java.util.Map;
  * {@linkplain #install(Tool) installed} for data collection, possibly providing their own services
  * with the resulting information.</li>
  * </ul>
+ * 
+ * @since 0.8 or earlier
  */
 public final class Instrumenter {
 
@@ -154,6 +156,8 @@ public final class Instrumenter {
      * <li>Return modification-safe representations of the data; and</li>
      * <li>Not change the state of the data.</li>
      * </ul>
+     * 
+     * @since 0.8 or earlier
      */
     public abstract static class Tool {
 
@@ -161,6 +165,7 @@ public final class Instrumenter {
 
         private Instrumenter instrumenter;
 
+        /** @since 0.8 or earlier */
         protected Tool() {
         }
 
@@ -176,6 +181,7 @@ public final class Instrumenter {
 
         /**
          * @return whether the tool is currently collecting data.
+         * @since 0.8 or earlier
          */
         public final boolean isEnabled() {
             return toolState == ToolState.ENABLED;
@@ -186,6 +192,7 @@ public final class Instrumenter {
          * collecting data, but keeping data already collected).
          *
          * @throws IllegalStateException if not yet installed or disposed.
+         * @since 0.8 or earlier
          */
         public final void setEnabled(boolean isEnabled) {
             checkInstalled();
@@ -197,6 +204,7 @@ public final class Instrumenter {
          * Clears any data already collected, but otherwise does not change the state of the tool.
          *
          * @throws IllegalStateException if not yet installed or disposed.
+         * @since 0.8 or earlier
          */
         public final void reset() {
             checkInstalled();
@@ -208,6 +216,7 @@ public final class Instrumenter {
          * already collected.
          *
          * @throws IllegalStateException if not yet installed or disposed.
+         * @since 0.8 or earlier
          */
         public final void dispose() {
             checkInstalled();
@@ -218,6 +227,7 @@ public final class Instrumenter {
 
         /**
          * @return whether the installation succeeded.
+         * @since 0.8 or earlier
          */
         protected abstract boolean internalInstall();
 
@@ -225,14 +235,18 @@ public final class Instrumenter {
          * No subclass action required.
          *
          * @param isEnabled
+         * @since 0.8 or earlier
          */
         protected void internalSetEnabled(boolean isEnabled) {
         }
 
+        /** @since 0.8 or earlier */
         protected abstract void internalReset();
 
+        /** @since 0.8 or earlier */
         protected abstract void internalDispose();
 
+        /** @since 0.8 or earlier */
         protected final Instrumenter getInstrumenter() {
             return instrumenter;
         }
@@ -310,6 +324,7 @@ public final class Instrumenter {
      *
      * @return a (possibly newly created) {@link Probe} associated with this node.
      * @throws ProbeException (unchecked) when a Probe cannot be created, leaving the AST unchanged
+     * @since 0.8 or earlier
      */
     @SuppressWarnings("rawtypes")
     public Probe probe(Node node) {
@@ -372,6 +387,8 @@ public final class Instrumenter {
 
     /**
      * Adds a {@link ProbeListener} to receive events.
+     * 
+     * @since 0.8 or earlier
      */
     public void addProbeListener(ProbeListener listener) {
         assert listener != null;
@@ -380,6 +397,8 @@ public final class Instrumenter {
 
     /**
      * Removes a {@link ProbeListener}. Ignored if listener not found.
+     * 
+     * @since 0.8 or earlier
      */
     public void removeProbeListener(ProbeListener listener) {
         probeListeners.remove(listener);
@@ -390,6 +409,7 @@ public final class Instrumenter {
      * probes if the specified tag is {@code null}.
      *
      * @return A collection of probes containing the given tag.
+     * @since 0.8 or earlier
      */
     public Collection<Probe> findProbesTaggedAs(SyntaxTag tag) {
         final List<Probe> taggedProbes = new ArrayList<>();
@@ -407,6 +427,8 @@ public final class Instrumenter {
     /**
      * Enables instrumentation at selected nodes in all subsequently constructed ASTs. Ignored if
      * the argument is already registered, runtime error if argument is {@code null}.
+     * 
+     * @since 0.8 or earlier
      */
     public void registerASTProber(ASTProber prober) {
         if (prober == null) {
@@ -415,6 +437,7 @@ public final class Instrumenter {
         astProbers.add(prober);
     }
 
+    /** @since 0.8 or earlier */
     public void unregisterASTProber(ASTProber prober) {
         astProbers.remove(prober);
     }
@@ -430,6 +453,7 @@ public final class Instrumenter {
      * @param listener receiver of execution events
      * @param instrumentInfo optional documentation about the Instrument
      * @return a handle for access to the binding
+     * @since 0.8 or earlier
      */
     public ProbeInstrument attach(Probe probe, SimpleInstrumentListener listener, String instrumentInfo) {
         assert probe.getInstrumenter() == this;
@@ -449,6 +473,7 @@ public final class Instrumenter {
      * @param listener receiver of execution events
      * @param instrumentInfo optional documentation about the Instrument
      * @return a handle for access to the binding
+     * @since 0.8 or earlier
      */
     public ProbeInstrument attach(Probe probe, StandardInstrumentListener listener, String instrumentInfo) {
         assert probe.getInstrumenter() == this;
@@ -480,6 +505,7 @@ public final class Instrumenter {
      * @param instrumentInfo instrumentInfo optional documentation about the Instrument
      * @return a handle for access to the binding
      * @deprecated
+     * @since 0.8 or earlier
      */
     @Deprecated
     @SuppressWarnings("rawtypes")
@@ -515,6 +541,7 @@ public final class Instrumenter {
      *            {@link CallTarget#call(java.lang.Object...)} returned from the <code>parse</code>
      *            method; the value can be <code>null</code>
      * @return a handle for access to the binding
+     * @since 0.8 or earlier
      */
     public ProbeInstrument attach(Probe probe, Source source, EvalInstrumentListener listener, String instrumentInfo, Map<String, Object> parameters) {
         final int size = parameters == null ? 0 : parameters.size();
@@ -562,6 +589,7 @@ public final class Instrumenter {
      * @param instrumentInfo optional, mainly for debugging.
      * @return a newly created, active Instrument
      * @throws IllegalStateException if called when a <em>before</em> Instrument is active.
+     * @since 0.8 or earlier
      */
     public TagInstrument attach(SyntaxTag tag, StandardBeforeInstrumentListener listener, String instrumentInfo) {
         if (beforeTagInstrument != null) {
@@ -586,6 +614,7 @@ public final class Instrumenter {
      * @param instrumentInfo optional, mainly for debugging.
      * @return a newly created, active Instrument
      * @throws IllegalStateException if called when a <em>after</em> Instrument is active.
+     * @since 0.8 or earlier
      */
     public TagInstrument attach(SyntaxTag tag, StandardAfterInstrumentListener listener, String instrumentInfo) {
         if (afterTagInstrument != null) {
@@ -601,6 +630,7 @@ public final class Instrumenter {
      *
      * @return the tool
      * @throws IllegalStateException if the tool has previously been installed or has been disposed.
+     * @since 0.8 or earlier
      */
     public Tool install(Tool tool) {
         tool.install(this);

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/KillException.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/KillException.java
@@ -28,9 +28,19 @@ import com.oracle.truffle.api.nodes.ControlFlowException;
 
 /**
  * Controls breaking out of an execution context, such as a shell or eval.
+ * 
+ * @since 0.8 or earlier
  */
 @Deprecated
 public final class KillException extends ControlFlowException {
 
     private static final long serialVersionUID = 3163641880088766957L;
+
+    /**
+     * Default constructor.
+     * 
+     * @since 0.8 or earlier
+     */
+    public KillException() {
+    }
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/Probe.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/Probe.java
@@ -64,6 +64,7 @@ import com.oracle.truffle.api.utilities.CyclicAssumption;
  * @see ASTProber
  * @see ProbeListener
  * @see SyntaxTag
+ * @since 0.8 or earlier
  */
 @SuppressWarnings("rawtypes")
 public final class Probe {
@@ -160,6 +161,8 @@ public final class Probe {
     /**
      * Adds a {@linkplain SyntaxTag tag} to the set of tags associated with this {@link Probe};
      * {@code no-op} if already in the set.
+     * 
+     * @since 0.8 or earlier
      */
     public void tagAs(SyntaxTag tag, Object tagValue) {
         assert tag != null;
@@ -191,6 +194,8 @@ public final class Probe {
     /**
      * Is the <em>Probed node</em> tagged as belonging to a particular human-sensible category of
      * language constructs?
+     * 
+     * @since 0.8 or earlier
      */
     public boolean isTaggedAs(SyntaxTag tag) {
         assert tag != null;
@@ -200,6 +205,8 @@ public final class Probe {
     /**
      * In which user-sensible categories has the <em>Probed node</em> been tagged (
      * <em>empty set</em> if none).
+     * 
+     * @since 0.8 or earlier
      */
     public Collection<SyntaxTag> getSyntaxTags() {
         return Collections.unmodifiableCollection(tags);
@@ -231,11 +238,14 @@ public final class Probe {
     /**
      * Gets the {@link SourceSection} associated with the <en>Probed AST node</em>, possibly
      * {@code null}.
+     * 
+     * @since 0.8 or earlier
      */
     public SourceSection getProbedSourceSection() {
         return sourceSection;
     }
 
+    /** @since 0.8 or earlier */
     public String getShortDescription() {
         final String location = sourceSection == null ? "<unknown>" : sourceSection.getShortDescription();
         return "Probe@" + location + getTagsDescription();

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/ProbeException.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/ProbeException.java
@@ -32,19 +32,24 @@ import com.oracle.truffle.api.nodes.Node;
  * failure.
  * <p>
  * Language and tool implementations should ensure that clients of tools never see this exception.
+ * 
+ * @since 0.8 or earlier
  */
 public class ProbeException extends RuntimeException {
     static final long serialVersionUID = 1L;
     private final ProbeFailure failure;
 
+    /** @since 0.8 or earlier */
     public ProbeException(Reason reason, Node parent, Node child, Object wrapper) {
         this.failure = new ProbeFailure(reason, parent, child, wrapper);
     }
 
+    /** @since 0.8 or earlier */
     public ProbeFailure getFailure() {
         return failure;
     }
 
+    /** @since 0.8 or earlier */
     @Override
     public String toString() {
         return failure.getMessage();

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/ProbeFailure.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/ProbeFailure.java
@@ -30,33 +30,45 @@ import com.oracle.truffle.api.nodes.NodeUtil;
 
 /**
  * Description of a failed attempt to instrument an AST node.
+ * 
+ * @since 0.8 or earlier
  */
 public final class ProbeFailure {
-
+    /** @since 0.8 or earlier */
     public enum Reason {
 
         /**
          * Node to be probed has no parent.
+         * 
+         * @since 0.8 or earlier
          */
         NO_PARENT("Node to be probed has no parent"),
 
         /**
          * The node to be probed is a wrapper.
+         * 
+         * @since 0.8 or earlier
          */
         WRAPPER_NODE("The node to be probed is a wrapper"),
 
         /**
          * The node to be probed does not support {@linkplain Instrumenter Instrumentation} .
+         * 
+         * @since 0.8 or earlier
          */
         NOT_INSTRUMENTABLE("The node to be project is \"not instrumentable\""),
 
         /**
          * No wrapper could be created that is also a {@link Node}.
+         * 
+         * @since 0.8 or earlier
          */
         NO_WRAPPER("No wrapper could be created"),
 
         /**
          * Wrapper not assignable to the parent's child field.
+         * 
+         * @since 0.8 or earlier
          */
         WRAPPER_TYPE("Wrapper not assignable to parent's child field");
 
@@ -66,6 +78,7 @@ public final class ProbeFailure {
             this.message = message;
         }
 
+        /** @since 0.8 or earlier */
         public String getMessage() {
             return message;
         }
@@ -83,6 +96,7 @@ public final class ProbeFailure {
      * @param parent the parent, if known, of the child being probed
      * @param child this child being probed
      * @param wrapper the {@link WrapperNode} created to implement the probe
+     * @since 0.8 or earlier
      */
     public ProbeFailure(Reason reason, Node parent, Node child, Object wrapper) {
         this.reason = reason;
@@ -93,6 +107,7 @@ public final class ProbeFailure {
 
     /**
      * @return a short explanation of the failure
+     * @since 0.8 or earlier
      */
     public Reason getReason() {
         return reason;
@@ -100,6 +115,7 @@ public final class ProbeFailure {
 
     /**
      * @return the parent, if any, of the node being probed
+     * @since 0.8 or earlier
      */
     public Node getParent() {
         return parent;
@@ -107,6 +123,7 @@ public final class ProbeFailure {
 
     /**
      * @return the node being probed
+     * @since 0.8 or earlier
      */
     public Node getChild() {
         return child;
@@ -114,11 +131,13 @@ public final class ProbeFailure {
 
     /**
      * @return the {@link WrapperNode} created for the probe attempt
+     * @since 0.8 or earlier
      */
     public Object getWrapper() {
         return wrapper;
     }
 
+    /** @since 0.8 or earlier */
     public String getMessage() {
         final StringBuilder sb = new StringBuilder(reason.message + ": ");
         if (parent != null) {

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/ProbeInstrument.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/ProbeInstrument.java
@@ -52,6 +52,7 @@ import com.oracle.truffle.api.source.SourceSection;
  *
  * @see Probe
  * @see Instrumenter
+ * @since 0.8 or earlier
  */
 public abstract class ProbeInstrument extends Instrument {
     Probe probe = null;
@@ -118,6 +119,8 @@ public abstract class ProbeInstrument extends Instrument {
     /**
      * Removes this Instrument from the Probe to which it attached and renders this Instrument
      * inert.
+     * 
+     * @since 0.8 or earlier
      */
     @Override
     protected void innerDispose() {
@@ -132,6 +135,8 @@ public abstract class ProbeInstrument extends Instrument {
      * Gets the {@link Probe} to which this {@link Instrument} is currently attached: {@code null}
      * if not yet attached to a Probe or if this Instrument has been {@linkplain #dispose()
      * disposed}.
+     * 
+     * @since 0.8 or earlier
      */
     public Probe getProbe() {
         return probe;
@@ -453,7 +458,9 @@ public abstract class ProbeInstrument extends Instrument {
     }
 
     // Experimental
+    /** @since 0.8 or earlier */
     public interface TruffleOptListener {
+        /** @since 0.8 or earlier */
         void notifyIsCompiled(boolean isCompiled);
     }
 

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/ProbeListener.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/ProbeListener.java
@@ -30,6 +30,8 @@ import com.oracle.truffle.api.nodes.RootNode;
 /**
  * An observer of events related to {@link Probe}s: creation of new Probes and the addition of new
  * {@linkplain SyntaxTag SyntaxTags} to existing Probes.
+ * 
+ * @since 0.8 or earlier
  */
 public interface ProbeListener {
 
@@ -38,6 +40,7 @@ public interface ProbeListener {
      * constructed AST.
      *
      * @param rootNode parent of the newly created AST
+     * @since 0.8 or earlier
      */
     void startASTProbing(RootNode rootNode);
 
@@ -49,6 +52,8 @@ public interface ProbeListener {
      * delivered the first time {@linkplain Instrumenter#probe(Node)} is called at a particular AST
      * node. There will also be no notification when the AST to which the Probe is attached is
      * cloned.
+     * 
+     * @since 0.8 or earlier
      */
     void newProbeInserted(Probe probe);
 
@@ -68,6 +73,7 @@ public interface ProbeListener {
      * @param tag the tag that has been newly added (subsequent additions of the tag are
      *            unreported).
      * @param tagValue an optional value associated with the tag for the purposes of reporting.
+     * @since 0.8 or earlier
      */
     void probeTaggedAs(Probe probe, SyntaxTag tag, Object tagValue);
 
@@ -76,6 +82,7 @@ public interface ProbeListener {
      * has completed.
      *
      * @param rootNode parent of the newly created AST
+     * @since 0.8 or earlier
      */
     void endASTProbing(RootNode rootNode);
 

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/QuitException.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/QuitException.java
@@ -28,9 +28,14 @@ import com.oracle.truffle.api.nodes.ControlFlowException;
 
 /**
  * Controls breaking out of all executions and ending Truffle execution.
+ * 
+ * @since 0.8 or earlier
  */
 @Deprecated
 public final class QuitException extends ControlFlowException {
-
     private static final long serialVersionUID = -4301115629772778413L;
+
+    /** @since 0.8 or earlier */
+    public QuitException() {
+    }
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/SimpleInstrumentListener.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/SimpleInstrumentListener.java
@@ -43,6 +43,8 @@ import com.oracle.truffle.api.source.SourceSection;
  * <p>
  * Notification is fully synchronous, so overrides have performance implications. Non-trivial
  * methods should be coded with Truffle guidelines and cautions in mind.
+ * 
+ * @since 0.8 or earlier
  */
 public interface SimpleInstrumentListener {
 
@@ -50,6 +52,8 @@ public interface SimpleInstrumentListener {
      * Receive notification that a program location is about to be executed.
      * <p>
      * <strong>Synchronous</strong>: Truffle execution waits until the call returns.
+     * 
+     * @since 0.8 or earlier
      */
     void onEnter(Probe probe);
 
@@ -58,6 +62,8 @@ public interface SimpleInstrumentListener {
      * completed.
      * <p>
      * <strong>Synchronous</strong>: Truffle execution waits until the call returns.
+     * 
+     * @since 0.8 or earlier
      */
     void onReturnVoid(Probe probe);
 
@@ -66,6 +72,8 @@ public interface SimpleInstrumentListener {
      * value (boxed if primitive).
      * <p>
      * <strong>Synchronous</strong>: Truffle execution waits until the call returns.
+     * 
+     * @since 0.8 or earlier
      */
     void onReturnValue(Probe probe, Object result);
 
@@ -73,6 +81,8 @@ public interface SimpleInstrumentListener {
      * Receive notification that a program location's execution has just thrown an exception.
      * <p>
      * <strong>Synchronous</strong>: Truffle execution waits until the call returns.
+     * 
+     * @since 0.8 or earlier
      */
     void onReturnExceptional(Probe probe, Throwable exception);
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/StandardAfterInstrumentListener.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/StandardAfterInstrumentListener.java
@@ -45,6 +45,8 @@ import com.oracle.truffle.api.source.SourceSection;
  * <p>
  * Notification is fully synchronous, so overrides have performance implications. Non-trivial
  * methods should be coded with Truffle guidelines and cautions in mind.
+ * 
+ * @since 0.8 or earlier
  */
 public interface StandardAfterInstrumentListener {
 
@@ -52,6 +54,8 @@ public interface StandardAfterInstrumentListener {
      * Receive notification that an AST Node's {@code void}-valued execute method has just returned.
      * <p>
      * <strong>Synchronous</strong>: Truffle execution waits until the call returns.
+     * 
+     * @since 0.8 or earlier
      */
     void onReturnVoid(Probe probe, Node node, VirtualFrame frame);
 
@@ -60,6 +64,8 @@ public interface StandardAfterInstrumentListener {
      * primitive).
      * <p>
      * <strong>Synchronous</strong>: Truffle execution waits until the call returns.
+     * 
+     * @since 0.8 or earlier
      */
     void onReturnValue(Probe probe, Node node, VirtualFrame frame, Object result);
 
@@ -67,6 +73,8 @@ public interface StandardAfterInstrumentListener {
      * Receive notification that an AST Node's execute method has just thrown an exception.
      * <p>
      * <strong>Synchronous</strong>: Truffle execution waits until the call returns.
+     * 
+     * @since 0.8 or earlier
      */
     void onReturnExceptional(Probe probe, Node node, VirtualFrame frame, Throwable exception);
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/StandardBeforeInstrumentListener.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/StandardBeforeInstrumentListener.java
@@ -45,6 +45,8 @@ import com.oracle.truffle.api.source.SourceSection;
  * <p>
  * Notification is fully synchronous, so overrides have performance implications. Non-trivial
  * methods should be coded with Truffle guidelines and cautions in mind.
+ * 
+ * @since 0.8 or earlier
  */
 public interface StandardBeforeInstrumentListener {
 
@@ -52,6 +54,8 @@ public interface StandardBeforeInstrumentListener {
      * Receive notification that an AST node's execute method is about to be called.
      * <p>
      * <strong>Synchronous</strong>: Truffle execution waits until the call returns.
+     * 
+     * @since 0.8 or earlier
      */
     void onEnter(Probe probe, Node node, VirtualFrame frame);
 

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/StandardInstrumentListener.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/StandardInstrumentListener.java
@@ -44,6 +44,8 @@ import com.oracle.truffle.api.source.SourceSection;
  * <p>
  * Notification is fully synchronous, so overrides have performance implications. Non-trivial
  * methods should be coded with Truffle guidelines and cautions in mind.
+ * 
+ * @since 0.8 or earlier
  */
 public interface StandardInstrumentListener {
 
@@ -51,6 +53,8 @@ public interface StandardInstrumentListener {
      * Receive notification that an AST node's execute method is about to be called.
      * <p>
      * <strong>Synchronous</strong>: Truffle execution waits until the call returns.
+     * 
+     * @since 0.8 or earlier
      */
     void onEnter(Probe probe, Node node, VirtualFrame frame);
 
@@ -58,6 +62,8 @@ public interface StandardInstrumentListener {
      * Receive notification that an AST Node's {@code void}-valued execute method has just returned.
      * <p>
      * <strong>Synchronous</strong>: Truffle execution waits until the call returns.
+     * 
+     * @since 0.8 or earlier
      */
     void onReturnVoid(Probe probe, Node node, VirtualFrame frame);
 
@@ -66,6 +72,8 @@ public interface StandardInstrumentListener {
      * primitive).
      * <p>
      * <strong>Synchronous</strong>: Truffle execution waits until the call returns.
+     * 
+     * @since 0.8 or earlier
      */
     void onReturnValue(Probe probe, Node node, VirtualFrame frame, Object result);
 
@@ -73,6 +81,8 @@ public interface StandardInstrumentListener {
      * Receive notification that an AST Node's execute method has just thrown an exception.
      * <p>
      * <strong>Synchronous</strong>: Truffle execution waits until the call returns.
+     * 
+     * @since 0.8 or earlier
      */
     void onReturnExceptional(Probe probe, Node node, VirtualFrame frame, Throwable exception);
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/StandardSyntaxTag.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/StandardSyntaxTag.java
@@ -32,36 +32,49 @@ package com.oracle.truffle.api.instrument;
  * (for example for mostly expression-oriented languages) or even for specific languages.
  *
  * @see Probe
+ * @since 0.8 or earlier
  */
 public enum StandardSyntaxTag implements SyntaxTag {
 
     /**
      * Marker for a variable assignment.
+     * 
+     * @since 0.8 or earlier
      */
     ASSIGNMENT("assignment", "a variable assignment"),
 
     /**
      * Marker for a call site.
+     * 
+     * @since 0.8 or earlier
      */
     CALL("call", "a method/procedure call site"),
 
     /**
      * Marker for a location where a guest language exception is about to be thrown.
+     * 
+     * @since 0.8 or earlier
      */
     THROW("throw", "creator of an exception"),
 
     /**
      * Marker for a location where ordinary "stepping" should halt.
+     * 
+     * @since 0.8 or earlier
      */
     STATEMENT("statement", "basic unit of the language, suitable for \"stepping\" in a debugger"),
 
     /**
      * Marker for the start of the body of a method.
+     * 
+     * @since 0.8 or earlier
      */
     START_METHOD("start-method", "start of the body of a method"),
 
     /**
      * Marker for the start of the body of a loop.
+     * 
+     * @since 0.8 or earlier
      */
     START_LOOP("start-loop", "start of the body of a loop"),
 
@@ -69,6 +82,8 @@ public enum StandardSyntaxTag implements SyntaxTag {
      * Marker that is attached to some arbitrary locations that appear often-enough in an AST so
      * that a location with this tag is regularly executed. Could be the start of method and loop
      * bodies. May be used to implement some kind of safepoint functionality.
+     * 
+     * @since 0.8 or earlier
      */
     PERIODIC("periodic", "arbitrary locations that appear often-enough in an AST so that a location with this tag is regularly executed");
 
@@ -80,10 +95,12 @@ public enum StandardSyntaxTag implements SyntaxTag {
         this.description = description;
     }
 
+    /** @since 0.8 or earlier */
     public String getName() {
         return name;
     }
 
+    /** @since 0.8 or earlier */
     public String getDescription() {
         return description;
     }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/SyntaxTag.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/SyntaxTag.java
@@ -38,17 +38,22 @@ package com.oracle.truffle.api.instrument;
  *
  * @see Probe
  * @see StandardSyntaxTag
+ * @since 0.8 or earlier
  */
 public interface SyntaxTag {
 
     /**
      * Human-friendly name of guest language program elements belonging to the category, e.g.
      * "statement".
+     * 
+     * @since 0.8 or earlier
      */
     String name();
 
     /**
      * Criteria and example uses for the tag.
+     * 
+     * @since 0.8 or earlier
      */
     String getDescription();
 

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/TagInstrument.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/TagInstrument.java
@@ -38,6 +38,7 @@ package com.oracle.truffle.api.instrument;
  *
  * @see SyntaxTag
  * @see Instrumenter
+ * @since 0.8 or earlier
  */
 public abstract class TagInstrument extends Instrument {
 
@@ -45,16 +46,19 @@ public abstract class TagInstrument extends Instrument {
 
     private SyntaxTag tag = null;
 
+    /** @since 0.8 or earlier */
     protected TagInstrument(Instrumenter instrumenter, SyntaxTag tag, String instrumentInfo) {
         super(instrumentInfo);
         this.instrumenter = instrumenter;
         this.tag = tag;
     }
 
+    /** @since 0.8 or earlier */
     public final SyntaxTag getTag() {
         return tag;
     }
 
+    /** @since 0.8 or earlier */
     protected final Instrumenter getInstrumenter() {
         return instrumenter;
     }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/Visualizer.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/Visualizer.java
@@ -34,30 +34,40 @@ import com.oracle.truffle.api.nodes.Node;
  * from the underlying Truffle implementation.
  * <p>
  * <strong>Disclaimer:</strong> experimental interface under development.
+ * 
+ * @since 0.8 or earlier
  */
 public interface Visualizer {
 
     /**
      * Gets a printer for Truffle ASTs, possibly specialized to be helpful for a specific guest
      * language implementation.
+     * 
+     * @since 0.8 or earlier
      */
     @Deprecated
     ASTPrinter getASTPrinter();
 
     /**
      * A short description of a source location in terms of source + line number.
+     * 
+     * @since 0.8 or earlier
      */
     @Deprecated
     String displaySourceLocation(Node node);
 
     /**
      * Describes the name of the method containing a node.
+     * 
+     * @since 0.8 or earlier
      */
     @Deprecated
     String displayMethodName(Node node);
 
     /**
      * The name of the method.
+     * 
+     * @since 0.8 or earlier
      */
     @Deprecated
     String displayCallTargetName(CallTarget callTarget);
@@ -67,12 +77,15 @@ public interface Visualizer {
      *
      * @param trim if {@code > 0}, them limit size of String to either the value of trim or the
      *            number of characters in the first line, whichever is lower.
+     * @since 0.8 or earlier
      */
     @Deprecated
     String displayValue(Object value, int trim);
 
     /**
      * Converts a slot identifier in the guest language to a display string.
+     * 
+     * @since 0.8 or earlier
      */
     @Deprecated
     String displayIdentifier(FrameSlot slot);

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/WrapperNode.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/instrument/WrapperNode.java
@@ -65,22 +65,29 @@ import com.oracle.truffle.api.nodes.Node;
  * <p>
  *
  * @see ProbeInstrument
+ * @since 0.8 or earlier
  */
 public interface WrapperNode extends InstrumentationNode {
 
     /**
      * Gets the node being "wrapped", i.e. the AST node for which {@linkplain EventHandlerNode
      * execution events} will be reported through the Instrumentation Framework.
+     * 
+     * @since 0.8 or earlier
      */
     Node getChild();
 
     /**
      * Gets the {@link Probe} responsible for installing this wrapper.
+     * 
+     * @since 0.8 or earlier
      */
     Probe getProbe();
 
     /**
      * Implementation support for completing a newly created wrapper node.
+     * 
+     * @since 0.8 or earlier
      */
     void insertEventHandlerNode(EventHandlerNode eventHandlerNode);
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/ControlFlowException.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/ControlFlowException.java
@@ -27,6 +27,8 @@ package com.oracle.truffle.api.nodes;
 /**
  * An exception thrown to model control flow in a Truffle interpreter. The Truffle optimizer has
  * special knowledge of this exception class for performance optimizations.
+ * 
+ * @since 0.8 or earlier
  */
 public class ControlFlowException extends RuntimeException {
 
@@ -34,6 +36,8 @@ public class ControlFlowException extends RuntimeException {
 
     /**
      * Creates an exception thrown to model control flow.
+     * 
+     * @since 0.8 or earlier
      */
     public ControlFlowException() {
         /*
@@ -47,6 +51,8 @@ public class ControlFlowException extends RuntimeException {
 
     /**
      * For performance reasons, this exception does not record any stack trace information.
+     * 
+     * @since 0.8 or earlier
      */
     @SuppressWarnings("sync-override")
     @Override

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/DirectCallNode.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/DirectCallNode.java
@@ -46,11 +46,13 @@ import com.oracle.truffle.api.frame.VirtualFrame;
  * @see TruffleRuntime#createDirectCallNode(CallTarget)
  * @see #forceInlining()
  * @see #cloneCallTarget()
+ * @since 0.8 or earlier
  */
 public abstract class DirectCallNode extends Node {
-
+    /** @since 0.8 or earlier */
     protected final CallTarget callTarget;
 
+    /** @since 0.8 or earlier */
     protected DirectCallNode(CallTarget callTarget) {
         this.callTarget = callTarget;
     }
@@ -60,6 +62,7 @@ public abstract class DirectCallNode extends Node {
      *
      * @param arguments the arguments that should be passed to the callee
      * @return the return result of the call
+     * @since 0.8 or earlier
      */
     public abstract Object call(VirtualFrame frame, Object[] arguments);
 
@@ -69,6 +72,7 @@ public abstract class DirectCallNode extends Node {
      * called. For that use {@link #getCurrentCallTarget()} instead.
      *
      * @return the {@link CallTarget} provided.
+     * @since 0.8 or earlier
      */
     public CallTarget getCallTarget() {
         return callTarget;
@@ -79,6 +83,7 @@ public abstract class DirectCallNode extends Node {
      * {@link CallTarget} in this {@link DirectCallNode}.
      *
      * @return true if inlining is supported.
+     * @since 0.8 or earlier
      */
     public abstract boolean isInlinable();
 
@@ -88,6 +93,7 @@ public abstract class DirectCallNode extends Node {
      * by the runtime system which may at any point decide to inline.
      *
      * @return true if this method was inlined else false.
+     * @since 0.8 or earlier
      */
     public abstract boolean isInliningForced();
 
@@ -95,6 +101,8 @@ public abstract class DirectCallNode extends Node {
      * Enforces the runtime system to inline the {@link CallTarget} at this call site. If the
      * runtime system does not support inlining or it is already inlined this method has no effect.
      * The runtime system may decide to not inline calls which were forced to inline.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract void forceInlining();
 
@@ -103,6 +111,7 @@ public abstract class DirectCallNode extends Node {
      * returns <code>true</code> in {@link RootNode#isCloningAllowed()}.
      *
      * @return <code>true</code> if the target is allowed to be cloned.
+     * @since 0.8 or earlier
      */
     public abstract boolean isCallTargetCloningAllowed();
 
@@ -112,6 +121,8 @@ public abstract class DirectCallNode extends Node {
      * sensitive profiling information for this {@link DirectCallNode}. If
      * {@link #isCallTargetCloningAllowed()} returns <code>false</code> this method has no effect
      * and returns <code>false</code>.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract boolean cloneCallTarget();
 
@@ -120,6 +131,7 @@ public abstract class DirectCallNode extends Node {
      * runtime system or by the guest language implementation.
      *
      * @return if the target was split
+     * @since 0.8 or earlier
      */
     public final boolean isCallTargetCloned() {
         return getClonedCallTarget() != null;
@@ -129,6 +141,7 @@ public abstract class DirectCallNode extends Node {
      * Returns the split {@link CallTarget} if this call site's {@link CallTarget} is cloned.
      *
      * @return the split {@link CallTarget}
+     * @since 0.8 or earlier
      */
     public abstract CallTarget getClonedCallTarget();
 
@@ -138,6 +151,7 @@ public abstract class DirectCallNode extends Node {
      * {@link #getClonedCallTarget()}.
      *
      * @return the used {@link CallTarget} when node is called
+     * @since 0.8 or earlier
      */
     public CallTarget getCurrentCallTarget() {
         CallTarget split = getClonedCallTarget();
@@ -155,6 +169,7 @@ public abstract class DirectCallNode extends Node {
      *
      * @see #getCurrentCallTarget()
      * @return the root node of the used call target
+     * @since 0.8 or earlier
      */
     public final RootNode getCurrentRootNode() {
         CallTarget target = getCurrentCallTarget();
@@ -164,11 +179,13 @@ public abstract class DirectCallNode extends Node {
         return null;
     }
 
+    /** @since 0.8 or earlier */
     @Override
     public String toString() {
         return String.format("%s(target=%s)", getClass().getSimpleName(), getCurrentCallTarget());
     }
 
+    /** @since 0.8 or earlier */
     public static DirectCallNode create(CallTarget target) {
         return Truffle.getRuntime().createDirectCallNode(target);
     }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/ExplodeLoop.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/ExplodeLoop.java
@@ -32,6 +32,8 @@ import java.lang.annotation.Target;
 /**
  * Specifies for a method that the loops with constant number of invocations should be fully
  * unrolled.
+ * 
+ * @since 0.8 or earlier
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/GraphPrintVisitor.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/GraphPrintVisitor.java
@@ -54,10 +54,13 @@ import com.oracle.truffle.api.nodes.NodeFieldAccessor.NodeFieldKind;
 
 /**
  * Utility class for creating output for the ideal graph visualizer.
+ * 
+ * @since 0.8 or earlier
  */
 public class GraphPrintVisitor implements Closeable {
-
+    /** @since 0.8 or earlier */
     public static final String GraphVisualizerAddress = "127.0.0.1";
+    /** @since 0.8 or earlier */
     public static final int GraphVisualizerPort = 4444;
     private static final String DEFAULT_GRAPH_NAME = "truffle tree";
 
@@ -215,10 +218,12 @@ public class GraphPrintVisitor implements Closeable {
         }
     }
 
+    /** @since 0.8 or earlier */
     public GraphPrintVisitor() {
         this(new ByteArrayOutputStream());
     }
 
+    /** @since 0.8 or earlier */
     public GraphPrintVisitor(OutputStream outputStream) {
         this.outputStream = outputStream;
         this.xmlstream = createImpl(outputStream);
@@ -236,6 +241,7 @@ public class GraphPrintVisitor implements Closeable {
         }
     }
 
+    /** @since 0.8 or earlier */
     public GraphPrintVisitor beginGroup(String groupName) {
         ensureOpen();
         maybeEndGraph();
@@ -261,6 +267,7 @@ public class GraphPrintVisitor implements Closeable {
         return this;
     }
 
+    /** @since 0.8 or earlier */
     public GraphPrintVisitor endGroup() {
         ensureOpen();
         if (openGroupCount <= 0) {
@@ -274,6 +281,7 @@ public class GraphPrintVisitor implements Closeable {
         return this;
     }
 
+    /** @since 0.8 or earlier */
     public GraphPrintVisitor beginGraph(String graphName) {
         ensureOpen();
         if (openGroupCount == 0) {
@@ -299,6 +307,7 @@ public class GraphPrintVisitor implements Closeable {
         }
     }
 
+    /** @since 0.8 or earlier */
     public GraphPrintVisitor endGraph() {
         ensureOpen();
         if (openGraphCount <= 0) {
@@ -366,6 +375,7 @@ public class GraphPrintVisitor implements Closeable {
         }
     }
 
+    /** @since 0.8 or earlier */
     @Override
     public String toString() {
         if (outputStream instanceof ByteArrayOutputStream) {
@@ -374,6 +384,7 @@ public class GraphPrintVisitor implements Closeable {
         return super.toString();
     }
 
+    /** @since 0.8 or earlier */
     public void printToFile(File f) {
         close();
         if (outputStream instanceof ByteArrayOutputStream) {
@@ -385,6 +396,7 @@ public class GraphPrintVisitor implements Closeable {
         }
     }
 
+    /** @since 0.8 or earlier */
     public void printToSysout() {
         close();
         if (outputStream instanceof ByteArrayOutputStream) {
@@ -393,6 +405,7 @@ public class GraphPrintVisitor implements Closeable {
         }
     }
 
+    /** @since 0.8 or earlier */
     public void printToNetwork(boolean ignoreErrors) {
         close();
         if (outputStream instanceof ByteArrayOutputStream) {
@@ -406,6 +419,7 @@ public class GraphPrintVisitor implements Closeable {
         }
     }
 
+    /** @since 0.8 or earlier */
     public void close() {
         if (xmlstream == null) {
             return;
@@ -504,6 +518,7 @@ public class GraphPrintVisitor implements Closeable {
         edgeList.add(new EdgeElement(fromNode, toNode, count, label));
     }
 
+    /** @since 0.8 or earlier */
     public GraphPrintVisitor visit(Object node) {
         if (openGraphCount == 0) {
             beginGraph(DEFAULT_GRAPH_NAME);
@@ -526,6 +541,7 @@ public class GraphPrintVisitor implements Closeable {
         return this;
     }
 
+    /** @since 0.8 or earlier */
     public GraphPrintVisitor visit(Object node, GraphPrintHandler handler) {
         if (openGraphCount == 0) {
             beginGraph(DEFAULT_GRAPH_NAME);
@@ -578,39 +594,55 @@ public class GraphPrintVisitor implements Closeable {
         }
     }
 
+    /** @since 0.8 or earlier */
     public class GraphPrintAdapter {
+        /**
+         * Default constructor.
+         * 
+         * @since 0.8 or earlier
+         */
+        public GraphPrintAdapter() {
+        }
 
+        /** @since 0.8 or earlier */
         public void createElementForNode(Object node) {
             GraphPrintVisitor.this.createElementForNode(node);
         }
 
+        /** @since 0.8 or earlier */
         public void visit(Object node) {
             GraphPrintVisitor.this.visit(node);
         }
 
+        /** @since 0.8 or earlier */
         public void visit(Object node, GraphPrintHandler handler) {
             GraphPrintVisitor.this.visit(node, handler);
         }
 
+        /** @since 0.8 or earlier */
         public void connectNodes(Object node, Object child) {
             GraphPrintVisitor.this.connectNodes(node, child, null);
         }
 
+        /** @since 0.8 or earlier */
         public void connectNodes(Object node, Object child, String label) {
             GraphPrintVisitor.this.connectNodes(node, child, label);
         }
 
+        /** @since 0.8 or earlier */
         public void setNodeProperty(Object node, String propertyName, Object value) {
             GraphPrintVisitor.this.setNodeProperty(node, propertyName, value);
         }
 
+        /** @since 0.8 or earlier */
         public boolean visited(Object node) {
             return GraphPrintVisitor.this.getElementByObject(node) != null;
         }
     }
 
+    /** @since 0.8 or earlier */
     public interface GraphPrintHandler {
-
+        /** @since 0.8 or earlier */
         void visit(Object node, GraphPrintAdapter printer);
     }
 
@@ -627,6 +659,7 @@ public class GraphPrintVisitor implements Closeable {
         }
     }
 
+    /** @since 0.8 or earlier */
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.TYPE)
     public @interface CustomGraphPrintHandler {
@@ -634,6 +667,7 @@ public class GraphPrintVisitor implements Closeable {
         Class<? extends GraphPrintHandler> handler();
     }
 
+    /** @since 0.8 or earlier */
     @Retention(RetentionPolicy.RUNTIME)
     @Target(ElementType.TYPE)
     public @interface NullGraphPrintHandler {

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/IndirectCallNode.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/IndirectCallNode.java
@@ -36,8 +36,16 @@ import com.oracle.truffle.api.frame.VirtualFrame;
  * Please note: This class is not intended to be sub classed by guest language implementations.
  *
  * @see DirectCallNode for faster calls with a constantly known {@link CallTarget}.
+ * @since 0.8 or earlier
  */
 public abstract class IndirectCallNode extends Node {
+    /**
+     * Constructor for implementation subclasses.
+     * 
+     * @since 0.8 or earlier
+     */
+    protected IndirectCallNode() {
+    }
 
     /**
      * Performs an indirect call to the given {@link CallTarget} target with the provided arguments.
@@ -46,9 +54,11 @@ public abstract class IndirectCallNode extends Node {
      * @param target the {@link CallTarget} to call
      * @param arguments the arguments to provide
      * @return the return value of the call
+     * @since 0.8 or earlier
      */
     public abstract Object call(VirtualFrame frame, CallTarget target, Object[] arguments);
 
+    /** @since 0.8 or earlier */
     public static IndirectCallNode create() {
         return Truffle.getRuntime().createIndirectCallNode();
     }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/InvalidAssumptionException.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/InvalidAssumptionException.java
@@ -28,9 +28,18 @@ package com.oracle.truffle.api.nodes;
  * An exception that should be thrown if an assumption is checked and the check fails. The Truffle
  * optimizer has special knowledge of this exception class and will never compile a catch block that
  * catches this exception type.
+ * 
+ * @since 0.8 or earlier
  */
 public final class InvalidAssumptionException extends SlowPathException {
 
     private static final long serialVersionUID = -6801338218909717979L;
 
+    /**
+     * Default constructor.
+     * 
+     * @since 0.8 or earlier
+     */
+    public InvalidAssumptionException() {
+    }
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/LoopNode.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/LoopNode.java
@@ -44,29 +44,29 @@ import com.oracle.truffle.api.nodes.Node.Child;
  * <pre>
  * <code>
  * public class WhileNode extends GuestLanguageNode {
- *
+ * 
  *     &#064;{@link Child} private {@link LoopNode} loop;
- *
+ * 
  *     public WhileNode(GuestLanguageNode conditionNode, GuestLanguageNode bodyNode) {
  *         loop = Truffle.getRuntime().createLoopNode(new WhileRepeatingNode(conditionNode, bodyNode));
  *     }
- *
+ * 
  *     &#064;Override
  *     public Object execute({@link VirtualFrame} frame) {
  *         loop.executeLoop(frame);
  *         return null;
  *     }
- *
+ * 
  *     private static class WhileRepeatingNode extends {@link Node} implements {@link RepeatingNode} {
- *
+ * 
  *         &#064;{@link Child} private GuestLanguageNode conditionNode;
  *         &#064;{@link Child} private GuestLanguageNode bodyNode;
- *
+ * 
  *         public WhileRepeatingNode(GuestLanguageNode conditionNode, GuestLanguageNode bodyNode) {
  *             this.conditionNode = conditionNode;
  *             this.bodyNode = bodyNode;
  *         }
- *
+ * 
  *         public boolean executeRepeating({@link VirtualFrame} frame) {
  *             if ((boolean) conditionNode.execute(frame)) {
  *                 try {
@@ -85,14 +85,14 @@ import com.oracle.truffle.api.nodes.Node.Child;
  *             }
  *         }
  *     }
- *
+ * 
  * }
- *
+ * 
  * // substitute with a guest language node type
  * public abstract class GuestLanguageNode extends {@link Node} {
- *
+ * 
  *     public abstract Object execute({@link VirtualFrame} frame);
- *
+ * 
  * }
  * // thrown by guest language continue statements
  * public final class ContinueException extends {@link ControlFlowException} {}
@@ -104,8 +104,16 @@ import com.oracle.truffle.api.nodes.Node.Child;
  *
  * @see RepeatingNode
  * @see TruffleRuntime#createLoopNode(RepeatingNode)
+ * @since 0.8 or earlier
  */
 public abstract class LoopNode extends Node {
+    /**
+     * Constructor for subclasses.
+     * 
+     * @since 0.8 or earlier
+     */
+    protected LoopNode() {
+    }
 
     /**
      * Invokes one loop invocation by repeatedly call
@@ -115,11 +123,14 @@ public abstract class LoopNode extends Node {
      *
      * @param frame the current execution frame or null if the repeating node does not require a
      *            frame
+     * @since 0.8 or earlier
      */
     public abstract void executeLoop(VirtualFrame frame);
 
     /**
      * Returns the repeating node the loop node was created with.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract RepeatingNode getRepeatingNode();
 

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/Node.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/Node.java
@@ -46,6 +46,8 @@ import com.oracle.truffle.api.utilities.JSONHelper;
 
 /**
  * Abstract base class for all Truffle nodes.
+ * 
+ * @since 0.8 or earlier
  */
 public abstract class Node implements NodeInterface, Cloneable {
     private final NodeClass nodeClass;
@@ -54,6 +56,8 @@ public abstract class Node implements NodeInterface, Cloneable {
 
     /**
      * Marks array fields that are children of this node.
+     * 
+     * @since 0.8 or earlier
      */
     @Retention(RetentionPolicy.RUNTIME)
     @Target({ElementType.FIELD})
@@ -62,12 +66,15 @@ public abstract class Node implements NodeInterface, Cloneable {
 
     /**
      * Marks fields that represent child nodes of this node.
+     * 
+     * @since 0.8 or earlier
      */
     @Retention(RetentionPolicy.RUNTIME)
     @Target({ElementType.FIELD})
     public @interface Child {
     }
 
+    /** @since 0.8 or earlier */
     protected Node() {
         CompilerAsserts.neverPartOfCompilation("do not create a Node from compiled code");
         this.nodeClass = NodeClass.get(getClass());
@@ -80,6 +87,7 @@ public abstract class Node implements NodeInterface, Cloneable {
      * @deprecated if your node provides source section, override {@link #getSourceSection()} to
      *             return it - this constructor will be removed
      * @param sourceSection
+     * @since 0.8 or earlier
      */
     @Deprecated
     protected Node(SourceSection sourceSection) {
@@ -92,6 +100,7 @@ public abstract class Node implements NodeInterface, Cloneable {
      *             return it - this method will be removed
      *
      * @param section the object representing a section in guest language source code
+     * @since 0.8 or earlier
      */
     @Deprecated
     public void assignSourceSection(SourceSection section) {
@@ -117,6 +126,8 @@ public abstract class Node implements NodeInterface, Cloneable {
      * {@link NodeInfo#cost()} of the {@link NodeInfo} annotation declared at the subclass. If no
      * {@link NodeInfo} annotation is declared the method returns {@link NodeCost#MONOMORPHIC} as a
      * default value.
+     * 
+     * @since 0.8 or earlier
      */
     public NodeCost getCost() {
         NodeInfo info = getClass().getAnnotation(NodeInfo.class);
@@ -131,6 +142,7 @@ public abstract class Node implements NodeInterface, Cloneable {
      *             return it - this method will be removed
      *
      *             Clears any previously assigned guest language source code from this node.
+     * @since 0.8 or earlier
      */
     @Deprecated
     public void clearSourceSection() {
@@ -154,6 +166,7 @@ public abstract class Node implements NodeInterface, Cloneable {
      * {@codesnippet MutableSourceSectionNode}
      *
      * @return the source code represented by this Node
+     * @since 0.8 or earlier
      */
     public SourceSection getSourceSection() {
         return sourceSection;
@@ -165,6 +178,7 @@ public abstract class Node implements NodeInterface, Cloneable {
      * this information.
      *
      * @return an approximation of the source code represented by this Node
+     * @since 0.8 or earlier
      */
     @ExplodeLoop
     public SourceSection getEncapsulatingSourceSection() {
@@ -185,6 +199,7 @@ public abstract class Node implements NodeInterface, Cloneable {
      *
      * @param newChildren the array of new children whose parent should be updated
      * @return the array of new children
+     * @since 0.8 or earlier
      */
     protected final <T extends Node> T[] insert(final T[] newChildren) {
         CompilerDirectives.transferToInterpreterAndInvalidate();
@@ -200,6 +215,7 @@ public abstract class Node implements NodeInterface, Cloneable {
      *
      * @param newChild the new child whose parent should be updated
      * @return the new child
+     * @since 0.8 or earlier
      */
     protected final <T extends Node> T insert(final T newChild) {
         CompilerDirectives.transferToInterpreterAndInvalidate();
@@ -208,6 +224,7 @@ public abstract class Node implements NodeInterface, Cloneable {
         return newChild;
     }
 
+    /** @since 0.8 or earlier */
     public final void adoptChildren() {
         CompilerDirectives.transferToInterpreterAndInvalidate();
         adoptHelper();
@@ -261,6 +278,7 @@ public abstract class Node implements NodeInterface, Cloneable {
      * subclasses to add their own custom properties.
      *
      * @return the properties as a key/value hash map
+     * @since 0.8 or earlier
      */
     public Map<String, Object> getDebugProperties() {
         Map<String, Object> properties = new HashMap<>();
@@ -271,6 +289,7 @@ public abstract class Node implements NodeInterface, Cloneable {
      * The current parent node of this node.
      *
      * @return the parent node
+     * @since 0.8 or earlier
      */
     public final Node getParent() {
         return parent;
@@ -283,6 +302,7 @@ public abstract class Node implements NodeInterface, Cloneable {
      * @param newNode the new node that is the replacement
      * @param reason a description of the reason for the replacement
      * @return the new node
+     * @since 0.8 or earlier
      */
     public final <T extends Node> T replace(final T newNode, final CharSequence reason) {
         CompilerDirectives.transferToInterpreterAndInvalidate();
@@ -300,6 +320,7 @@ public abstract class Node implements NodeInterface, Cloneable {
      *
      * @param newNode the new node that is the replacement
      * @return the new node
+     * @since 0.8 or earlier
      */
     public final <T extends Node> T replace(T newNode) {
         return replace(newNode, "");
@@ -327,6 +348,8 @@ public abstract class Node implements NodeInterface, Cloneable {
 
     /**
      * Checks if this node can be replaced by another node: tree structure & type.
+     * 
+     * @since 0.8 or earlier
      */
     public final boolean isSafelyReplaceableBy(Node newNode) {
         return NodeUtil.isReplacementSafe(getParent(), this, newNode);
@@ -363,6 +386,7 @@ public abstract class Node implements NodeInterface, Cloneable {
      *
      * @param newNode the replacement node
      * @param reason the reason the replace supplied
+     * @since 0.8 or earlier
      */
     protected void onReplace(Node newNode, CharSequence reason) {
         // empty default
@@ -373,6 +397,7 @@ public abstract class Node implements NodeInterface, Cloneable {
      * child nodes.
      *
      * @param nodeVisitor the visitor
+     * @since 0.8 or earlier
      */
     public final void accept(NodeVisitor nodeVisitor) {
         if (nodeVisitor.visit(this)) {
@@ -384,6 +409,7 @@ public abstract class Node implements NodeInterface, Cloneable {
      * Iterator over the children of this node.
      *
      * @return the iterator
+     * @since 0.8 or earlier
      */
     public final Iterable<Node> getChildren() {
         return new Iterable<Node>() {
@@ -397,6 +423,7 @@ public abstract class Node implements NodeInterface, Cloneable {
      * Creates a shallow copy of this node.
      *
      * @return the new copy
+     * @since 0.8 or earlier
      */
     public Node copy() {
         CompilerAsserts.neverPartOfCompilation("do not call Node.copy from compiled code");
@@ -412,6 +439,7 @@ public abstract class Node implements NodeInterface, Cloneable {
      * Creates a deep copy of this node.
      *
      * @return the new deep copy
+     * @since 0.8 or earlier
      */
     public Node deepCopy() {
         return NodeUtil.deepCopyImpl(this);
@@ -421,6 +449,7 @@ public abstract class Node implements NodeInterface, Cloneable {
      * Get the root node of the tree a node belongs to.
      *
      * @return the {@link RootNode} or {@code null} if there is none.
+     * @since 0.8 or earlier
      */
     public final RootNode getRootNode() {
         Node rootNode = this;
@@ -436,6 +465,8 @@ public abstract class Node implements NodeInterface, Cloneable {
 
     /**
      * Converts this node to a textual representation useful for debugging.
+     * 
+     * @since 0.8 or earlier
      */
     @Override
     public String toString() {
@@ -454,6 +485,7 @@ public abstract class Node implements NodeInterface, Cloneable {
         return sb.toString();
     }
 
+    /** @since 0.8 or earlier */
     public final void atomic(Runnable closure) {
         RootNode rootNode = getRootNode();
         // Major Assumption: parent is never null after a node got adopted
@@ -469,6 +501,7 @@ public abstract class Node implements NodeInterface, Cloneable {
         }
     }
 
+    /** @since 0.8 or earlier */
     public final <T> T atomic(Callable<T> closure) {
         try {
             RootNode rootNode = getRootNode();
@@ -493,6 +526,8 @@ public abstract class Node implements NodeInterface, Cloneable {
     /**
      * Returns a user-readable description of the purpose of the Node, or "" if no description is
      * available.
+     * 
+     * @since 0.8 or earlier
      */
     public String getDescription() {
         NodeInfo info = getClass().getAnnotation(NodeInfo.class);
@@ -505,6 +540,8 @@ public abstract class Node implements NodeInterface, Cloneable {
     /**
      * Returns a string representing the language this node has been implemented for. If the
      * language is unknown, returns "".
+     * 
+     * @since 0.8 or earlier
      */
     public String getLanguage() {
         NodeInfo info = getClass().getAnnotation(NodeInfo.class);

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/NodeClass.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/NodeClass.java
@@ -31,6 +31,8 @@ import java.util.Iterator;
 /**
  * Information about a {@link Node} class. A single instance of this class is allocated for every
  * subclass of {@link Node} that is used.
+ * 
+ * @since 0.8 or earlier
  */
 public abstract class NodeClass {
     private static final ClassValue<NodeClass> nodeClasses = new ClassValue<NodeClass>() {
@@ -46,30 +48,40 @@ public abstract class NodeClass {
         }
     };
 
+    /** @since 0.8 or earlier */
     public static NodeClass get(Class<? extends Node> clazz) {
         return nodeClasses.get(clazz);
     }
 
+    /** @since 0.8 or earlier */
     public static NodeClass get(Node node) {
         return node.getNodeClass();
     }
 
+    /** @since 0.8 or earlier */
     @SuppressWarnings("unused")
     public NodeClass(Class<? extends Node> clazz) {
     }
 
+    /** @since 0.8 or earlier */
     public abstract NodeFieldAccessor getNodeClassField();
 
+    /** @since 0.8 or earlier */
     public abstract NodeFieldAccessor[] getCloneableFields();
 
+    /** @since 0.8 or earlier */
     public abstract NodeFieldAccessor[] getFields();
 
+    /** @since 0.8 or earlier */
     public abstract NodeFieldAccessor getParentField();
 
+    /** @since 0.8 or earlier */
     public abstract NodeFieldAccessor[] getChildFields();
 
+    /** @since 0.8 or earlier */
     public abstract NodeFieldAccessor[] getChildrenFields();
 
+    /** @since 0.8 or earlier */
     public abstract Iterator<Node> makeIterator(Node node);
 
     /**
@@ -77,6 +89,7 @@ public abstract class NodeClass {
      * created for}.
      * 
      * @return the clazz of node this <code>NodeClass</code> describes
+     * @since 0.8 or earlier
      */
     public abstract Class<? extends Node> getType();
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/NodeCloneable.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/NodeCloneable.java
@@ -26,8 +26,19 @@ package com.oracle.truffle.api.nodes;
 
 /**
  * Declarative base class for node fields that are to be cloned together with the containing node.
+ * 
+ * @since 0.8 or earlier
  */
 public abstract class NodeCloneable implements Cloneable {
+    /**
+     * Constructor for subclasses.
+     * 
+     * @since 0.8 or earlier
+     */
+    protected NodeCloneable() {
+    }
+
+    /** @since 0.8 or earlier */
     @Override
     protected Object clone() {
         try {

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/NodeCost.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/NodeCost.java
@@ -31,12 +31,15 @@ import com.oracle.truffle.api.CompilerDirectives;
  * systems or guest languages to implement heuristics based on Truffle ASTs.
  *
  * @see Node#getCost()
+ * @since 0.8 or earlier
  */
 public enum NodeCost {
 
     /**
      * This node has literally no costs and should be ignored for heuristics. This is particularly
      * useful for wrapper and profiling nodes which should not influence the heuristics.
+     * 
+     * @since 0.8 or earlier
      */
     NONE,
 
@@ -44,11 +47,15 @@ public enum NodeCost {
      * This node has a {@link CompilerDirectives#transferToInterpreter()} or
      * {@link CompilerDirectives#transferToInterpreterAndInvalidate()} as its first unconditional
      * statement.
+     * 
+     * @since 0.8 or earlier
      */
     UNINITIALIZED,
 
     /**
      * This node represents a specialized monomorphic version of an operation.
+     * 
+     * @since 0.8 or earlier
      */
     MONOMORPHIC,
 
@@ -56,6 +63,8 @@ public enum NodeCost {
      * This node represents a polymorphic version of an operation. For multiple chained polymorphic
      * nodes the first may return {@link #MONOMORPHIC} and all additional nodes should return
      * {@link #POLYMORPHIC}.
+     * 
+     * @since 0.8 or earlier
      */
     POLYMORPHIC,
 
@@ -63,11 +72,13 @@ public enum NodeCost {
      * This node represents a megamorphic version of an operation. This value should only be used if
      * the operation implementation supports monomorphism and polymorphism otherwise
      * {@link #MONOMORPHIC} should be used instead.
+     * 
+     * @since 0.8 or earlier
      */
     MEGAMORPHIC;
 
+    /** @since 0.8 or earlier */
     public boolean isTrivial() {
         return this == NONE || this == UNINITIALIZED;
     }
-
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/NodeFieldAccessor.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/NodeFieldAccessor.java
@@ -33,19 +33,41 @@ import com.oracle.truffle.api.nodes.Node.Children;
 
 /**
  * Information about a field in a {@link Node} class.
+ * 
+ * @since 0.8 or earlier
  */
 public abstract class NodeFieldAccessor {
-
+    /** @since 0.8 or earlier */
     public enum NodeFieldKind {
-        /** The reference to the {@link NodeClass}. */
+        /**
+         * The reference to the {@link NodeClass}.
+         * 
+         * @since 0.8 or earlier
+         */
         NODE_CLASS,
-        /** The single {@link Node#getParent() parent} field. */
+        /**
+         * The single {@link Node#getParent() parent} field.
+         * 
+         * @since 0.8 or earlier
+         */
         PARENT,
-        /** A field annotated with {@link Child}. */
+        /**
+         * A field annotated with {@link Child}.
+         * 
+         * @since 0.8 or earlier
+         */
         CHILD,
-        /** A field annotated with {@link Children}. */
+        /**
+         * A field annotated with {@link Children}.
+         * 
+         * @since 0.8 or earlier
+         */
         CHILDREN,
-        /** A normal non-child data field of the node. */
+        /**
+         * A normal non-child data field of the node.
+         * 
+         * @since 0.8 or earlier
+         */
         DATA
     }
 
@@ -54,15 +76,19 @@ public abstract class NodeFieldAccessor {
     private final NodeFieldKind kind;
     private final Class<?> declaringClass;
     private final String name;
+    /** @since 0.8 or earlier */
     protected final Class<?> type;
 
+    /** @since 0.8 or earlier */
     protected NodeFieldAccessor(NodeFieldKind kind, Class<?> declaringClass, String name, Class<?> type) {
         this.kind = kind;
         this.declaringClass = declaringClass;
         this.name = name;
+        /** @since 0.8 or earlier */
         this.type = type;
     }
 
+    /** @since 0.8 or earlier */
     protected static NodeFieldAccessor create(NodeFieldKind kind, Field field) {
         if (USE_UNSAFE) {
             return new UnsafeNodeField(kind, field);
@@ -71,40 +97,50 @@ public abstract class NodeFieldAccessor {
         }
     }
 
+    /** @since 0.8 or earlier */
     public NodeFieldKind getKind() {
         return kind;
     }
 
+    /** @since 0.8 or earlier */
     public Class<?> getType() {
         return type;
     }
 
+    /** @since 0.8 or earlier */
     public Class<?> getDeclaringClass() {
         return declaringClass;
     }
 
+    /** @since 0.8 or earlier */
     public String getName() {
         return name;
     }
 
     /**
      * @deprecated The visibility of this method will be reduced to protected. Do not use.
+     * @since 0.8 or earlier
      */
     @Deprecated
     public abstract void putObject(Node receiver, Object value);
 
+    /** @since 0.8 or earlier */
     public abstract Object getObject(Node receiver);
 
+    /** @since 0.8 or earlier */
     public abstract Object loadValue(Node node);
 
+    /** @since 0.8 or earlier */
     public abstract static class AbstractUnsafeNodeFieldAccessor extends NodeFieldAccessor {
-
+        /** @since 0.8 or earlier */
         protected AbstractUnsafeNodeFieldAccessor(NodeFieldKind kind, Class<?> declaringClass, String name, Class<?> type) {
             super(kind, declaringClass, name, type);
         }
 
+        /** @since 0.8 or earlier */
         public abstract long getOffset();
 
+        /** @since 0.8 or earlier */
         @SuppressWarnings("deprecation")
         @Override
         public void putObject(Node receiver, Object value) {
@@ -115,6 +151,7 @@ public abstract class NodeFieldAccessor {
             }
         }
 
+        /** @since 0.8 or earlier */
         @Override
         public Object getObject(Node receiver) {
             if (!type.isPrimitive()) {
@@ -124,6 +161,7 @@ public abstract class NodeFieldAccessor {
             }
         }
 
+        /** @since 0.8 or earlier */
         @Override
         public Object loadValue(Node node) {
             if (type == boolean.class) {

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/NodeInfo.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/NodeInfo.java
@@ -31,6 +31,8 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation for providing additional information on nodes.
+ * 
+ * @since 0.8 or earlier
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/NodeInterface.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/NodeInterface.java
@@ -28,6 +28,7 @@ package com.oracle.truffle.api.nodes;
  * Common base interface for all Truffle nodes.
  *
  * @see Node
+ * @since 0.8 or earlier
  */
 public interface NodeInterface {
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/NodeUtil.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/NodeUtil.java
@@ -46,13 +46,23 @@ import com.oracle.truffle.api.source.SourceSection;
 
 /**
  * Utility class that manages the special access methods for node instances.
+ * 
+ * @since 0.8 or earlier
  */
 public final class NodeUtil {
+    /**
+     * @deprecated accidentally public - don't use
+     * @since 0.8 or earlier
+     */
+    @Deprecated
+    public NodeUtil() {
+    }
 
     static Iterator<Node> makeIterator(Node node) {
         return node.getNodeClass().makeIterator(node);
     }
 
+    /** @since 0.8 or earlier */
     public static Iterator<Node> makeRecursiveIterator(Node node) {
         return new RecursiveNodeIterator(node);
     }
@@ -121,6 +131,7 @@ public final class NodeUtil {
         }
     }
 
+    /** @since 0.8 or earlier */
     @SuppressWarnings("unchecked")
     public static <T extends Node> T cloneNode(T orig) {
         return (T) orig.deepCopy();
@@ -165,6 +176,7 @@ public final class NodeUtil {
         return clone;
     }
 
+    /** @since 0.8 or earlier */
     public static List<Node> findNodeChildren(Node node) {
         CompilerAsserts.neverPartOfCompilation("do not call Node.findNodeChildren from compiled code");
         List<Node> nodes = new ArrayList<>();
@@ -190,11 +202,13 @@ public final class NodeUtil {
         return nodes;
     }
 
+    /** @since 0.8 or earlier */
     public static <T extends Node> T nonAtomicReplace(Node oldNode, T newNode, CharSequence reason) {
         oldNode.replaceHelper(newNode, reason);
         return newNode;
     }
 
+    /** @since 0.8 or earlier */
     public static boolean replaceChild(Node parent, Node oldChild, Node newChild) {
         return replaceChild(parent, oldChild, newChild, false);
     }
@@ -260,6 +274,7 @@ public final class NodeUtil {
      * Finds the field in a parent node, if any, that holds a specified child node.
      *
      * @return the field (possibly an array) holding the child, {@code null} if not found.
+     * @since 0.8 or earlier
      */
     public static NodeFieldAccessor findChildField(Node parent, Node child) {
         assert child != null;
@@ -287,6 +302,8 @@ public final class NodeUtil {
 
     /**
      * Determines whether a proposed child replacement would be safe: structurally and type.
+     * 
+     * @since 0.8 or earlier
      */
     public static boolean isReplacementSafe(Node parent, Node oldChild, Node newChild) {
         assert newChild != null;
@@ -310,6 +327,7 @@ public final class NodeUtil {
      * Executes a closure for every non-null child of the parent node.
      *
      * @return {@code true} if all children were visited, {@code false} otherwise
+     * @since 0.8 or earlier
      */
     public static boolean forEachChild(Node parent, NodeVisitor visitor) {
         CompilerAsserts.neverPartOfCompilation("do not iterate over Node children from compiled code");
@@ -381,6 +399,7 @@ public final class NodeUtil {
         return true;
     }
 
+    /** @since 0.8 or earlier */
     public static <T> T[] concat(T[] first, T[] second) {
         T[] result = Arrays.copyOf(first, first.length + second.length);
         System.arraycopy(second, 0, result, first.length, second.length);
@@ -390,6 +409,8 @@ public final class NodeUtil {
     /**
      * Get the nth parent of a node, where the 0th parent is the node itself. Returns null if there
      * are less than n ancestors.
+     * 
+     * @since 0.8 or earlier
      */
     public static Node getNthParent(Node node, int n) {
         Node parent = node;
@@ -405,7 +426,11 @@ public final class NodeUtil {
         return parent;
     }
 
-    /** find annotation in class/interface hierarchy. */
+    /**
+     * Find annotation in class/interface hierarchy.
+     * 
+     * @since 0.8 or earlier
+     */
     public static <T extends Annotation> T findAnnotation(Class<?> clazz, Class<T> annotationClass) {
         if (clazz.getAnnotation(annotationClass) != null) {
             return clazz.getAnnotation(annotationClass);
@@ -424,6 +449,7 @@ public final class NodeUtil {
         return null;
     }
 
+    /** @since 0.8 or earlier */
     public static <T> T findParent(Node start, Class<T> clazz) {
         Node parent = start.getParent();
         if (parent == null) {
@@ -435,6 +461,7 @@ public final class NodeUtil {
         }
     }
 
+    /** @since 0.8 or earlier */
     public static <T> List<T> findAllParents(Node start, Class<T> clazz) {
         List<T> parents = new ArrayList<>();
         T parent = findParent(start, clazz);
@@ -445,6 +472,7 @@ public final class NodeUtil {
         return parents;
     }
 
+    /** @since 0.8 or earlier */
     public static List<Node> collectNodes(Node parent, Node child) {
         List<Node> nodes = new ArrayList<>();
         Node current = child;
@@ -458,6 +486,7 @@ public final class NodeUtil {
         throw new IllegalArgumentException("Node " + parent + " is not a parent of " + child + ".");
     }
 
+    /** @since 0.8 or earlier */
     public static <T> T findFirstNodeInstance(Node root, Class<T> clazz) {
         if (clazz.isInstance(root)) {
             return clazz.cast(root);
@@ -471,6 +500,7 @@ public final class NodeUtil {
         return null;
     }
 
+    /** @since 0.8 or earlier */
     public static <T> List<T> findAllNodeInstances(final Node root, final Class<T> clazz) {
         final List<T> nodeList = new ArrayList<>();
         root.accept(new NodeVisitor() {
@@ -484,18 +514,21 @@ public final class NodeUtil {
         return nodeList;
     }
 
+    /** @since 0.8 or earlier */
     public static int countNodes(Node root) {
         return countNodes(root, NodeCountFilter.NO_FILTER);
     }
 
+    /** @since 0.8 or earlier */
     public static int countNodes(Node root, NodeCountFilter filter) {
         NodeCounter counter = new NodeCounter(filter);
         root.accept(counter);
         return counter.count;
     }
 
+    /** @since 0.8 or earlier */
     public interface NodeCountFilter {
-
+        /** @since 0.8 or earlier */
         NodeCountFilter NO_FILTER = new NodeCountFilter() {
 
             public boolean isCounted(Node node) {
@@ -503,16 +536,19 @@ public final class NodeUtil {
             }
         };
 
+        /** @since 0.8 or earlier */
         boolean isCounted(Node node);
 
     }
 
+    /** @since 0.8 or earlier */
     public static String printCompactTreeToString(Node node) {
         StringWriter out = new StringWriter();
         printCompactTree(new PrintWriter(out), null, node, 1);
         return out.toString();
     }
 
+    /** @since 0.8 or earlier */
     public static void printCompactTree(OutputStream out, Node node) {
         printCompactTree(new PrintWriter(out), null, node, 1);
     }
@@ -538,16 +574,19 @@ public final class NodeUtil {
         p.flush();
     }
 
+    /** @since 0.8 or earlier */
     public static String printSourceAttributionTree(Node node) {
         StringWriter out = new StringWriter();
         printSourceAttributionTree(new PrintWriter(out), null, node, 1);
         return out.toString();
     }
 
+    /** @since 0.8 or earlier */
     public static void printSourceAttributionTree(OutputStream out, Node node) {
         printSourceAttributionTree(new PrintWriter(out), null, node, 1);
     }
 
+    /** @since 0.8 or earlier */
     public static void printSourceAttributionTree(PrintWriter out, Node node) {
         printSourceAttributionTree(out, null, node, 1);
     }
@@ -615,6 +654,8 @@ public final class NodeUtil {
      * <li>"[]" if the node supports tags, but none are present; and</li>
      * <li>"" if the node does not support tags.</li>
      * </ul>
+     * 
+     * @since 0.8 or earlier
      */
     public static String printSyntaxTags(final Object node) {
         if ((node instanceof Node) && ((Node) node).getSourceSection() != null) {
@@ -629,17 +670,20 @@ public final class NodeUtil {
      *
      * @param out the stream to print to.
      * @param node the root node to write
+     * @since 0.8 or earlier
      */
     public static void printTree(OutputStream out, Node node) {
         printTree(new PrintWriter(out), node);
     }
 
+    /** @since 0.8 or earlier */
     public static String printTreeToString(Node node) {
         StringWriter out = new StringWriter();
         printTree(new PrintWriter(out), node);
         return out.toString();
     }
 
+    /** @since 0.8 or earlier */
     public static void printTree(PrintWriter p, Node node) {
         printTree(p, node, 1);
         p.println();
@@ -734,6 +778,7 @@ public final class NodeUtil {
         return "";
     }
 
+    /** @since 0.8 or earlier */
     public static boolean verify(Node root) {
         Iterable<Node> children = root.getChildren();
         for (Node child : children) {

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/NodeVisitor.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/NodeVisitor.java
@@ -26,6 +26,8 @@ package com.oracle.truffle.api.nodes;
 
 /**
  * Visitor for trees of nodes.
+ * 
+ * @since 0.8 or earlier
  */
 public interface NodeVisitor {
 
@@ -35,6 +37,7 @@ public interface NodeVisitor {
      *
      * @param node the node that is currently visited
      * @return {@code true} if the children should be visited too, {@code false} otherwise
+     * @since 0.8 or earlier
      */
     boolean visit(Node node);
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/RepeatingNode.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/RepeatingNode.java
@@ -36,6 +36,7 @@ import com.oracle.truffle.api.frame.VirtualFrame;
  *
  * @see LoopNode
  * @see TruffleRuntime#createLoopNode(RepeatingNode)
+ * @since 0.8 or earlier
  */
 public interface RepeatingNode extends NodeInterface {
 
@@ -46,6 +47,7 @@ public interface RepeatingNode extends NodeInterface {
      * @param frame the current execution frame passed through the interpreter
      * @return <code>true</code> if the method should be executed again to complete the loop and
      *         <code>false</code> if it must not.
+     * @since 0.8 or earlier
      */
     boolean executeRepeating(VirtualFrame frame);
 

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/RootNode.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/RootNode.java
@@ -42,6 +42,8 @@ import com.oracle.truffle.api.source.SourceSection;
  * A root node is a node with a method to execute it given only a frame as a parameter. Therefore, a
  * root node can be used to create a call target using
  * {@link TruffleRuntime#createCallTarget(RootNode)}.
+ * 
+ * @since 0.8 or earlier
  */
 @SuppressWarnings("rawtypes")
 public abstract class RootNode extends Node {
@@ -61,6 +63,7 @@ public abstract class RootNode extends Node {
      * @param language the language of the node, <b>cannot be</b> <code>null</code>
      * @param sourceSection a part of source associated with this node, can be <code>null</code>
      * @param frameDescriptor descriptor of slots, can be <code>null</code>
+     * @since 0.8 or earlier
      */
     protected RootNode(Class<? extends TruffleLanguage> language, SourceSection sourceSection, FrameDescriptor frameDescriptor) {
         this(language, sourceSection, frameDescriptor, true);
@@ -82,6 +85,7 @@ public abstract class RootNode extends Node {
         }
     }
 
+    /** @since 0.8 or earlier */
     @Override
     public Node copy() {
         RootNode root = (RootNode) super.copy();
@@ -98,6 +102,7 @@ public abstract class RootNode extends Node {
      * .
      *
      * @return <code>true</code> if cloning is allowed else <code>false</code>.
+     * @since 0.8 or earlier
      */
     public boolean isCloningAllowed() {
         return false;
@@ -106,6 +111,8 @@ public abstract class RootNode extends Node {
     /**
      * Reports the execution count of a loop that is a child of this node. The optimization
      * heuristics can use the loop count to guide compilation and inlining.
+     * 
+     * @since 0.8 or earlier
      */
     public final void reportLoopCount(int count) {
         CompilerAsserts.neverPartOfCompilation("do not call RootNode.reportLoopCount from compiled code");
@@ -119,17 +126,21 @@ public abstract class RootNode extends Node {
      *
      * @param frame the frame of the currently executing guest language method
      * @return the value of the execution
+     * @since 0.8 or earlier
      */
     public abstract Object execute(VirtualFrame frame);
 
+    /** @since 0.8 or earlier */
     public final RootCallTarget getCallTarget() {
         return callTarget;
     }
 
+    /** @since 0.8 or earlier */
     public final FrameDescriptor getFrameDescriptor() {
         return frameDescriptor;
     }
 
+    /** @since 0.8 or earlier */
     public final void setCallTarget(RootCallTarget callTarget) {
         this.callTarget = callTarget;
     }
@@ -148,6 +159,8 @@ public abstract class RootNode extends Node {
      * </code> </pre>
      *
      * Returns <code>null</code> by default.
+     * 
+     * @since 0.8 or earlier
      */
     public ExecutionContext getExecutionContext() {
         return null;
@@ -155,6 +168,8 @@ public abstract class RootNode extends Node {
 
     /**
      * Get compiler options specific to this <code>RootNode</code>.
+     * 
+     * @since 0.8 or earlier
      */
     public CompilerOptions getCompilerOptions() {
         final ExecutionContext context = getExecutionContext();
@@ -166,6 +181,7 @@ public abstract class RootNode extends Node {
         }
     }
 
+    /** @since 0.8 or earlier */
     public final void applyInstrumentation() {
         if (isInstrumentable()) {
             Node.ACCESSOR.probeAST(this);
@@ -174,6 +190,8 @@ public abstract class RootNode extends Node {
 
     /**
      * Does this contain AST content that it is possible to instrument.
+     * 
+     * @since 0.8 or earlier
      */
     protected boolean isInstrumentable() {
         return true;
@@ -187,6 +205,7 @@ public abstract class RootNode extends Node {
      *
      * @param constant the constant to return
      * @return root node returning the constant
+     * @since 0.8 or earlier
      */
     public static RootNode createConstantNode(Object constant) {
         return new Constant(constant);

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/SlowPathException.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/SlowPathException.java
@@ -29,6 +29,8 @@ import com.oracle.truffle.api.CompilerDirectives;
 /**
  * An exception thrown to enter a slow path. The Truffle optimizer has special knowledge of this
  * exception class and will never compile a catch block that catches this exception type.
+ * 
+ * @since 0.8 or earlier
  */
 public class SlowPathException extends Exception {
 
@@ -36,6 +38,8 @@ public class SlowPathException extends Exception {
 
     /**
      * Creates an exception thrown to enter a slow path.
+     * 
+     * @since 0.8 or earlier
      */
     public SlowPathException() {
         CompilerDirectives.transferToInterpreter();
@@ -43,6 +47,8 @@ public class SlowPathException extends Exception {
 
     /**
      * Creates an exception thrown to enter a slow path.
+     * 
+     * @since 0.8 or earlier
      */
     public SlowPathException(String message, Throwable cause) {
         super(message, cause);
@@ -51,6 +57,8 @@ public class SlowPathException extends Exception {
 
     /**
      * Creates an exception thrown to enter a slow path.
+     * 
+     * @since 0.8 or earlier
      */
     public SlowPathException(String message) {
         super(message);
@@ -59,6 +67,8 @@ public class SlowPathException extends Exception {
 
     /**
      * Creates an exception thrown to enter a slow path.
+     * 
+     * @since 0.8 or earlier
      */
     public SlowPathException(Throwable cause) {
         super(cause);
@@ -67,6 +77,8 @@ public class SlowPathException extends Exception {
 
     /**
      * For performance reasons, this exception does not record any stack trace information.
+     * 
+     * @since 0.8 or earlier
      */
     @SuppressWarnings("sync-override")
     @Override

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/UnexpectedResultException.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/UnexpectedResultException.java
@@ -30,6 +30,8 @@ import com.oracle.truffle.api.CompilerDirectives;
  * An exception that should be thrown if the return value cannot be represented as a value of the
  * return type. The Truffle optimizer has special knowledge of this exception class and will never
  * compile a catch block that catches this exception type.
+ * 
+ * @since 0.8 or earlier
  */
 public final class UnexpectedResultException extends SlowPathException {
 
@@ -41,6 +43,7 @@ public final class UnexpectedResultException extends SlowPathException {
      * the return type.
      *
      * @param result the alternative result
+     * @since 0.8 or earlier
      */
     public UnexpectedResultException(Object result) {
         CompilerDirectives.transferToInterpreterAndInvalidate();
@@ -49,6 +52,7 @@ public final class UnexpectedResultException extends SlowPathException {
 
     /**
      * @return the unexpected result
+     * @since 0.8 or earlier
      */
     public Object getResult() {
         return result;

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/source/LineLocation.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/source/LineLocation.java
@@ -28,6 +28,8 @@ package com.oracle.truffle.api.source;
  * A specification for a location in guest language source, expressed as a line number in a specific
  * instance of {@link Source}, suitable for hash table keys with equality defined in terms of
  * content.
+ * 
+ * @since 0.8 or earlier
  */
 public final class LineLocation implements Comparable<LineLocation> {
     private final Source source;
@@ -39,6 +41,7 @@ public final class LineLocation implements Comparable<LineLocation> {
         this.line = line;
     }
 
+    /** @since 0.8 or earlier */
     public Source getSource() {
         return source;
     }
@@ -47,20 +50,24 @@ public final class LineLocation implements Comparable<LineLocation> {
      * Gets the 1-based number of a line in the source.
      *
      * @return value from 1 to infinity
+     * @since 0.8 or earlier
      */
     public int getLineNumber() {
         return line;
     }
 
+    /** @since 0.8 or earlier */
     public String getShortDescription() {
         return source.getShortName() + ":" + line;
     }
 
+    /** @since 0.8 or earlier */
     @Override
     public String toString() {
         return "Line[" + getShortDescription() + "]";
     }
 
+    /** @since 0.8 or earlier */
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -70,6 +77,7 @@ public final class LineLocation implements Comparable<LineLocation> {
         return result;
     }
 
+    /** @since 0.8 or earlier */
     @Override
     public boolean equals(Object obj) {
         if (this == obj) {
@@ -88,6 +96,7 @@ public final class LineLocation implements Comparable<LineLocation> {
         return source.getHashKey().equals(other.source.getHashKey());
     }
 
+    /** @since 0.8 or earlier */
     @Override
     public int compareTo(LineLocation o) {
         int sourceResult = 0;

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/source/Source.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/source/Source.java
@@ -108,6 +108,8 @@ import com.oracle.truffle.api.TruffleLanguage.Registration;
  * reload.</li>
  * </ol>
  * <p>
+ * 
+ * @since 0.8 or earlier
  */
 public abstract class Source {
     private static final Logger LOG = Logger.getLogger(Source.class.getName());
@@ -126,6 +128,8 @@ public abstract class Source {
 
     /**
      * Locates an existing instance by the name under which it was indexed.
+     * 
+     * @since 0.8 or earlier
      */
     public static Source find(String name) {
         final WeakReference<Source> nameRef = nameToSource.get(name);
@@ -140,6 +144,7 @@ public abstract class Source {
      * @param reset forces any existing {@link Source} cache to be cleared, forcing a re-read
      * @return canonical representation of the file's contents.
      * @throws IOException if the file can not be read
+     * @since 0.8 or earlier
      */
     public static Source fromFileName(String fileName, boolean reset) throws IOException {
 
@@ -171,6 +176,7 @@ public abstract class Source {
      * @param fileName name
      * @return canonical representation of the file's contents.
      * @throws IOException if the file can not be read
+     * @since 0.8 or earlier
      */
     public static Source fromFileName(String fileName) throws IOException {
         return fromFileName(fileName, false);
@@ -196,6 +202,7 @@ public abstract class Source {
      * @return canonical representation of the file's contents.
      * @throws IOException if the file cannot be found, or if an existing Source not created by this
      *             method matches the file name
+     * @since 0.8 or earlier
      */
     public static Source fromFileName(CharSequence chars, String fileName) throws IOException {
         CompilerAsserts.neverPartOfCompilation("do not call Source.fromFileName from compiled code");
@@ -229,6 +236,7 @@ public abstract class Source {
      * @param chars textual source code
      * @param description a note about the origin, for error messages and debugging
      * @return a newly created, non-indexed source representation
+     * @since 0.8 or earlier
      */
     public static Source fromText(CharSequence chars, String description) {
         CompilerAsserts.neverPartOfCompilation("do not call Source.fromText from compiled code");
@@ -241,6 +249,7 @@ public abstract class Source {
      *
      * @param description a note about the origin, for error messages and debugging
      * @return a newly created, non-indexed, initially empty, appendable source representation
+     * @since 0.8 or earlier
      */
     public static Source fromAppendableText(String description) {
         CompilerAsserts.neverPartOfCompilation("do not call Source.fromAppendableText from compiled code");
@@ -255,6 +264,7 @@ public abstract class Source {
      * @param chars textual source code
      * @param name string to use for indexing/lookup
      * @return a newly created, source representation
+     * @since 0.8 or earlier
      */
     public static Source fromNamedText(CharSequence chars, String name) {
         CompilerAsserts.neverPartOfCompilation("do not call Source.fromNamedText from compiled code");
@@ -271,6 +281,7 @@ public abstract class Source {
      *
      * @param name string to use for indexing/lookup
      * @return a newly created, indexed, initially empty, appendable source representation
+     * @since 0.8 or earlier
      */
     public static Source fromNamedAppendableText(String name) {
         CompilerAsserts.neverPartOfCompilation("do not call Source.fromNamedAppendable from compiled code");
@@ -288,6 +299,7 @@ public abstract class Source {
      * @param length the number of characters in the sub-range
      * @return a new instance representing a sub-range of another Source
      * @throws IllegalArgumentException if the specified sub-range is not contained in the base
+     * @since 0.8 or earlier
      */
     public static Source subSource(Source base, int baseCharIndex, int length) {
         CompilerAsserts.neverPartOfCompilation(NO_FASTPATH_SUBSOURCE_CREATION_MESSAGE);
@@ -303,6 +315,7 @@ public abstract class Source {
      * @param baseCharIndex 0-based index of the first character of the sub-range
      * @return a new instance representing a sub-range at the end of another Source
      * @throws IllegalArgumentException if the index is out of range
+     * @since 0.8 or earlier
      */
     public static Source subSource(Source base, int baseCharIndex) {
         CompilerAsserts.neverPartOfCompilation(NO_FASTPATH_SUBSOURCE_CREATION_MESSAGE);
@@ -317,6 +330,7 @@ public abstract class Source {
      * @param description identifies the origin, possibly useful for debugging
      * @return a newly created, non-indexed source representation
      * @throws IOException if reading fails
+     * @since 0.8 or earlier
      */
     public static Source fromURL(URL url, String description) throws IOException {
         CompilerAsserts.neverPartOfCompilation("do not call Source.fromURL from compiled code");
@@ -330,6 +344,7 @@ public abstract class Source {
      * @param description a note about the origin, possibly useful for debugging
      * @return a newly created, non-indexed source representation
      * @throws IOException if reading fails
+     * @since 0.8 or earlier
      */
     public static Source fromReader(Reader reader, String description) throws IOException {
         CompilerAsserts.neverPartOfCompilation("do not call Source.fromReader from compiled code");
@@ -345,6 +360,7 @@ public abstract class Source {
      * @param description a note about the origin, possibly useful for debugging
      * @param charset how to decode the bytes into Java strings
      * @return a newly created, non-indexed source representation
+     * @since 0.8 or earlier
      */
     public static Source fromBytes(byte[] bytes, String description, Charset charset) {
         return fromBytes(bytes, 0, bytes.length, description, charset);
@@ -362,6 +378,7 @@ public abstract class Source {
      * @param description a note about the origin, possibly useful for debugging
      * @param charset how to decode the bytes into Java strings
      * @return a newly created, non-indexed source representation
+     * @since 0.8 or earlier
      */
     public static Source fromBytes(byte[] bytes, int byteIndex, int length, String description, Charset charset) {
         CompilerAsserts.neverPartOfCompilation("do not call Source.fromBytes from compiled code");
@@ -372,6 +389,8 @@ public abstract class Source {
     /**
      * Enables/disables caching of file contents, <em>disabled</em> by default. Caching of sources
      * created from literal text or readers is always enabled.
+     * 
+     * @since 0.8 or earlier
      */
     public static void setFileCaching(boolean enabled) {
         fileCacheEnabled = enabled;
@@ -409,6 +428,7 @@ public abstract class Source {
      * name of a guest language source code file.
      *
      * @return the name of the guest language program
+     * @since 0.8 or earlier
      */
     public abstract String getName();
 
@@ -418,11 +438,14 @@ public abstract class Source {
      * rather than a full path.
      *
      * @return the short name of the guest language program
+     * @since 0.8 or earlier
      */
     public abstract String getShortName();
 
     /**
      * The normalized, canonical name if the source is a file.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract String getPath();
 
@@ -430,16 +453,21 @@ public abstract class Source {
      * The URL if the source is retrieved via URL.
      *
      * @return URL or <code>null</code>
+     * @since 0.8 or earlier
      */
     public abstract URL getURL();
 
     /**
      * Access to the source contents.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract Reader getReader();
 
     /**
      * Access to the source contents.
+     * 
+     * @since 0.8 or earlier
      */
     public final InputStream getInputStream() {
         return new ByteArrayInputStream(getCode().getBytes());
@@ -447,6 +475,8 @@ public abstract class Source {
 
     /**
      * Gets the number of characters in the source.
+     * 
+     * @since 0.8 or earlier
      */
     public final int getLength() {
         return getTextMap().length();
@@ -454,11 +484,15 @@ public abstract class Source {
 
     /**
      * Returns the complete text of the code.
+     * 
+     * @since 0.8 or earlier
      */
     public abstract String getCode();
 
     /**
      * Returns a subsection of the code test.
+     * 
+     * @since 0.8 or earlier
      */
     public String getCode(int charIndex, int charLength) {
         return getCode().substring(charIndex, charIndex + charLength);
@@ -466,6 +500,8 @@ public abstract class Source {
 
     /**
      * Gets the text (not including a possible terminating newline) in a (1-based) numbered line.
+     * 
+     * @since 0.8 or earlier
      */
     public final String getCode(int lineNumber) {
         final int offset = getTextMap().lineStartOffset(lineNumber);
@@ -476,6 +512,8 @@ public abstract class Source {
     /**
      * The number of text lines in the source, including empty lines; characters at the end of the
      * source without a terminating newline count as a line.
+     * 
+     * @since 0.8 or earlier
      */
     public final int getLineCount() {
         return getTextMap().lineCount();
@@ -486,6 +524,7 @@ public abstract class Source {
      * position.
      *
      * @throws IllegalArgumentException if the offset is outside the text contents
+     * @since 0.8 or earlier
      */
     public final int getLineNumber(int offset) throws IllegalArgumentException {
         return getTextMap().offsetToLine(offset);
@@ -495,6 +534,7 @@ public abstract class Source {
      * Given a 0-based character offset, return the 1-based number of the column at the position.
      *
      * @throws IllegalArgumentException if the offset is outside the text contents
+     * @since 0.8 or earlier
      */
     public final int getColumnNumber(int offset) throws IllegalArgumentException {
         return getTextMap().offsetToCol(offset);
@@ -504,6 +544,7 @@ public abstract class Source {
      * Given a 1-based line number, return the 0-based offset of the first character in the line.
      *
      * @throws IllegalArgumentException if there is no such line in the text
+     * @since 0.8 or earlier
      */
     public final int getLineStartOffset(int lineNumber) throws IllegalArgumentException {
         return getTextMap().lineStartOffset(lineNumber);
@@ -514,6 +555,7 @@ public abstract class Source {
      * numbered line.
      *
      * @throws IllegalArgumentException if there is no such line in the text
+     * @since 0.8 or earlier
      */
     public final int getLineLength(int lineNumber) throws IllegalArgumentException {
         return getTextMap().lineLength(lineNumber);
@@ -524,6 +566,7 @@ public abstract class Source {
      *
      * @param chars the text to append
      * @throws UnsupportedOperationException by concrete subclasses that do not support appending
+     * @since 0.8 or earlier
      */
     public void appendCode(CharSequence chars) {
         throw new UnsupportedOperationException();
@@ -543,6 +586,7 @@ public abstract class Source {
      * @param charIndex the 0-based index of the first character of the section
      * @param length the number of characters in the section
      * @return newly created object representing the specified region
+     * @since 0.8 or earlier
      */
     public final SourceSection createSection(String identifier, int startLine, int startColumn, int charIndex, int length) {
         checkRange(charIndex, length);
@@ -565,6 +609,7 @@ public abstract class Source {
      * @param tags the tags associated with this section. Tags must be non-null and
      *            {@link String#intern() interned}.
      * @return newly created object representing the specified region
+     * @since 0.8 or earlier
      */
     public final SourceSection createSection(String identifier, int startLine, int startColumn, int charIndex, int length, String... tags) {
         checkRange(charIndex, length);
@@ -591,6 +636,7 @@ public abstract class Source {
      * @return newly created object representing the specified region
      * @throws IllegalArgumentException if arguments are outside the text of the source
      * @throws IllegalStateException if the source is one of the "null" instances
+     * @since 0.8 or earlier
      */
     public final SourceSection createSection(String identifier, int startLine, int startColumn, int length) {
         final int lineStartOffset = getTextMap().lineStartOffset(startLine);
@@ -619,6 +665,7 @@ public abstract class Source {
      * @throws IllegalArgumentException if either of the arguments are outside the text of the
      *             source
      * @throws IllegalStateException if the source is one of the "null" instances
+     * @since 0.8 or earlier
      */
     public final SourceSection createSection(String identifier, int charIndex, int length) throws IllegalArgumentException {
         return createSection(identifier, charIndex, length, SourceSection.EMTPY_TAGS);
@@ -644,6 +691,7 @@ public abstract class Source {
      * @throws IllegalArgumentException if either of the arguments are outside the text of the
      *             source
      * @throws IllegalStateException if the source is one of the "null" instances
+     * @since 0.8 or earlier
      */
     public final SourceSection createSection(String identifier, int charIndex, int length, String... tags) throws IllegalArgumentException {
         checkRange(charIndex, length);
@@ -667,6 +715,7 @@ public abstract class Source {
      * @return newly created object representing the specified line
      * @throws IllegalArgumentException if the line does not exist the source
      * @throws IllegalStateException if the source is one of the "null" instances
+     * @since 0.8 or earlier
      */
     public final SourceSection createSection(String identifier, int lineNumber) {
         final int charIndex = getTextMap().lineStartOffset(lineNumber);
@@ -680,6 +729,7 @@ public abstract class Source {
      *
      * @param lineNumber a 1-based line number in this source
      * @return a representation of a line in this source
+     * @since 0.8 or earlier
      */
     public final LineLocation createLineLocation(int lineNumber) {
         return new LineLocation(this, lineNumber);
@@ -719,6 +769,7 @@ public abstract class Source {
      *
      * @param mime mime type to use
      * @return new (identical) source, just associated {@link #getMimeType()}
+     * @since 0.8 or earlier
      */
     public final Source withMimeType(String mime) {
         try {
@@ -736,6 +787,7 @@ public abstract class Source {
      * one can directly {@link #withMimeType(java.lang.String) provide a MIME type} to each source.
      *
      * @return MIME type of this source or <code>null</code>, if unknown
+     * @since 0.8 or earlier
      */
     public String getMimeType() {
         if (mimeType == null) {

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/source/SourceSection.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/source/SourceSection.java
@@ -37,6 +37,7 @@ import java.util.Arrays;
  * @see Source#createSection(String, int, int)
  * @see Source#createSection(String, int)
  * @see #createUnavailable
+ * @since 0.8 or earlier
  */
 public final class SourceSection {
 
@@ -106,6 +107,7 @@ public final class SourceSection {
      *
      * @param tag the tag to search for
      * @return <code>true</code> if tag was found else <code>false</code>
+     * @since 0.8 or earlier
      */
     @SuppressFBWarnings("ES_COMPARING_PARAMETER_STRING_WITH_EQ")
     public boolean hasTag(String tag) {
@@ -122,6 +124,7 @@ public final class SourceSection {
      * Representation of the source program that contains this section.
      *
      * @return the source object
+     * @since 0.8 or earlier
      */
     public Source getSource() {
         return source;
@@ -131,6 +134,7 @@ public final class SourceSection {
      * Returns 1-based line number of the first character in this section (inclusive).
      *
      * @return the starting line number
+     * @since 0.8 or earlier
      */
     public int getStartLine() {
         return startLine;
@@ -140,6 +144,7 @@ public final class SourceSection {
      * Gets a representation of the first line of the section, suitable for a hash key.
      *
      * @return first line of the section
+     * @since 0.8 or earlier
      */
     public LineLocation getLineLocation() {
         return source.createLineLocation(startLine);
@@ -149,6 +154,7 @@ public final class SourceSection {
      * Returns the 1-based column number of the first character in this section (inclusive).
      *
      * @return the starting column number
+     * @since 0.8 or earlier
      */
     public int getStartColumn() {
         return startColumn;
@@ -158,6 +164,7 @@ public final class SourceSection {
      * Returns 1-based line number of the last character in this section (inclusive).
      *
      * @return the starting line number
+     * @since 0.8 or earlier
      */
     public int getEndLine() {
         return source.getLineNumber(charIndex + charLength - 1);
@@ -167,6 +174,7 @@ public final class SourceSection {
      * Returns the 1-based column number of the last character in this section (inclusive).
      *
      * @return the starting column number
+     * @since 0.8 or earlier
      */
     public int getEndColumn() {
         return source.getColumnNumber(charIndex + charLength - 1);
@@ -176,6 +184,7 @@ public final class SourceSection {
      * Returns the 0-based index of the first character in this section.
      *
      * @return the starting character index
+     * @since 0.8 or earlier
      */
     public int getCharIndex() {
         return charIndex;
@@ -185,6 +194,7 @@ public final class SourceSection {
      * Returns the length of this section in characters.
      *
      * @return the number of characters in the section
+     * @since 0.8 or earlier
      */
     public int getCharLength() {
         return charLength;
@@ -195,6 +205,7 @@ public final class SourceSection {
      * section.
      *
      * @return the end position of the section
+     * @since 0.8 or earlier
      */
     public int getCharEndIndex() {
         return charIndex + charLength;
@@ -204,6 +215,7 @@ public final class SourceSection {
      * Returns terse text describing this source section, typically used for printing the section.
      *
      * @return the identifier of the section
+     * @since 0.8 or earlier
      */
     public String getIdentifier() {
         return identifier;
@@ -214,6 +226,7 @@ public final class SourceSection {
      *
      * @return the code as a string, or {@code "<unavailable>"} if the SourceSection was created
      *         using {@link #createUnavailable}.
+     * @since 0.8 or earlier
      */
     public String getCode() {
         return source == null ? "<unavailable>" : source.getCode(charIndex, charLength);
@@ -224,6 +237,7 @@ public final class SourceSection {
      * full path.
      *
      * @return a short description of the source section formatted as {@code <filename>:<line>}.
+     * @since 0.8 or earlier
      */
     public String getShortDescription() {
         if (source == null) {
@@ -238,6 +252,7 @@ public final class SourceSection {
      *
      * @see #getCode()
      * @see #getShortDescription()
+     * @since 0.8 or earlier
      */
     @Override
     public String toString() {
@@ -257,6 +272,7 @@ public final class SourceSection {
      *
      * @param tags source section tags
      * @return a copy of the source section with different tags
+     * @since 0.8 or earlier
      */
     public SourceSection withTags(@SuppressWarnings("hiding") String... tags) {
         if (sameTags(tags)) {
@@ -279,6 +295,7 @@ public final class SourceSection {
         return false;
     }
 
+    /** @since 0.8 or earlier */
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -293,6 +310,7 @@ public final class SourceSection {
         return result;
     }
 
+    /** @since 0.8 or earlier */
     @Override
     @SuppressFBWarnings("ES_COMPARING_STRINGS_WITH_EQ")
     public boolean equals(Object obj) {
@@ -355,6 +373,7 @@ public final class SourceSection {
      * @param kind the general category, e.g. "JS builtin"
      * @param name specific name for this section
      * @return source section which is mostly <em>empty</em>
+     * @since 0.8 or earlier
      */
     public static SourceSection createUnavailable(String kind, String name) {
         return new SourceSection(kind, null, name == null ? "<unknown>" : name, -1, -1, -1, -1, EMTPY_TAGS);

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/utilities/AlwaysValidAssumption.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/utilities/AlwaysValidAssumption.java
@@ -30,28 +30,34 @@ import com.oracle.truffle.api.nodes.InvalidAssumptionException;
 /**
  * An assumption that is always valid. Used as a placeholder where an assumption is needed but never
  * invalidated.
+ * 
+ * @since 0.8 or earlier
  */
 public final class AlwaysValidAssumption implements Assumption {
-
+    /** @since 0.8 or earlier */
     public static final AlwaysValidAssumption INSTANCE = new AlwaysValidAssumption();
 
     private AlwaysValidAssumption() {
     }
 
+    /** @since 0.8 or earlier */
     @Override
     public void check() throws InvalidAssumptionException {
     }
 
+    /** @since 0.8 or earlier */
     @Override
     public void invalidate() {
         throw new UnsupportedOperationException("Cannot invalidate this assumption - it is always valid");
     }
 
+    /** @since 0.8 or earlier */
     @Override
     public String getName() {
         return getClass().getName();
     }
 
+    /** @since 0.8 or earlier */
     @Override
     public boolean isValid() {
         return true;

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/utilities/AssumedValue.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/utilities/AssumedValue.java
@@ -37,6 +37,8 @@ import com.oracle.truffle.api.nodes.InvalidAssumptionException;
  * take care to only change values infrequently, or to monitor the number of times the value has
  * changed and at some point to replace the value with something more generic so that it does not
  * have to be changed and code does not have to keep being recompiled.
+ * 
+ * @since 0.8 or earlier
  */
 public class AssumedValue<T> {
 
@@ -45,10 +47,12 @@ public class AssumedValue<T> {
     @CompilationFinal private T value;
     @CompilationFinal private Assumption assumption;
 
+    /** @since 0.8 or earlier */
     public AssumedValue(T initialValue) {
         this(null, initialValue);
     }
 
+    /** @since 0.8 or earlier */
     public AssumedValue(String name, T initialValue) {
         this.name = name;
         value = initialValue;
@@ -58,6 +62,8 @@ public class AssumedValue<T> {
     /**
      * Get the current value, updating it if it has been {@link #set}. The compiler may be able to
      * make this method return a constant value, but still accommodate mutation.
+     * 
+     * @since 0.8 or earlier
      */
     public T get() {
         try {
@@ -71,6 +77,8 @@ public class AssumedValue<T> {
 
     /**
      * Set a new value, which will be picked up the next time {@link #get} is called.
+     * 
+     * @since 0.8 or earlier
      */
     public void set(T newValue) {
         CompilerDirectives.transferToInterpreter();

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/utilities/BinaryConditionProfile.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/utilities/BinaryConditionProfile.java
@@ -30,6 +30,7 @@ import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 /**
  * @deprecated package name renamed to {@link com.oracle.truffle.api.profiles.ConditionProfile}
  *             instead
+ * @since 0.8 or earlier
  */
 @SuppressWarnings("deprecation")
 @Deprecated
@@ -42,6 +43,7 @@ public final class BinaryConditionProfile extends ConditionProfile {
         /* package protected constructor */
     }
 
+    /** @since 0.8 or earlier */
     @Override
     public boolean profile(boolean value) {
         if (value) {
@@ -59,14 +61,17 @@ public final class BinaryConditionProfile extends ConditionProfile {
         }
     }
 
+    /** @since 0.8 or earlier */
     public boolean wasTrue() {
         return wasTrue;
     }
 
+    /** @since 0.8 or earlier */
     public boolean wasFalse() {
         return wasFalse;
     }
 
+    /** @since 0.8 or earlier */
     @Override
     public String toString() {
         return String.format("%s(wasTrue=%s, wasFalse=%s)@%x", getClass().getSimpleName(), wasTrue, wasFalse, hashCode());

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/utilities/BranchProfile.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/utilities/BranchProfile.java
@@ -30,6 +30,7 @@ import com.oracle.truffle.api.nodes.NodeCloneable;
 
 /**
  * @deprecated use {@link com.oracle.truffle.api.profiles.BranchProfile} instead
+ * @since 0.8 or earlier
  */
 @Deprecated
 public final class BranchProfile extends NodeCloneable {
@@ -39,6 +40,7 @@ public final class BranchProfile extends NodeCloneable {
     private BranchProfile() {
     }
 
+    /** @since 0.8 or earlier */
     public void enter() {
         if (!visited) {
             CompilerDirectives.transferToInterpreterAndInvalidate();
@@ -46,18 +48,21 @@ public final class BranchProfile extends NodeCloneable {
         }
     }
 
+    /** @since 0.8 or earlier */
     public boolean isVisited() {
         return visited;
     }
 
     /**
      * @deprecated use {@link com.oracle.truffle.api.profiles.BranchProfile#create()} instead
+     * @since 0.8 or earlier
      */
     @Deprecated
     public static BranchProfile create() {
         return new BranchProfile();
     }
 
+    /** @since 0.8 or earlier */
     @Override
     public String toString() {
         return String.format("%s(%s)@%x", getClass().getSimpleName(), visited ? "visited" : "not-visited", hashCode());

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/utilities/ConditionProfile.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/utilities/ConditionProfile.java
@@ -28,18 +28,21 @@ import com.oracle.truffle.api.nodes.NodeCloneable;
 
 /**
  * @deprecated use {@link com.oracle.truffle.api.profiles.ConditionProfile} instead
+ * @since 0.8 or earlier
  */
 @Deprecated
 public abstract class ConditionProfile extends NodeCloneable {
     ConditionProfile() {
     }
 
+    /** @since 0.8 or earlier */
     public abstract boolean profile(boolean value);
 
     /**
      * @deprecated use
      *             {@link com.oracle.truffle.api.profiles.ConditionProfile#createCountingProfile()}
      *             instead
+     * @since 0.8 or earlier
      */
     @SuppressWarnings("deprecation")
     @Deprecated
@@ -51,6 +54,7 @@ public abstract class ConditionProfile extends NodeCloneable {
      * @deprecated use
      *             {@link com.oracle.truffle.api.profiles.ConditionProfile#createBinaryProfile()}
      *             instead
+     * @since 0.8 or earlier
      */
     @Deprecated
     @SuppressWarnings("deprecation")

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/utilities/CountingConditionProfile.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/utilities/CountingConditionProfile.java
@@ -30,6 +30,7 @@ import com.oracle.truffle.api.CompilerDirectives.CompilationFinal;
 /**
  * @deprecated use {@link com.oracle.truffle.api.profiles.ConditionProfile#createCountingProfile()}
  *             instead
+ * @since 0.8 or earlier
  */
 @Deprecated
 @SuppressWarnings("deprecation")
@@ -42,6 +43,7 @@ public final class CountingConditionProfile extends ConditionProfile {
         /* package protected constructor */
     }
 
+    /** @since 0.8 or earlier */
     @Override
     public boolean profile(boolean value) {
         if (value) {
@@ -66,14 +68,17 @@ public final class CountingConditionProfile extends ConditionProfile {
         return CompilerDirectives.injectBranchProbability((double) trueCount / (double) (trueCount + falseCount), value);
     }
 
+    /** @since 0.8 or earlier */
     public int getTrueCount() {
         return trueCount;
     }
 
+    /** @since 0.8 or earlier */
     public int getFalseCount() {
         return falseCount;
     }
 
+    /** @since 0.8 or earlier */
     @Override
     public String toString() {
         return String.format("%s(trueCount=%s, falseCount=%s)@%x", getClass().getSimpleName(), trueCount, falseCount, hashCode());

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/utilities/CyclicAssumption.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/utilities/CyclicAssumption.java
@@ -36,6 +36,8 @@ import com.oracle.truffle.api.Truffle;
  * an assumption that may be recreated can have a final reference to an object of this class. Note
  * that you should be careful that repeated invalidations do not cause a deoptimization loop in that
  * same way that you would with any other assumption.
+ * 
+ * @since 0.8 or earlier
  */
 public class CyclicAssumption {
 
@@ -44,11 +46,13 @@ public class CyclicAssumption {
 
     private static final AtomicReferenceFieldUpdater<CyclicAssumption, Assumption> ASSUMPTION_UPDATER = AtomicReferenceFieldUpdater.newUpdater(CyclicAssumption.class, Assumption.class, "assumption");
 
+    /** @since 0.8 or earlier */
     public CyclicAssumption(String name) {
         this.name = name;
         this.assumption = Truffle.getRuntime().createAssumption(name);
     }
 
+    /** @since 0.8 or earlier */
     @TruffleBoundary
     public void invalidate() {
         Assumption newAssumption = Truffle.getRuntime().createAssumption(name);
@@ -56,6 +60,7 @@ public class CyclicAssumption {
         oldAssumption.invalidate();
     }
 
+    /** @since 0.8 or earlier */
     public Assumption getAssumption() {
         return assumption;
     }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/utilities/JSONHelper.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/utilities/JSONHelper.java
@@ -33,23 +33,35 @@ import java.util.Map;
 
 /**
  * Helper function that allows to dump the AST during creation to a JSON format.
+ * 
+ * @since 0.8 or earlier
  */
 public class JSONHelper {
+    /**
+     * @deprecated accidentally public - to be removed.
+     * @since 0.8 or earlier
+     */
+    @Deprecated
+    public JSONHelper() {
+    }
 
     private static StringBuilder AstJsonDumpBuilder = new StringBuilder();
 
+    /** @since 0.8 or earlier */
     public static void dumpNewChild(Node parentNode, Node childNode) {
         if (AstJsonDumpBuilder != null) {
             AstJsonDumpBuilder.append("{ \"action\": \"insertNode\", \"parentId\": \"" + getID(parentNode) + "\", \"newId\": \"" + getID(childNode) + "\" },\n");
         }
     }
 
+    /** @since 0.8 or earlier */
     public static void dumpReplaceChild(Node oldNode, Node newNode, CharSequence reason) {
         if (AstJsonDumpBuilder != null) {
             AstJsonDumpBuilder.append("{ \"action\": \"replaceNode\", \"oldId\": \"" + getID(oldNode) + "\", \"newId\": \"" + getID(newNode) + "\", \"reason\": " + quote(reason) + " },\n");
         }
     }
 
+    /** @since 0.8 or earlier */
     public static void dumpNewNode(Node newNode) {
         if (AstJsonDumpBuilder != null) {
             AstJsonDumpBuilder.append("{ \"action\": \"createNode\", \"newId\": \"" + getID(newNode) + "\", \"type\": \"" + getType(newNode) + "\", \"description\": \"" + newNode.getDescription() +
@@ -66,6 +78,7 @@ public class JSONHelper {
         }
     }
 
+    /** @since 0.8 or earlier */
     public static String getResult() {
         return AstJsonDumpBuilder.toString();
     }
@@ -120,19 +133,34 @@ public class JSONHelper {
         return builder.toString();
     }
 
+    /** @since 0.8 or earlier */
     public static void restart() {
         AstJsonDumpBuilder = new StringBuilder();
     }
 
+    /** @since 0.8 or earlier */
     public static JSONObjectBuilder object() {
         return new JSONObjectBuilder();
     }
 
+    /** @since 0.8 or earlier */
     public static JSONArrayBuilder array() {
         return new JSONArrayBuilder();
     }
 
+    /**
+     * @since 0.8 or earlier
+     */
     public abstract static class JSONStringBuilder {
+        /**
+         * @deprecated accidentally public - don't use
+         * @since 0.8 or earlier
+         */
+        @Deprecated
+        protected JSONStringBuilder() {
+        }
+
+        /** @since 0.8 or earlier */
         @Override
         public final String toString() {
             StringBuilder sb = new StringBuilder();
@@ -140,8 +168,10 @@ public class JSONHelper {
             return sb.toString();
         }
 
+        /** @since 0.8 or earlier */
         protected abstract void appendTo(StringBuilder sb);
 
+        /** @since 0.8 or earlier */
         protected static void appendValue(StringBuilder sb, Object value) {
             if (value instanceof JSONStringBuilder) {
                 ((JSONStringBuilder) value).appendTo(sb);
@@ -153,32 +183,38 @@ public class JSONHelper {
         }
     }
 
+    /** @since 0.8 or earlier */
     public static final class JSONObjectBuilder extends JSONStringBuilder {
         private final Map<String, Object> contents = new LinkedHashMap<>();
 
         private JSONObjectBuilder() {
         }
 
+        /** @since 0.8 or earlier */
         public JSONObjectBuilder add(String key, String value) {
             contents.put(key, value);
             return this;
         }
 
+        /** @since 0.8 or earlier */
         public JSONObjectBuilder add(String key, Number value) {
             contents.put(key, value);
             return this;
         }
 
+        /** @since 0.8 or earlier */
         public JSONObjectBuilder add(String key, Boolean value) {
             contents.put(key, value);
             return this;
         }
 
+        /** @since 0.8 or earlier */
         public JSONObjectBuilder add(String key, JSONStringBuilder value) {
             contents.put(key, value);
             return this;
         }
 
+        /** @since 0.8 or earlier */
         @Override
         protected void appendTo(StringBuilder sb) {
             sb.append("{");
@@ -196,32 +232,38 @@ public class JSONHelper {
         }
     }
 
+    /** @since 0.8 or earlier */
     public static final class JSONArrayBuilder extends JSONStringBuilder {
         private final List<Object> contents = new ArrayList<>();
 
         private JSONArrayBuilder() {
         }
 
+        /** @since 0.8 or earlier */
         public JSONArrayBuilder add(String value) {
             contents.add(value);
             return this;
         }
 
+        /** @since 0.8 or earlier */
         public JSONArrayBuilder add(Number value) {
             contents.add(value);
             return this;
         }
 
+        /** @since 0.8 or earlier */
         public JSONArrayBuilder add(Boolean value) {
             contents.add(value);
             return this;
         }
 
+        /** @since 0.8 or earlier */
         public JSONArrayBuilder add(JSONStringBuilder value) {
             contents.add(value);
             return this;
         }
 
+        /** @since 0.8 or earlier */
         @Override
         protected void appendTo(StringBuilder sb) {
             sb.append("[");

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/utilities/NeverValidAssumption.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/utilities/NeverValidAssumption.java
@@ -30,28 +30,34 @@ import com.oracle.truffle.api.nodes.InvalidAssumptionException;
 /**
  * An assumption that is never valid. Used as a placeholder where an assumption is needed that
  * should be invalid from the start.
+ * 
+ * @since 0.8 or earlier
  */
 public final class NeverValidAssumption implements Assumption {
-
+    /** @since 0.8 or earlier */
     public static final NeverValidAssumption INSTANCE = new NeverValidAssumption();
 
     private NeverValidAssumption() {
     }
 
+    /** @since 0.8 or earlier */
     @Override
     public void check() throws InvalidAssumptionException {
         throw new InvalidAssumptionException();
     }
 
+    /** @since 0.8 or earlier */
     @Override
     public void invalidate() {
     }
 
+    /** @since 0.8 or earlier */
     @Override
     public String getName() {
         return getClass().getName();
     }
 
+    /** @since 0.8 or earlier */
     @Override
     public boolean isValid() {
         return false;

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/utilities/PrimitiveValueProfile.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/utilities/PrimitiveValueProfile.java
@@ -31,6 +31,7 @@ import java.util.Objects;
 
 /**
  * @deprecated use {@link com.oracle.truffle.api.profiles.PrimitiveValueProfile} instead
+ * @since 0.8 or earlier
  */
 @Deprecated
 @SuppressWarnings("deprecation")
@@ -44,6 +45,7 @@ public class PrimitiveValueProfile extends ValueProfile {
     PrimitiveValueProfile() {
     }
 
+    /** @since 0.8 or earlier */
     @SuppressWarnings("unchecked")
     @Override
     public <T> T profile(T v) {
@@ -90,6 +92,7 @@ public class PrimitiveValueProfile extends ValueProfile {
         return (T) value;
     }
 
+    /** @since 0.8 or earlier */
     public byte profile(byte value) {
         Object snapshot = this.cachedValue;
         if (snapshot != GENERIC) {
@@ -102,6 +105,7 @@ public class PrimitiveValueProfile extends ValueProfile {
         return value;
     }
 
+    /** @since 0.8 or earlier */
     public short profile(short value) {
         Object snapshot = this.cachedValue;
         if (snapshot != GENERIC) {
@@ -114,6 +118,7 @@ public class PrimitiveValueProfile extends ValueProfile {
         return value;
     }
 
+    /** @since 0.8 or earlier */
     public int profile(int value) {
         Object snapshot = this.cachedValue;
         if (snapshot != GENERIC) {
@@ -126,6 +131,7 @@ public class PrimitiveValueProfile extends ValueProfile {
         return value;
     }
 
+    /** @since 0.8 or earlier */
     public long profile(long value) {
         Object snapshot = this.cachedValue;
         if (snapshot != GENERIC) {
@@ -138,6 +144,7 @@ public class PrimitiveValueProfile extends ValueProfile {
         return value;
     }
 
+    /** @since 0.8 or earlier */
     public float profile(float value) {
         Object snapshot = this.cachedValue;
         if (snapshot != GENERIC) {
@@ -150,6 +157,7 @@ public class PrimitiveValueProfile extends ValueProfile {
         return value;
     }
 
+    /** @since 0.8 or earlier */
     public double profile(double value) {
         Object snapshot = this.cachedValue;
         if (snapshot != GENERIC) {
@@ -162,6 +170,7 @@ public class PrimitiveValueProfile extends ValueProfile {
         return value;
     }
 
+    /** @since 0.8 or earlier */
     public boolean profile(boolean value) {
         Object snapshot = this.cachedValue;
         if (snapshot != GENERIC) {
@@ -174,6 +183,7 @@ public class PrimitiveValueProfile extends ValueProfile {
         return value;
     }
 
+    /** @since 0.8 or earlier */
     public char profile(char value) {
         Object snapshot = this.cachedValue;
         if (snapshot != GENERIC) {
@@ -186,18 +196,22 @@ public class PrimitiveValueProfile extends ValueProfile {
         return value;
     }
 
+    /** @since 0.8 or earlier */
     public boolean isGeneric() {
         return cachedValue == GENERIC;
     }
 
+    /** @since 0.8 or earlier */
     public boolean isUninitialized() {
         return cachedValue == UNINITIALIZED;
     }
 
+    /** @since 0.8 or earlier */
     public Object getCachedValue() {
         return cachedValue;
     }
 
+    /** @since 0.8 or earlier */
     @Override
     public String toString() {
         return String.format("%s(%s)@%x", getClass().getSimpleName(), formatValue(), hashCode());
@@ -213,6 +227,7 @@ public class PrimitiveValueProfile extends ValueProfile {
         }
     }
 
+    /** @since 0.8 or earlier */
     public static boolean exactCompare(float a, float b) {
         /*
          * -0.0 == 0.0, but you can tell the difference through other means, so we need to
@@ -221,6 +236,7 @@ public class PrimitiveValueProfile extends ValueProfile {
         return Float.floatToRawIntBits(a) == Float.floatToRawIntBits(b);
     }
 
+    /** @since 0.8 or earlier */
     public static boolean exactCompare(double a, double b) {
         /*
          * -0.0 == 0.0, but you can tell the difference through other means, so we need to

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/utilities/UnionAssumption.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/utilities/UnionAssumption.java
@@ -30,6 +30,8 @@ import com.oracle.truffle.api.nodes.InvalidAssumptionException;
 /**
  * An assumption that combines two other assumptions. A check on this assumption checks both of the
  * child assumptions.
+ * 
+ * @since 0.8 or earlier
  */
 public class UnionAssumption implements Assumption {
 
@@ -37,33 +39,39 @@ public class UnionAssumption implements Assumption {
     private final Assumption first;
     private final Assumption second;
 
+    /** @since 0.8 or earlier */
     public UnionAssumption(String name, Assumption first, Assumption second) {
         this.name = name;
         this.first = first;
         this.second = second;
     }
 
+    /** @since 0.8 or earlier */
     public UnionAssumption(Assumption first, Assumption second) {
         this(null, first, second);
     }
 
+    /** @since 0.8 or earlier */
     @Override
     public void check() throws InvalidAssumptionException {
         first.check();
         second.check();
     }
 
+    /** @since 0.8 or earlier */
     @Override
     public void invalidate() {
         first.invalidate();
         second.invalidate();
     }
 
+    /** @since 0.8 or earlier */
     @Override
     public String getName() {
         return name;
     }
 
+    /** @since 0.8 or earlier */
     @Override
     public boolean isValid() {
         return first.isValid() && second.isValid();

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/utilities/ValueProfile.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/utilities/ValueProfile.java
@@ -28,17 +28,27 @@ import com.oracle.truffle.api.nodes.NodeCloneable;
 
 /**
  * @deprecated use {@link com.oracle.truffle.api.profiles.ValueProfile} instead
+ * @since 0.8 or earlier
  */
 @Deprecated
 @SuppressWarnings("deprecation")
 public abstract class ValueProfile extends NodeCloneable {
+    /**
+     * @since 0.8 or earlier
+     * @deprecated don't use
+     */
+    @Deprecated
+    public ValueProfile() {
+    }
 
+    /** @since 0.8 or earlier */
     public abstract <T> T profile(T value);
 
     /**
      * @deprecated use
      *             {@link com.oracle.truffle.api.profiles.PrimitiveValueProfile#createEqualityProfile()}
      *             instead
+     * @since 0.8 or earlier
      */
     @Deprecated
     public static PrimitiveValueProfile createPrimitiveProfile() {
@@ -48,6 +58,7 @@ public abstract class ValueProfile extends NodeCloneable {
     /**
      * @deprecated use {@link com.oracle.truffle.api.profiles.ValueProfile#createClassProfile()}
      *             instead
+     * @since 0.8 or earlier
      */
     @Deprecated
     public static ValueProfile createClassProfile() {
@@ -57,6 +68,7 @@ public abstract class ValueProfile extends NodeCloneable {
     /**
      * @deprecated use {@link com.oracle.truffle.api.profiles.ValueProfile#createIdentityProfile()}
      *             instead
+     * @since 0.8 or earlier
      */
     @Deprecated
     public static ValueProfile createIdentityProfile() {

--- a/truffle/com.oracle.truffle.tck/src/com/oracle/truffle/tck/TruffleTCK.java
+++ b/truffle/com.oracle.truffle.tck/src/com/oracle/truffle/tck/TruffleTCK.java
@@ -68,12 +68,12 @@ import static org.junit.Assert.fail;
  *     <em>// create the engine</em>
  *     <em>// execute necessary scripts</em>
  *   }
- *
+ * 
  *   {@link Override @Override}
  *   <b>protected</b> {@link String} fourtyTwo() {
  *     <b>return</b> <em>// name of function that returns 42</em>
  *   }
- *
+ * 
  *   <em>// and so on...</em>
  * }
  * </pre>
@@ -111,11 +111,14 @@ import static org.junit.Assert.fail;
  * Should the <em>TCK</em> be found unsuitable for your {@link TruffleLanguage language
  * implementation} please speak-up (at <em>Truffle/Graal</em> mailing list for example) and we do
  * our best to analyze your case and adjust the <em>TCK</em> to suite everyone's needs.
+ * 
+ * @since 0.8 or earlier
  */
 public abstract class TruffleTCK {
     private static final Random RANDOM = new Random();
     private PolyglotEngine tckVM;
 
+    /** @since 0.8 or earlier */
     protected TruffleTCK() {
     }
 
@@ -129,6 +132,7 @@ public abstract class TruffleTCK {
      *
      * @return initialized Truffle virtual machine
      * @throws java.lang.Exception thrown when the VM preparation fails
+     * @since 0.8 or earlier
      */
     protected abstract PolyglotEngine prepareVM() throws Exception;
 
@@ -138,6 +142,7 @@ public abstract class TruffleTCK {
      * {@link #prepareVM() created engine}.
      *
      * @return mime type of the tested language
+     * @since 0.8 or earlier
      */
     protected abstract String mimeType();
 
@@ -147,6 +152,7 @@ public abstract class TruffleTCK {
      * <code>42</code>.
      *
      * @return name of globally exported symbol
+     * @since 0.8 or earlier
      */
     protected abstract String fourtyTwo();
 
@@ -158,6 +164,7 @@ public abstract class TruffleTCK {
      * true.
      *
      * @return name of globally exported symbol
+     * @since 0.8 or earlier
      */
     protected abstract String returnsNull();
 
@@ -167,6 +174,7 @@ public abstract class TruffleTCK {
      * {@link Number#intValue()} is equivalent of <code>param1 + param2</code>.
      *
      * @return name of globally exported symbol
+     * @since 0.8 or earlier
      */
     protected String plusInt() {
         throw new UnsupportedOperationException("Override plus(Class,Class) method!");
@@ -174,7 +182,7 @@ public abstract class TruffleTCK {
 
     /**
      * Name of function to add two numbers together. The symbol will be invoked with two parameters
-     * of <code>type1</code> and <code>type2</code> and expects result of type {@link Number}
+     * of <code>type1</code> and <code>type2</code> and expects result of type {@link Number} 
      * which's {@link Number#intValue()} is equivalent of <code>param1 + param2</code>. As some
      * languages may have different operations for different types of numbers, the actual types are
      * passed to the method and the implementation can decide to return different symbol based on
@@ -183,6 +191,7 @@ public abstract class TruffleTCK {
      * @param type1 one of byte, short, int, long, float, double class
      * @param type2 one of byte, short, int, long, float, double class
      * @return name of globally exported symbol
+     * @since 0.8 or earlier
      */
     protected String plus(Class<?> type1, Class<?> type2) {
         return plusInt();
@@ -195,6 +204,7 @@ public abstract class TruffleTCK {
      * back to its caller.
      *
      * @return name of globally exported symbol
+     * @since 0.8 or earlier
      */
     protected abstract String applyNumbers();
 
@@ -204,6 +214,7 @@ public abstract class TruffleTCK {
      * identical output.
      *
      * @return name of globally exported symbol
+     * @since 0.8 or earlier
      */
     protected String identity() {
         throw new UnsupportedOperationException("identity() method not implemented");
@@ -215,6 +226,7 @@ public abstract class TruffleTCK {
      * imaginary. The first argument contains the result of the addition.
      *
      * @return name of globally exported symbol
+     * @since 0.8 or earlier
      */
     protected String complexAdd() {
         throw new UnsupportedOperationException("complexAdd() method not implemented");
@@ -227,6 +239,7 @@ public abstract class TruffleTCK {
      * result of the addition.
      *
      * @return name of globally exported symbol
+     * @since 0.8 or earlier
      */
     protected String complexAddWithMethod() {
         throw new UnsupportedOperationException("complexAddWithMethod() method not implemented");
@@ -238,6 +251,7 @@ public abstract class TruffleTCK {
      * numbers.
      *
      * @return name of globally exported symbol, <code>null</code> if the test should be skipped
+     * @since 0.8 or earlier
      */
     protected String complexSumReal() {
         throw new UnsupportedOperationException("complexSumReal() method not implemented");
@@ -250,6 +264,7 @@ public abstract class TruffleTCK {
      * source.
      *
      * @return name of globally exported symbol, <code>null</code> if the test should be skipped
+     * @since 0.8 or earlier
      */
     protected String complexCopy() {
         throw new UnsupportedOperationException("complexCopy() method not implemented");
@@ -263,6 +278,7 @@ public abstract class TruffleTCK {
      *
      * @return name of globally exported symbol, return <code>null</code> if the language doesn't
      *         support the concept of global object
+     * @since 0.8 or earlier
      */
     protected String globalObject() {
         throw new UnsupportedOperationException("globalObject() method not implemented");
@@ -275,6 +291,7 @@ public abstract class TruffleTCK {
      * execute it. The result of the execution is then returned back to the caller.
      *
      * @return name of globally exported symbol to invoke when one wants to execute some code
+     * @since 0.8 or earlier
      */
     protected String evaluateSource() {
         throw new UnsupportedOperationException("evaluateSource() method not implemented");
@@ -289,6 +306,7 @@ public abstract class TruffleTCK {
      * @param firstName name of the first variable to multiplyCode
      * @param secondName name of the second variable to multiplyCode
      * @return code snippet that multiplies the two variables in your language
+     * @since 0.8 or earlier
      */
     protected String multiplyCode(String firstName, String secondName) {
         throw new UnsupportedOperationException("multiply(String,String) method not implemeted!");
@@ -304,6 +322,7 @@ public abstract class TruffleTCK {
      * each other. Without being mutually influenced.
      *
      * @return name of globally expected symbol
+     * @since 0.8 or earlier
      */
     protected abstract String countInvocations();
 
@@ -313,6 +332,7 @@ public abstract class TruffleTCK {
      * yield an exception.
      *
      * @return code snippet invalid in the tested language
+     * @since 0.8 or earlier
      */
     protected abstract String invalidCode();
 
@@ -336,6 +356,7 @@ public abstract class TruffleTCK {
      * <b>returnsThis</b> that will return the object itself again.
      *
      * @return name of a function that returns such compound object
+     * @since 0.8 or earlier
      */
     protected String compoundObject() {
         throw new UnsupportedOperationException("compoundObject() method not implemented");
@@ -365,6 +386,7 @@ public abstract class TruffleTCK {
      * should yield new object.
      *
      * @return name of a function that returns such values object
+     * @since 0.8 or earlier
      */
     protected String valuesObject() {
         throw new UnsupportedOperationException("valuesObject() method not implemented");
@@ -384,6 +406,7 @@ public abstract class TruffleTCK {
      * @param expectedValue the value expected by the test
      * @param actualValue the real value produced by the language
      * @throws AssertionError if the values are different according to the language semantics
+     * @since 0.8 or earlier
      */
     protected void assertDouble(String msg, double expectedValue, double actualValue) {
         assertEquals(msg, expectedValue, actualValue, 0.1);
@@ -399,7 +422,7 @@ public abstract class TruffleTCK {
     //
     // The tests
     //
-
+    /** @since 0.8 or earlier */
     @Test
     public void testFortyTwo() throws Exception {
         PolyglotEngine.Value fourtyTwo = findGlobalSymbol(fourtyTwo());
@@ -413,6 +436,7 @@ public abstract class TruffleTCK {
         assert 42 == n.intValue() : "The value is 42 =  " + n.intValue();
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testFortyTwoWithCompoundObject() throws Exception {
         CompoundObject obj = findCompoundSymbol();
@@ -423,6 +447,7 @@ public abstract class TruffleTCK {
         assertEquals("Should be 42", 42, res.intValue());
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testNull() throws Exception {
         PolyglotEngine.Value retNull = findGlobalSymbol(returnsNull());
@@ -432,6 +457,7 @@ public abstract class TruffleTCK {
         assertNull("Should yield real Java null", res);
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testNullCanBeCastToAnything() throws Exception {
         PolyglotEngine.Value retNull = findGlobalSymbol(returnsNull());
@@ -441,6 +467,7 @@ public abstract class TruffleTCK {
         assertNull("Should yield real Java null", res);
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testNullInCompoundObject() throws Exception {
         CompoundObject obj = findCompoundSymbol();
@@ -451,6 +478,7 @@ public abstract class TruffleTCK {
         assertNull("Should yield real Java null", res);
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPlusWithInts() throws Exception {
         int a = RANDOM.nextInt(100);
@@ -458,6 +486,7 @@ public abstract class TruffleTCK {
         doPlusWithInts(a, b);
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPlusWithOneNegativeInt() throws Exception {
         int a = -RANDOM.nextInt(100);
@@ -472,6 +501,7 @@ public abstract class TruffleTCK {
         assert a + b == n.intValue() : "The value is correct: (" + a + " + " + b + ") =  " + n.intValue();
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPlusWithBytes() throws Exception {
         int a = RANDOM.nextInt(100);
@@ -479,6 +509,7 @@ public abstract class TruffleTCK {
         doPlusWithBytes(a, b);
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPlusWithOneNegativeByte() throws Exception {
         int a = -RANDOM.nextInt(100);
@@ -493,6 +524,7 @@ public abstract class TruffleTCK {
         assert a + b == n.intValue() : "The value is correct: (" + a + " + " + b + ") =  " + n.intValue();
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPlusWithShort() throws Exception {
         int a = RANDOM.nextInt(100);
@@ -500,6 +532,7 @@ public abstract class TruffleTCK {
         doPlusWithShorts(a, b);
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPlusWithOneNegativeShort() throws Exception {
         int a = RANDOM.nextInt(100);
@@ -514,6 +547,7 @@ public abstract class TruffleTCK {
         assert a + b == n.intValue() : "The value is correct: (" + a + " + " + b + ") =  " + n.intValue();
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPlusWithLong() throws Exception {
         long a = RANDOM.nextInt(100);
@@ -521,6 +555,7 @@ public abstract class TruffleTCK {
         doPlusWithLong(a, b);
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPlusWithLongMaxIntMinInt() throws Exception {
         doPlusWithLong(Integer.MAX_VALUE, Integer.MIN_VALUE);
@@ -533,6 +568,7 @@ public abstract class TruffleTCK {
         assert a + b == n.longValue() : "The value is correct: (" + a + " + " + b + ") =  " + n.longValue();
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPlusWithDoubleFloatSameAsInt() throws Exception {
         int x = RANDOM.nextInt(100);
@@ -555,6 +591,7 @@ public abstract class TruffleTCK {
         assertEquals("Correct value computed via double: (" + a + " + " + b + ")", intResult.intValue(), doubleResult.intValue());
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPlusWithFloat() throws Exception {
         float a = RANDOM.nextFloat() * 100.0f;
@@ -570,6 +607,7 @@ public abstract class TruffleTCK {
         assertDouble("Correct value computed: (" + a + " + " + b + ")", a + b, n.floatValue());
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPlusWithDouble() throws Exception {
         double a = RANDOM.nextDouble() * 100.0;
@@ -577,6 +615,7 @@ public abstract class TruffleTCK {
         doPlusWithDouble(a, b);
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPlusWithDoubleRound() throws Exception {
         double a = RANDOM.nextInt(1000);
@@ -585,6 +624,7 @@ public abstract class TruffleTCK {
         doPlusWithDouble(a, b);
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPlusWithDoubleMaxInt() throws Exception {
         double a = Integer.MAX_VALUE;
@@ -593,6 +633,7 @@ public abstract class TruffleTCK {
         doPlusWithDouble(a, b);
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPlusWithDoubleMaxMinInt() throws Exception {
         double a = Integer.MAX_VALUE;
@@ -601,6 +642,7 @@ public abstract class TruffleTCK {
         doPlusWithDouble(a, b);
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPlusWithDoubleMinIntMinusOne() throws Exception {
         double a = -1;
@@ -609,6 +651,7 @@ public abstract class TruffleTCK {
         doPlusWithDouble(a, b);
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPlusWithDoubleMaxIntPlusOne() throws Exception {
         double a = 1;
@@ -617,6 +660,7 @@ public abstract class TruffleTCK {
         doPlusWithDouble(a, b);
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPlusWithDoubleNaNPlusNegInf() throws Exception {
         double a = Double.NaN;
@@ -625,6 +669,7 @@ public abstract class TruffleTCK {
         doPlusWithDouble(a, b);
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPlusWithDoubleNaNPlusPosInf() throws Exception {
         double a = Double.NaN;
@@ -633,6 +678,7 @@ public abstract class TruffleTCK {
         doPlusWithDouble(a, b);
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPlusWithDoubleMaxIntPlusPosInf() throws Exception {
         double a = Integer.MAX_VALUE;
@@ -641,6 +687,7 @@ public abstract class TruffleTCK {
         doPlusWithDouble(a, b);
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPlusWithDoubleMaxIntPlusNegInf() throws Exception {
         double a = Integer.MAX_VALUE;
@@ -656,6 +703,7 @@ public abstract class TruffleTCK {
         assertDouble("Correct value computed: (" + a + " + " + b + ")", a + b, n.doubleValue());
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPlusWithIntsOnCompoundObject() throws Exception {
         int a = RANDOM.nextInt(100);
@@ -670,6 +718,7 @@ public abstract class TruffleTCK {
         assert a + b == n.intValue() : "The value is correct: (" + a + " + " + b + ") =  " + n.intValue();
     }
 
+    /** @since 0.8 or earlier */
     @Test(expected = IOException.class)
     public void testInvalidTestMethod() throws Exception {
         String mime = mimeType();
@@ -678,6 +727,7 @@ public abstract class TruffleTCK {
         fail("Should yield IOException, but returned " + ret);
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testMaxOrMinValue() throws Exception {
         PolyglotEngine.Value apply = findGlobalSymbol(applyNumbers());
@@ -692,6 +742,7 @@ public abstract class TruffleTCK {
         assert 42 == n.intValue() : "32 > 18 and plus 10";
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testMaxOrMinValue2() throws Exception {
         PolyglotEngine.Value apply = findGlobalSymbol(applyNumbers());
@@ -710,6 +761,7 @@ public abstract class TruffleTCK {
         assert 28 == n.intValue() : "18 < 32 and plus 10";
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPrimitiveReturnTypeByte() throws Exception {
         PolyglotEngine.Value apply = findGlobalSymbol(applyNumbers());
@@ -721,6 +773,7 @@ public abstract class TruffleTCK {
         assertEquals("The same value returned (" + value + " + 10): ", value + 10, n.byteValue());
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPrimitiveReturnTypeShort() throws Exception {
         PolyglotEngine.Value apply = findGlobalSymbol(applyNumbers());
@@ -732,6 +785,7 @@ public abstract class TruffleTCK {
         assertEquals("The same value returned (" + value + " + 10): ", value + 10, n.shortValue());
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPrimitiveReturnTypeInt() throws Exception {
         PolyglotEngine.Value apply = findGlobalSymbol(applyNumbers());
@@ -743,6 +797,7 @@ public abstract class TruffleTCK {
         assertEquals("The same value returned (" + value + " + 10): ", value + 10, n.intValue());
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPrimitiveReturnTypeLong() throws Exception {
         PolyglotEngine.Value apply = findGlobalSymbol(applyNumbers());
@@ -754,6 +809,7 @@ public abstract class TruffleTCK {
         assertEquals("The same value returned (" + value + " + 10): ", value + 10, n.longValue());
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPrimitiveReturnTypeFloat() throws Exception {
         PolyglotEngine.Value apply = findGlobalSymbol(applyNumbers());
@@ -765,6 +821,7 @@ public abstract class TruffleTCK {
         assertDouble("The same value returned (" + value + " + 10): ", value + 10, n.floatValue());
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPrimitiveReturnTypeDouble() throws Exception {
         PolyglotEngine.Value apply = findGlobalSymbol(applyNumbers());
@@ -776,6 +833,7 @@ public abstract class TruffleTCK {
         assertDouble("The same value returned (" + value + " + 10): ", value + 10, n.doubleValue());
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPrimitiveidentityByte() throws Exception {
         String id = identity();
@@ -790,6 +848,7 @@ public abstract class TruffleTCK {
         assertEquals("The same value returned", value, n.byteValue());
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPrimitiveidentityBoxedByte() throws Exception {
         String id = identity();
@@ -805,6 +864,7 @@ public abstract class TruffleTCK {
         assertEquals("The same value returned", value, n.byteValue());
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPrimitiveidentityShort() throws Exception {
         String id = identity();
@@ -818,6 +878,7 @@ public abstract class TruffleTCK {
         assertEquals("The same value returned", value, n.shortValue());
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPrimitiveidentityBoxedShort() throws Exception {
         String id = identity();
@@ -833,6 +894,7 @@ public abstract class TruffleTCK {
         assertEquals("The same value returned", value, n.shortValue());
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPrimitiveidentityInt() throws Exception {
         String id = identity();
@@ -847,6 +909,7 @@ public abstract class TruffleTCK {
         assertEquals("The same value returned", value, n.intValue());
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPrimitiveidentityBoxedInt() throws Exception {
         String id = identity();
@@ -862,6 +925,7 @@ public abstract class TruffleTCK {
         assertEquals("The same value returned", value, n.intValue());
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPrimitiveidentityLong() throws Exception {
         String id = identity();
@@ -876,6 +940,7 @@ public abstract class TruffleTCK {
         assertEquals("The same value returned", value, n.longValue());
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPrimitiveidentityBoxedLong() throws Exception {
         String id = identity();
@@ -891,6 +956,7 @@ public abstract class TruffleTCK {
         assertEquals("The same value returned", value, n.longValue());
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPrimitiveidentityFloat() throws Exception {
         String id = identity();
@@ -905,6 +971,7 @@ public abstract class TruffleTCK {
         assertDouble("The same value returned", value, n.floatValue());
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPrimitiveidentityBoxedFloat() throws Exception {
         String id = identity();
@@ -920,6 +987,7 @@ public abstract class TruffleTCK {
         assertDouble("The same value returned", value, n.floatValue());
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPrimitiveidentityDouble() throws Exception {
         String id = identity();
@@ -934,6 +1002,7 @@ public abstract class TruffleTCK {
         assertDouble("The same value returned", value, n.doubleValue());
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPrimitiveidentityBoxedDouble() throws Exception {
         String id = identity();
@@ -949,6 +1018,7 @@ public abstract class TruffleTCK {
         assertDouble("The same value returned", value, n.doubleValue());
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPrimitiveidentityString() throws Exception {
         String id = identity();
@@ -963,6 +1033,7 @@ public abstract class TruffleTCK {
         assertEquals("The same value returned", value, ret);
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPrimitiveidentityBoxedString() throws Exception {
         String id = identity();
@@ -978,6 +1049,7 @@ public abstract class TruffleTCK {
         assertEquals("The same value returned", value, ret);
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testPrimitiveIdentityForeignObject() throws Exception {
         String id = identity();
@@ -992,6 +1064,7 @@ public abstract class TruffleTCK {
         assertSameTruffleObject("The same value returned", fn, ret);
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testCoExistanceOfMultipleLanguageInstances() throws Exception {
         final String countMethod = countInvocations();
@@ -1025,6 +1098,7 @@ public abstract class TruffleTCK {
         }
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testGlobalObjectIsAccessible() throws Exception {
         String globalObjectFunction = globalObject();
@@ -1040,6 +1114,7 @@ public abstract class TruffleTCK {
         assertEquals("Global from the language same with Java obtained one", language.getGlobalObject().get(), global);
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testEvaluateSource() throws Exception {
         Language language = vm().getLanguages().get(mimeType());
@@ -1055,6 +1130,7 @@ public abstract class TruffleTCK {
         assertDouble("Gets the double", expect, value);
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void multiplyTwoVariables() throws Exception {
         final String firstVar = "var" + (char) ('A' + RANDOM.nextInt(24));
@@ -1068,6 +1144,7 @@ public abstract class TruffleTCK {
         assertEquals("Right value for " + firstVar + " and " + secondVar, 42, ((Number) result).intValue());
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testAddComplexNumbers() throws Exception {
         String id = complexAdd();
@@ -1085,6 +1162,7 @@ public abstract class TruffleTCK {
         assertEquals(42.0, a.get(ComplexNumber.IMAGINARY_IDENTIFIER), 0.1);
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testAddComplexNumbersWithMethod() throws Exception {
         String id = complexAddWithMethod();
@@ -1102,6 +1180,7 @@ public abstract class TruffleTCK {
         assertDouble("The same value returned", 42.0, a.get(ComplexNumber.IMAGINARY_IDENTIFIER));
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testSumRealOfComplexNumbersA() throws Exception {
         String id = complexSumReal();
@@ -1116,6 +1195,7 @@ public abstract class TruffleTCK {
         assertDouble("The same value returned", 42.0, n.doubleValue());
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testSumRealOfComplexNumbersB() throws Exception {
         String id = complexSumReal();
@@ -1130,6 +1210,7 @@ public abstract class TruffleTCK {
         assertDouble("The same value returned", 42.0, n.doubleValue());
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testSumRealOfComplexNumbersAsStructuredDataRowBased() throws Exception {
         String id = complexSumReal();
@@ -1147,6 +1228,7 @@ public abstract class TruffleTCK {
         assertDouble("The same value returned", 42.0, n.doubleValue());
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testSumRealOfComplexNumbersAsStructuredDataColumnBased() throws Exception {
         String id = complexSumReal();
@@ -1165,6 +1247,7 @@ public abstract class TruffleTCK {
         assertDouble("The same value returned", 42.0, n.doubleValue());
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testCopyComplexNumbersA() throws Exception {
         String id = complexCopy();
@@ -1181,6 +1264,7 @@ public abstract class TruffleTCK {
         Assert.assertArrayEquals(new double[]{41, 42, 43, 44, 45, 46}, a.getData(), 0.1);
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testCopyComplexNumbersB() throws Exception {
         String id = complexCopy();
@@ -1197,6 +1281,7 @@ public abstract class TruffleTCK {
         Assert.assertArrayEquals(new double[]{41, 42, 43, 44, 45, 46}, a.getData(), 0.1);
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void testCopyStructuredComplexToComplexNumbersA() throws Exception {
         String id = complexCopy();
@@ -1218,6 +1303,7 @@ public abstract class TruffleTCK {
         Assert.assertArrayEquals(new double[]{41, 42, 43, 44, 45, 46}, a.getData(), 0.1);
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void readWriteByteValue() throws Exception {
         String id = valuesObject();
@@ -1228,6 +1314,7 @@ public abstract class TruffleTCK {
         assertEquals("Correct value", value, values.byteValue());
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void readWriteShortValue() throws Exception {
         String id = valuesObject();
@@ -1238,6 +1325,7 @@ public abstract class TruffleTCK {
         assertEquals("Correct value", value, values.shortValue());
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void readWriteIntValue() throws Exception {
         String id = valuesObject();
@@ -1248,6 +1336,7 @@ public abstract class TruffleTCK {
         assertEquals("Correct value", value, values.intValue());
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void readWriteFloatValue() throws Exception {
         String id = valuesObject();
@@ -1258,6 +1347,7 @@ public abstract class TruffleTCK {
         assertDouble("Correct value", value, values.floatValue());
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void readWriteDoubleValue() throws Exception {
         String id = valuesObject();
@@ -1268,6 +1358,7 @@ public abstract class TruffleTCK {
         assertDouble("Correct value", value, values.doubleValue());
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void readWriteCharValue() throws Exception {
         String id = valuesObject();
@@ -1279,6 +1370,7 @@ public abstract class TruffleTCK {
         assertEquals("Correct value", value, values.charValue());
     }
 
+    /** @since 0.8 or earlier */
     @Test
     public void readWriteBooleanValue() throws Exception {
         String id = valuesObject();

--- a/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/REPLClient.java
+++ b/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/REPLClient.java
@@ -27,11 +27,15 @@ package com.oracle.truffle.tools.debug.shell;
 /**
  * The client side of a simple message-based protocol for a possibly remote language
  * Read-Eval-Print-Loop.
+ * 
+ * @since 0.8 or earlier
  */
 public interface REPLClient {
 
     /**
      * Accepts a reply from the server; there may be more than one reply in response to a request.
+     * 
+     * @since 0.8 or earlier
      */
     REPLMessage receive(REPLMessage reply);
 

--- a/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/REPLMessage.java
+++ b/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/REPLMessage.java
@@ -38,103 +38,194 @@ import com.oracle.truffle.tools.debug.shell.server.REPLServer;
  *
  * @see REPLClient
  * @see REPLServer
+ * @since 0.8 or earlier
  */
 public final class REPLMessage {
-
+    /** @since 0.8 or earlier */
     // Some standard keys and values
     public static final String AST = "ast";
+    /** @since 0.8 or earlier */
     public static final String AST_DEPTH = "show-max-depth";
+    /** @since 0.8 or earlier */
     public static final String BACKTRACE = "backtrace";
+    /** @since 0.8 or earlier */
     public static final String BREAK_AT_LINE = "break-at-line";
+    /** @since 0.8 or earlier */
     public static final String BREAK_AT_LINE_ONCE = "break-at-line-once";
+    /** @since 0.8 or earlier */
     @Deprecated public static final String BREAK_AT_THROW = "break-at-throw";
+    /** @since 0.8 or earlier */
     @Deprecated public static final String BREAK_AT_THROW_ONCE = "break-at-throw-once";
+    /** @since 0.8 or earlier */
     public static final String BREAKPOINT_CONDITION = "breakpoint-condition";
+    /** @since 0.8 or earlier */
     public static final String BREAKPOINT_HIT_COUNT = "breakpoint-hit-count";
+    /** @since 0.8 or earlier */
     public static final String BREAKPOINT_ID = "breakpoint-id";
+    /** @since 0.8 or earlier */
     public static final String BREAKPOINT_IGNORE_COUNT = "breakpoint-ignore-count";
+    /** @since 0.8 or earlier */
     public static final String BREAKPOINT_INFO = "breakpoint-info";
+    /** @since 0.8 or earlier */
     public static final String BREAKPOINT_STATE = "breakpoint-state";
+    /** @since 0.8 or earlier */
     public static final String CALL = "call";
+    /** @since 0.8 or earlier */
     public static final String ARG0 = "call-argument-0";
+    /** @since 0.8 or earlier */
     public static final String ARG1 = "call-argument-1";
+    /** @since 0.8 or earlier */
     public static final String ARG2 = "call-argument-2";
+    /** @since 0.8 or earlier */
     public static final String ARG3 = "call-argument-3";
+    /** @since 0.8 or earlier */
     public static final String ARG4 = "call-argument-4";
+    /** @since 0.8 or earlier */
     public static final String ARG5 = "call-argument-5";
+    /** @since 0.8 or earlier */
     public static final String ARG6 = "call-argument-6";
+    /** @since 0.8 or earlier */
     public static final String ARG7 = "call-argument-7";
+    /** @since 0.8 or earlier */
     public static final String ARG8 = "call-argument-8";
+    /** @since 0.8 or earlier */
     public static final String ARG9 = "call-argument-9";
+    /** @since 0.8 or earlier */
     public static final String CALL_NAME = "call-name";
+    /** @since 0.8 or earlier */
     public static final String CLEAR_BREAK = "clear-breakpoint";
+    /** @since 0.8 or earlier */
     public static final String CODE = "code";
+    /** @since 0.8 or earlier */
     public static final String CONTINUE = "continue";
+    /** @since 0.8 or earlier */
     public static final String DEBUG_LEVEL = "debug-level";
+    /** @since 0.8 or earlier */
     public static final String DELETE_BREAK = "delete-breakpoint";
+    /** @since 0.8 or earlier */
     public static final String DISABLE_BREAK = "disable-breakpoint";
+    /** @since 0.8 or earlier */
     public static final String DISPLAY_MSG = "displayable-message";
+    /** @since 0.8 or earlier */
     public static final String DOWN = "down";
+    /** @since 0.8 or earlier */
     public static final String ENABLE_BREAK = "enable-breakpoint";
+    /** @since 0.8 or earlier */
     public static final String EVAL = "eval";
+    /** @since 0.8 or earlier */
     public static final String FAILED = "failed";
+    /** @since 0.8 or earlier */
     public static final String FILE = "file";
+    /** @since 0.8 or earlier */
     public static final String FILE_PATH = "path";
+    /** @since 0.8 or earlier */
     public static final String FRAME = "frame";
+    /** @since 0.8 or earlier */
     public static final String FRAME_INFO = "frame-info";
+    /** @since 0.8 or earlier */
     public static final String FRAME_NUMBER = "frame-number";
+    /** @since 0.8 or earlier */
     public static final String INFO = "info";
+    /** @since 0.8 or earlier */
     public static final String INFO_CURRENT_LANGUAGE = "info-current-language";
+    /** @since 0.8 or earlier */
     public static final String INFO_KEY = "info-key";
+    /** @since 0.8 or earlier */
     public static final String INFO_SUPPORTED_LANGUAGES = "info-supported-languages";
+    /** @since 0.8 or earlier */
     public static final String INFO_VALUE = "info-value";
+    /** @since 0.8 or earlier */
     public static final String KILL = "kill";
+    /** @since 0.8 or earlier */
     public static final String LANG_NAME = "language-name";
+    /** @since 0.8 or earlier */
     public static final String LANG_VER = "language-version";
+    /** @since 0.8 or earlier */
     public static final String LANG_MIME = "language-MIME type";
+    /** @since 0.8 or earlier */
     public static final String LINE_NUMBER = "line-number";
+    /** @since 0.8 or earlier */
     public static final String LIST = "list";
+    /** @since 0.8 or earlier */
     public static final String LOAD_SOURCE = "load-source";
+    /** @since 0.8 or earlier */
     public static final String METHOD_NAME = "method-name";
+    /** @since 0.8 or earlier */
     public static final String OP = "op";
+    /** @since 0.8 or earlier */
     public static final String OPTION = "option";
+    /** @since 0.8 or earlier */
     public static final String QUIT = "quit";
+    /** @since 0.8 or earlier */
     public static final String REPEAT = "repeat";
+    /** @since 0.8 or earlier */
     public static final String SET = "set";
+    /** @since 0.8 or earlier */
     public static final String SET_BREAK_CONDITION = "set-breakpoint-condition";
+    /** @since 0.8 or earlier */
     public static final String SET_LANGUAGE = "set-language";
+    /** @since 0.8 or earlier */
     public static final String SLOT_ID = "slot-identifier";
+    /** @since 0.8 or earlier */
     public static final String SLOT_INDEX = "slot-index";
+    /** @since 0.8 or earlier */
     public static final String SLOT_VALUE = "slot-value";
+    /** @since 0.8 or earlier */
     public static final String SOURCE_LINE_TEXT = "source-line-text";
+    /** @since 0.8 or earlier */
     public static final String SOURCE_LOCATION = "source-location";
+    /** @since 0.8 or earlier */
     public static final String SOURCE_NAME = "source-name";
+    /** @since 0.8 or earlier */
     public static final String SOURCE_TEXT = "source-text";
+    /** @since 0.8 or earlier */
     public static final String STACK_SIZE = "stack-size";
+    /** @since 0.8 or earlier */
     public static final String STATUS = "status";
+    /** @since 0.8 or earlier */
     public static final String STEP_INTO = "step-into";
+    /** @since 0.8 or earlier */
     public static final String STEP_OUT = "step-out";
+    /** @since 0.8 or earlier */
     public static final String STEP_OVER = "step-over";
+    /** @since 0.8 or earlier */
     public static final String STOPPED = "stopped";
+    /** @since 0.8 or earlier */
     public static final String SUB = "sub";
+    /** @since 0.8 or earlier */
     public static final String SUBTREE = "subtree";
+    /** @since 0.8 or earlier */
     public static final String SUCCEEDED = "succeeded";
+    /** @since 0.8 or earlier */
     public static final String TOPIC = "topic";
+    /** @since 0.8 or earlier */
     public static final String TRUE = "true";
+    /** @since 0.8 or earlier */
     public static final String TRUFFLE = "truffle";
+    /** @since 0.8 or earlier */
     public static final String TRUFFLE_AST = "truffle-ast";
+    /** @since 0.8 or earlier */
     public static final String TRUFFLE_NODE = "truffle-node";
+    /** @since 0.8 or earlier */
     public static final String TRUFFLE_SUBTREE = "truffle-subtree";
+    /** @since 0.8 or earlier */
     public static final String UNSET_BREAK_CONDITION = "unset-breakpoint-condition";
+    /** @since 0.8 or earlier */
     public static final String UP = "up";
+    /** @since 0.8 or earlier */
     public static final String VALUE = "value";
+    /** @since 0.8 or earlier */
     public static final String WARNINGS = "warnings";
+    /** @since 0.8 or earlier */
     public static final String WELCOME_MESSAGE = "welcome-message";
+    /** @since 0.8 or earlier */
     public static final String[] ARG_NAMES = new String[]{ARG0, ARG1, ARG2, ARG3, ARG4, ARG5, ARG6, ARG7, ARG8, ARG9};
     private final Map<String, String> map;
 
     /**
      * Creates an empty REPL message.
+     * 
+     * @since 0.8 or earlier
      */
     public REPLMessage() {
         this.map = new TreeMap<>();
@@ -142,22 +233,28 @@ public final class REPLMessage {
 
     /**
      * Creates a REPL message with an initial entry.
+     * 
+     * @since 0.8 or earlier
      */
     public REPLMessage(String key, String value) {
         this();
         map.put(key, value);
     }
 
+    /** @since 0.8 or earlier */
     public REPLMessage(REPLMessage message) {
         this.map = new TreeMap<>(message.map);
     }
 
+    /** @since 0.8 or earlier */
     public String get(String key) {
         return map.get(key);
     }
 
     /**
      * Returns the specified key value as an integer; {@code null} if missing or non-numeric.
+     * 
+     * @since 0.8 or earlier
      */
     public Integer getIntValue(String key) {
         final String value = map.get(key);
@@ -171,18 +268,22 @@ public final class REPLMessage {
         return null;
     }
 
+    /** @since 0.8 or earlier */
     public String put(String key, String value) {
         return map.put(key, value);
     }
 
+    /** @since 0.8 or earlier */
     public String remove(String key) {
         return map.remove(key);
     }
 
+    /** @since 0.8 or earlier */
     public Set<String> keys() {
         return map.keySet();
     }
 
+    /** @since 0.8 or earlier */
     public void print(PrintStream out, String linePrefix) {
         map.keySet();
 


### PR DESCRIPTION
As an initial response to https://github.com/graalvm/truffle/issues/42 I am trying to get under control what is and isn't in the Truffle API. The rule is simple: "*Every element in the API needs to have Javadoc with @since tag*". The rule builds on following observations:
* Obviously having elements in the API without Javadoc is wrong
* with Javadoc being there, the additional requirement to add one more line `@since X.Y` is simple
* Developers are used to read Javadoc that contains `@since` tag - just like JDK does

We already have sigtest, but its biggest strength is in its binary compatibility check. It cannot verify presence of Javadoc and while it can be set to do exact API check, it has the drawback of keeping its info separate file(s) and not providing any of its information to developers reading Javadoc. As such I propose to use [slight modification](https://github.com/jtulach/codesnippet4javadoc/commit/6fcf07084b7056457a2e7bc545b9871d01187f3c) of our doclet to check that everything that is in the API is intended to be there.

This pull request is result of running [the tool](https://github.com/jtulach/codesnippet4javadoc/commit/6fcf07084b7056457a2e7bc545b9871d01187f3c) (via `mx javadoc --unified`) and doing additional manual changes (related mostly to default constructors). It assigns `@since 0.8 or earlier` to all elements. The consensus was that it doesn't make sense to go deeper into the history of the API than 0.8. After a quick poll the people around me have chosen the text `0.8 or earlier` as the best among `pre-0.8`, `<0.8`, `0.1-0.8`, `(0.1,0.8]` alternatives. Mostly because the part of the text before first space really represents a version.

I would prefer to merge the change as soon as possible, as the amount of changes is likely to contribute to higher probability of merge conflicts. In any case I plan to work on improvements - use `0.9`, `0.10`, `0.11` and `0.12` for elements introduced after 0.8 version.

Btw. The request to document every API element needlessly increases verbosity of the source code in once case: on default constructors. True, I had to add few of them manually. On the other hand I also discovered ~five errors where default constructors were left in the API and clearly that wasn't the intention.  By requiring `@since` tag being present we'll warn every Truffle API developers of this kind of errors - if that can make the Truffle API better at least in one case (and I am sure of that), I don't mind how much verbose our source code gets.

Please, review my diff and help me find places where [my automatic tool](https://github.com/jtulach/codesnippet4javadoc/commit/6fcf07084b7056457a2e7bc545b9871d01187f3c) made mistakes.