### PR TITLE
Ignore dists/truffle-mx.jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ workingsets.xml
 findbugs.results
 .metadata/
 /eclipseformat.backup.zip
+dists/truffle-mx.jar


### PR DESCRIPTION
This file is created by `mx maven-install`. I frequently have git confused by its presence.