### PR TITLE
Test downstream users (JRuby to start with) of Truffle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,7 @@ env:
   - TEST_COMMAND='mx/mx canonicalizeprojects'
   - TEST_COMMAND='mx/mx checkstyle'
   - TEST_COMMAND='sh .travis.sigtest.sh'
+  - TEST_COMMAND='mx/mx testdownstream'
+matrix:
+  allow_failures:
+    - env: TEST_COMMAND='mx/mx testdownstream'

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,3 @@ env:
   - TEST_COMMAND='mx/mx canonicalizeprojects'
   - TEST_COMMAND='mx/mx checkstyle'
   - TEST_COMMAND='sh .travis.sigtest.sh'
-  
-
-

--- a/mx.truffle/mx_truffle.py
+++ b/mx.truffle/mx_truffle.py
@@ -26,6 +26,9 @@
 #
 # ----------------------------------------------------------------------------------------------------
 
+import os
+import subprocess
+
 import mx
 
 from mx_unittest import unittest
@@ -54,6 +57,26 @@ def sldebug(args):
     vmArgs, slArgs = mx.extract_VM_args(args, useDoubleDash=True)
     mx.run_java(vmArgs + ['-cp', mx.classpath("com.oracle.truffle.sl.tools"), "com.oracle.truffle.sl.tools.debug.SLREPL"] + slArgs)
 
+def testdownstream(args):
+    """test downstream users of the Truffle API"""
+    jruby_dir = 'jruby'
+    jruby_repo = 'https://github.com/jruby/jruby.git'
+    jruby_branch = 'truffle-head'
+    git = mx.GitConfig()
+    if os.path.exists('jruby'):
+        git.run(['git', 'reset', 'HEAD', '--hard'], nonZeroIsFatal=True, cwd=jruby_dir)
+        git.pull('jruby')
+    else:
+        git.clone(jruby_repo, jruby_dir)
+        git.run(['git', 'checkout', jruby_branch], nonZeroIsFatal=True, cwd=jruby_dir)
+    dev_version = _suite.release_version(snapshotSuffix='SNAPSHOT')
+    subprocess.check_call(['tool/truffle/set_truffle_version.sh', dev_version], cwd=jruby_dir)
+    mx.build([])
+    mx.maven_install([])
+    subprocess.check_call(['./mvnw', 'clean'], cwd=jruby_dir)
+    subprocess.check_call(['./mvnw'], cwd=jruby_dir)
+    subprocess.check_call(['bin/jruby', 'tool/jt.rb', 'test', 'fast'], cwd=jruby_dir)
+
 def _truffle_gate_runner(args, tasks):
     with Task('Truffle Javadoc', tasks) as t:
         if t: mx.javadoc(['--unified'])
@@ -68,4 +91,5 @@ mx.update_commands(_suite, {
     'javadoc' : [javadoc, '[SL args|@VM options]'],
     'sl' : [sl, '[SL args|@VM options]'],
     'sldebug' : [sldebug, '[SL args|@VM options]'],
+    'testdownstream' : [testdownstream, ''],
 })


### PR DESCRIPTION
This adds a new command `mx testdownstream` and runs that on Travis as an allowed-failure (it doesn't fail the overall commit if it fails, but you still see the result). Only JRuby so far, and runs 64k of JRuby's fastest tests so it only takes a couple of minutes.

This allows you to see if your changes are immediately compatible with JRuby. For example it would have caught the problems with the `iterateFrames` changes.

Potential problems are if the JRuby build is broken anyway (it very rarely is, but sometimes), or if people ignore it because it's allowed-failure.

@mickjordan am I using mx correctly here?