### PR TITLE
Restore old behavior in FrameInstance#getCallNode()

### DIFF
--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/StackTraceTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/StackTraceTest.java
@@ -76,9 +76,9 @@ public class StackTraceTest {
         assertInvariants(stack);
         Assert.assertEquals(2, stack.frames.size());
         Assert.assertSame(createStackTrace, stack.currentFrame.getCallTarget());
-        Assert.assertSame(findCallNode(call), stack.currentFrame.getCallNode());
+        Assert.assertNull(stack.currentFrame.getCallNode());
         Assert.assertSame(call, stack.callerFrame.getCallTarget());
-        Assert.assertNull(stack.callerFrame.getCallNode());
+        Assert.assertSame(findCallNode(call), stack.callerFrame.getCallNode());
     }
 
     @Test
@@ -89,9 +89,9 @@ public class StackTraceTest {
 
         Assert.assertEquals(2, stack.frames.size());
         Assert.assertSame(createStackTrace, stack.currentFrame.getCallTarget());
-        Assert.assertSame(findCallNode(call), stack.currentFrame.getCallNode());
+        Assert.assertNull(stack.currentFrame.getCallNode());
         Assert.assertSame(call, stack.callerFrame.getCallTarget());
-        Assert.assertNull(stack.callerFrame.getCallNode());
+        Assert.assertSame(findCallNode(call), stack.callerFrame.getCallNode());
         assertInvariants(stack);
     }
 
@@ -123,13 +123,13 @@ public class StackTraceTest {
         Assert.assertSame(createStackTrace, stack.currentFrame.getCallTarget());
         Assert.assertNull(stack.currentFrame.getCallNode());
         Assert.assertSame(callTarget, stack.callerFrame.getCallTarget());
-        Assert.assertSame(findCallNode(indirect), stack.callerFrame.getCallNode());
+        Assert.assertNull(stack.callerFrame.getCallNode());
 
         Assert.assertSame(indirect, stack.frames.get(2).getCallTarget());
-        Assert.assertSame(findCallNode(direct), stack.frames.get(2).getCallNode());
+        Assert.assertSame(findCallNode(indirect), stack.frames.get(2).getCallNode());
 
         Assert.assertSame(direct, stack.frames.get(3).getCallTarget());
-        Assert.assertNull(stack.frames.get(3).getCallNode());
+        Assert.assertSame(findCallNode(direct), stack.frames.get(3).getCallNode());
     }
 
     @Test
@@ -230,13 +230,13 @@ public class StackTraceTest {
                             Assert.assertSame(createStackTrace, stack.currentFrame.getCallTarget());
                             Assert.assertNull(stack.currentFrame.getCallNode());
                             Assert.assertSame(callTarget, stack.callerFrame.getCallTarget());
-                            Assert.assertSame(findCallNode(indirect), stack.callerFrame.getCallNode());
+                            Assert.assertNull(stack.callerFrame.getCallNode());
 
                             Assert.assertSame(indirect, stack.frames.get(2).getCallTarget());
-                            Assert.assertSame(findCallNode(direct), stack.frames.get(2).getCallNode());
+                            Assert.assertSame(findCallNode(indirect), stack.frames.get(2).getCallNode());
 
                             Assert.assertSame(direct, stack.frames.get(3).getCallTarget());
-                            Assert.assertNull(stack.frames.get(3).getCallNode());
+                            Assert.assertSame(findCallNode(direct), stack.frames.get(3).getCallNode());
                         }
                         return null;
                     }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/FrameInstance.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/FrameInstance.java
@@ -25,6 +25,7 @@
 package com.oracle.truffle.api.frame;
 
 import com.oracle.truffle.api.CallTarget;
+import com.oracle.truffle.api.TruffleRuntime;
 import com.oracle.truffle.api.nodes.Node;
 
 /** @since 0.8 or earlier */
@@ -47,9 +48,18 @@ public interface FrameInstance {
     /** @since 0.8 or earlier */
     boolean isVirtualFrame();
 
-    /** @since 0.8 or earlier */
+    /**
+     * @return the node that is calling the next {@link CallTarget target} or <code>null</code> if
+     *         its the topmost frame or the next {@link CallTarget target} was called without a
+     *         {@link TruffleRuntime#createDirectCallNode(CallTarget)} or
+     *         {@link TruffleRuntime#createIndirectCallNode() indirect} call node.
+     * @since 0.8 or earlier
+     **/
     Node getCallNode();
 
-    /** @since 0.8 or earlier */
+    /**
+     * @return the {@link CallTarget target} that created this frame instance by executing it.
+     * @since 0.8 or earlier
+     **/
     CallTarget getCallTarget();
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/FrameInstance.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/FrameInstance.java
@@ -28,7 +28,29 @@ import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.TruffleRuntime;
 import com.oracle.truffle.api.nodes.Node;
 
-/** @since 0.8 or earlier */
+/**
+ *
+ *
+ * <pre>
+ *                     ===============
+ * {@link TruffleRuntime#getCurrentFrame() getCurrentFrame()}: |  CallTarget   | FrameInstance
+ *                     ===============
+ * {@link TruffleRuntime#getCallerFrame() getCallerFrame()}:  |  CallNode     | FrameInstance
+ *                    |  CallTarget   |
+ *                     ===============
+ *                    |  CallNode     | FrameInstance
+ *                    |  CallTarget   |
+ *                     ===============
+ *                          ...
+ *                     ===============
+ *                    |  CallNode     | FrameInstance
+ *Initial call:       |  CallTarget   |
+ *                     ===============
+ *
+ * </pre>
+ *
+ * @since 0.8 or earlier
+ */
 public interface FrameInstance {
     /** @since 0.8 or earlier */
     enum FrameAccess {
@@ -49,10 +71,33 @@ public interface FrameInstance {
     boolean isVirtualFrame();
 
     /**
-     * @return the node that is calling the next {@link CallTarget target} or <code>null</code> if
-     *         its the topmost frame or the next {@link CallTarget target} was called without a
-     *         {@link TruffleRuntime#createDirectCallNode(CallTarget)} or
-     *         {@link TruffleRuntime#createIndirectCallNode() indirect} call node.
+     * Returns a node representing the callsite of the next new target on the stack.
+     *
+     * This picture indicates how {@link FrameInstance} groups the stack.
+     *
+     * <pre>
+     *                     ===============
+     * {@link TruffleRuntime#getCurrentFrame() Current}:         ,>|  CallTarget   | FrameInstance
+     *                  | ===============
+     * {@link TruffleRuntime#getCallerFrame() Caller}:          '-|  CallNode     | FrameInstance
+     *                  ,>|  CallTarget   |
+     *                  |  ===============
+     *                  '-|  CallNode     | FrameInstance
+     *                    |  CallTarget   |
+     *                     ===============
+     *                          ...
+     *                     ===============
+     *                    |  CallNode     | FrameInstance
+     *Initial call:       |  CallTarget   |
+     *                     ===============
+     *
+     * </pre>
+     *
+     * @return a node representing the callsite of the next new target on the stack. Null in case
+     *         there is no upper target or if the target was not invoked using a
+     *         {@link TruffleRuntime#createDirectCallNode(CallTarget) direct} or
+     *         {@link TruffleRuntime#createDirectCallNode(CallTarget) indirect} call node.
+     *
      * @since 0.8 or earlier
      **/
     Node getCallNode();

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/FrameInstance.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/FrameInstance.java
@@ -29,26 +29,6 @@ import com.oracle.truffle.api.TruffleRuntime;
 import com.oracle.truffle.api.nodes.Node;
 
 /**
- *
- *
- * <pre>
- *                     ===============
- * {@link TruffleRuntime#getCurrentFrame() getCurrentFrame()}: |  CallTarget   | FrameInstance
- *                     ===============
- * {@link TruffleRuntime#getCallerFrame() getCallerFrame()}:  |  CallNode     | FrameInstance
- *                    |  CallTarget   |
- *                     ===============
- *                    |  CallNode     | FrameInstance
- *                    |  CallTarget   |
- *                     ===============
- *                          ...
- *                     ===============
- *                    |  CallNode     | FrameInstance
- *Initial call:       |  CallTarget   |
- *                     ===============
- *
- * </pre>
- *
  * @since 0.8 or earlier
  */
 public interface FrameInstance {
@@ -76,20 +56,20 @@ public interface FrameInstance {
      * This picture indicates how {@link FrameInstance} groups the stack.
      *
      * <pre>
-     *                     ===============
-     * {@link TruffleRuntime#getCurrentFrame() Current}:         ,>|  CallTarget   | FrameInstance
-     *                  | ===============
-     * {@link TruffleRuntime#getCallerFrame() Caller}:          '-|  CallNode     | FrameInstance
-     *                  ,>|  CallTarget   |
-     *                  |  ===============
-     *                  '-|  CallNode     | FrameInstance
-     *                    |  CallTarget   |
-     *                     ===============
-     *                          ...
-     *                     ===============
-     *                    |  CallNode     | FrameInstance
-     *Initial call:       |  CallTarget   |
-     *                     ===============
+     *                      ===============
+     *  {@link TruffleRuntime#getCurrentFrame() Current}:         ,>|  CallTarget   | FrameInstance
+     *                   |  ===============
+     *  {@link TruffleRuntime#getCallerFrame() Caller}:          '-|  CallNode     | FrameInstance
+     *                   ,>|  CallTarget   |
+     *                   |  ===============
+     *                   '-|  CallNode     | FrameInstance
+     *                     |  CallTarget   |
+     *                      ===============
+     *                           ...
+     *                      ===============
+     *                     |  CallNode     | FrameInstance
+     * Initial call:       |  CallTarget   |
+     *                      ===============
      *
      * </pre>
      *

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/FrameInstance.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/frame/FrameInstance.java
@@ -103,7 +103,6 @@ public interface FrameInstance {
     Node getCallNode();
 
     /**
-     * @return the {@link CallTarget target} that created this frame instance by executing it.
      * @since 0.8 or earlier
      **/
     CallTarget getCallTarget();

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/DefaultCallTarget.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/DefaultCallTarget.java
@@ -24,13 +24,9 @@
  */
 package com.oracle.truffle.api.impl;
 
-import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.TruffleRuntime;
-import com.oracle.truffle.api.frame.Frame;
-import com.oracle.truffle.api.frame.FrameInstance;
-import com.oracle.truffle.api.frame.VirtualFrame;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.RootNode;
 
@@ -63,7 +59,7 @@ public final class DefaultCallTarget implements RootCallTarget {
             initialize();
         }
         final DefaultVirtualFrame frame = new DefaultVirtualFrame(getRootNode().getFrameDescriptor(), args);
-        getRuntime().pushFrame(new CallNodeFrameInstance(this, frame, callNode));
+        getRuntime().pushFrame(frame, this, callNode);
         try {
             return getRootNode().execute(frame);
         } finally {
@@ -77,7 +73,7 @@ public final class DefaultCallTarget implements RootCallTarget {
             initialize();
         }
         final DefaultVirtualFrame frame = new DefaultVirtualFrame(getRootNode().getFrameDescriptor(), args);
-        getRuntime().pushFrame(new CallTargetFrameInstance(this, frame));
+        getRuntime().pushFrame(frame, this);
         try {
             return getRootNode().execute(frame);
         } finally {
@@ -87,63 +83,6 @@ public final class DefaultCallTarget implements RootCallTarget {
 
     private static DefaultTruffleRuntime getRuntime() {
         return (DefaultTruffleRuntime) Truffle.getRuntime();
-    }
-
-    private abstract static class DefaultFrameInstance implements FrameInstance {
-
-        private final CallTarget target;
-        private final VirtualFrame frame;
-
-        DefaultFrameInstance(CallTarget target, VirtualFrame frame) {
-            this.target = target;
-            this.frame = frame;
-        }
-
-        public final Frame getFrame(FrameAccess access, boolean slowPath) {
-            if (access == FrameAccess.NONE) {
-                return null;
-            }
-            if (access == FrameAccess.MATERIALIZE) {
-                return frame.materialize();
-            }
-            return frame;
-        }
-
-        public final boolean isVirtualFrame() {
-            return false;
-        }
-
-        public final CallTarget getCallTarget() {
-            return target;
-        }
-
-    }
-
-    private static class CallTargetFrameInstance extends DefaultFrameInstance {
-
-        CallTargetFrameInstance(CallTarget target, VirtualFrame frame) {
-            super(target, frame);
-        }
-
-        public Node getCallNode() {
-            return null;
-        }
-
-    }
-
-    private static class CallNodeFrameInstance extends DefaultFrameInstance {
-
-        private final Node callNode;
-
-        CallNodeFrameInstance(CallTarget target, VirtualFrame frame, Node callNode) {
-            super(target, frame);
-            this.callNode = callNode;
-        }
-
-        public Node getCallNode() {
-            return callNode;
-        }
-
     }
 
     private void initialize() {

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/DefaultTruffleRuntime.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/DefaultTruffleRuntime.java
@@ -24,12 +24,19 @@
  */
 package com.oracle.truffle.api.impl;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.WeakHashMap;
+
 import com.oracle.truffle.api.Assumption;
 import com.oracle.truffle.api.CallTarget;
 import com.oracle.truffle.api.CompilerOptions;
 import com.oracle.truffle.api.RootCallTarget;
 import com.oracle.truffle.api.Truffle;
 import com.oracle.truffle.api.TruffleRuntime;
+import com.oracle.truffle.api.frame.Frame;
 import com.oracle.truffle.api.frame.FrameDescriptor;
 import com.oracle.truffle.api.frame.FrameInstance;
 import com.oracle.truffle.api.frame.FrameInstanceVisitor;
@@ -41,11 +48,6 @@ import com.oracle.truffle.api.nodes.LoopNode;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.RepeatingNode;
 import com.oracle.truffle.api.nodes.RootNode;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.Map;
-import java.util.WeakHashMap;
 
 /**
  * Default implementation of the Truffle runtime if the virtual machine does not provide a better
@@ -156,12 +158,30 @@ public final class DefaultTruffleRuntime implements TruffleRuntime {
         return result;
     }
 
-    void pushFrame(FrameInstance frame) {
-        getThreadLocalStackTrace().addFirst(frame);
+    void pushFrame(VirtualFrame frame, CallTarget target) {
+        LinkedList<FrameInstance> threadLocalStackTrace = getThreadLocalStackTrace();
+        threadLocalStackTrace.addFirst(new DefaultFrameInstance(frame, target, null));
+    }
+
+    void pushFrame(VirtualFrame frame, CallTarget target, Node parentCallNode) {
+        LinkedList<FrameInstance> threadLocalStackTrace = getThreadLocalStackTrace();
+        // we need to ensure that frame instances are immutable to we need to recreate the parent
+        // frame
+        if (threadLocalStackTrace.size() > 0) {
+            DefaultFrameInstance oldInstance = (DefaultFrameInstance) threadLocalStackTrace.removeFirst();
+            threadLocalStackTrace.addFirst(new DefaultFrameInstance(oldInstance.getFrame(), oldInstance.getCallTarget(), parentCallNode));
+        }
+        threadLocalStackTrace.addFirst(new DefaultFrameInstance(frame, target, null));
     }
 
     void popFrame() {
-        getThreadLocalStackTrace().removeFirst();
+        LinkedList<FrameInstance> threadLocalStackTrace = getThreadLocalStackTrace();
+        threadLocalStackTrace.removeFirst();
+
+        if (threadLocalStackTrace.size() > 0) {
+            DefaultFrameInstance parent = (DefaultFrameInstance) threadLocalStackTrace.removeFirst();
+            threadLocalStackTrace.addFirst(new DefaultFrameInstance(parent.getFrame(), parent.getCallTarget(), null));
+        }
     }
 
     public <T> T getCapability(Class<T> capability) {
@@ -180,5 +200,45 @@ public final class DefaultTruffleRuntime implements TruffleRuntime {
 
     public boolean isProfilingEnabled() {
         return false;
+    }
+
+    private static class DefaultFrameInstance implements FrameInstance {
+
+        private final CallTarget target;
+        private final VirtualFrame frame;
+        private final Node callNode;
+
+        DefaultFrameInstance(VirtualFrame frame, CallTarget target, Node callNode) {
+            this.target = target;
+            this.frame = frame;
+            this.callNode = callNode;
+        }
+
+        public final Frame getFrame(FrameAccess access, boolean slowPath) {
+            if (access == FrameAccess.NONE) {
+                return null;
+            }
+            if (access == FrameAccess.MATERIALIZE) {
+                return frame.materialize();
+            }
+            return frame;
+        }
+
+        final VirtualFrame getFrame() {
+            return frame;
+        }
+
+        public final boolean isVirtualFrame() {
+            return false;
+        }
+
+        public final CallTarget getCallTarget() {
+            return target;
+        }
+
+        public Node getCallNode() {
+            return callNode;
+        }
+
     }
 }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/DefaultTruffleRuntime.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/DefaultTruffleRuntime.java
@@ -165,7 +165,7 @@ public final class DefaultTruffleRuntime implements TruffleRuntime {
 
     void pushFrame(VirtualFrame frame, CallTarget target, Node parentCallNode) {
         LinkedList<FrameInstance> threadLocalStackTrace = getThreadLocalStackTrace();
-        // we need to ensure that frame instances are immutable to we need to recreate the parent
+        // we need to ensure that frame instances are immutable so we need to recreate the parent
         // frame
         if (threadLocalStackTrace.size() > 0) {
             DefaultFrameInstance oldInstance = (DefaultFrameInstance) threadLocalStackTrace.removeFirst();


### PR DESCRIPTION
@chrisseaton  please verify that the behavior is now fixed in ruby.