### PR TITLE
mx javadoc to verify @since tags

### DIFF
--- a/mx.truffle/mx_truffle.py
+++ b/mx.truffle/mx_truffle.py
@@ -35,6 +35,10 @@ import mx_gate
 
 _suite = mx.suite('truffle')
 
+def javadoc(args, vm=None):
+    """build the Javadoc for all API packages"""
+    mx.javadoc(['--unified'] + args)
+
 def build(args, vm=None):
     """build the Java sources"""
     opts2 = mx.build(['--source', '1.7'] + args)
@@ -61,6 +65,7 @@ def _truffle_gate_runner(args, tasks):
 mx_gate.add_gate_runner(_suite, _truffle_gate_runner)
 
 mx.update_commands(_suite, {
+    'javadoc' : [javadoc, '[SL args|@VM options]'],
     'sl' : [sl, '[SL args|@VM options]'],
     'sldebug' : [sldebug, '[SL args|@VM options]'],
 })

--- a/mx.truffle/suite.py
+++ b/mx.truffle/suite.py
@@ -1,5 +1,5 @@
 suite = {
-  "mxversion" : "5.8.0",
+  "mxversion" : "5.9.0",
   "name" : "truffle",
   "url" : "http://openjdk.java.net/projects/graal",
   "developer" : {


### PR DESCRIPTION
Turning on the `@since` tag check introduced in https://github.com/graalvm/mx/pull/62

By default generating the *unified* javadoc as that is what we want other contributors to check and it is hard to teach all of them that the most important version of Truffle javadoc requires some argument.