### PR TITLE
Debugger NPE patch

### DIFF
--- a/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/Debugger.java
+++ b/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/Debugger.java
@@ -62,7 +62,7 @@ import com.oracle.truffle.api.vm.PolyglotEngine;
  * Instance of this class is delivered via {@link SuspendedEvent#getDebugger()} and
  * {@link ExecutionEvent#getDebugger()} events, once {@link com.oracle.truffle.api.debug debugging
  * is turned on}.
- * 
+ *
  * @since 0.9
  */
 public final class Debugger {
@@ -71,7 +71,7 @@ public final class Debugger {
      * A {@link SourceSection#withTags(java.lang.String...) tag} used to mark program locations
      * where ordinary stepping should halt. The debugger will halt just <em>before</em> a code
      * location is executed that is marked with this tag.
-     * 
+     *
      * @since 0.9
      */
     public static final String HALT_TAG = "debug-HALT";
@@ -232,7 +232,7 @@ public final class Debugger {
     /**
      * Gets all existing breakpoints, whatever their status, in natural sorted order. Modification
      * save.
-     * 
+     *
      * @since 0.9
      */
     @TruffleBoundary
@@ -957,15 +957,9 @@ public final class Debugger {
                     if (stackIndex < contextStackDepth) {
                         final Node callNode = frameInstance.getCallNode();
                         if (callNode != null) {
-                            final SourceSection sourceSection = callNode.getEncapsulatingSourceSection();
-                            if (sourceSection != null && !sourceSection.getIdentifier().equals("<unknown>")) {
-                                frames.add(frameInstance);
-                            } else if (TRACE) {
-                                contextTrace("HIDDEN frame added: " + callNode);
-                                frames.add(frameInstance);
-                            }
+                            frames.add(frameInstance);
                         } else if (TRACE) {
-                            contextTrace("HIDDEN frame added");
+                            contextTrace("including frame %d with no callNode: %s", stackIndex, frameInstance.getFrame(FrameAccess.READ_ONLY, true));
                             frames.add(frameInstance);
                         }
                         stackIndex++;

--- a/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/Debugger.java
+++ b/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/Debugger.java
@@ -955,13 +955,10 @@ public final class Debugger {
                 @Override
                 public FrameInstance visitFrame(FrameInstance frameInstance) {
                     if (stackIndex < contextStackDepth) {
-                        final Node callNode = frameInstance.getCallNode();
-                        if (callNode != null) {
-                            frames.add(frameInstance);
-                        } else if (TRACE) {
+                        if (TRACE && frameInstance.getCallNode() != null) {
                             contextTrace("including frame %d with no callNode: %s", stackIndex, frameInstance.getFrame(FrameAccess.READ_ONLY, true));
-                            frames.add(frameInstance);
                         }
+                        frames.add(frameInstance);
                         stackIndex++;
                         return null;
                     }

--- a/truffle/com.oracle.truffle.sl.tools/src/com/oracle/truffle/sl/tools/debug/SLREPL.java
+++ b/truffle/com.oracle.truffle.sl.tools/src/com/oracle/truffle/sl/tools/debug/SLREPL.java
@@ -49,6 +49,8 @@ public final class SLREPL {
 
     public static void main(String[] args) {
 
+        System.setProperty("truffle.debug.trace", "false");
+        System.setProperty("truffle.instrumentation.trace", "false");
         final REPLServer server = new REPLServer("application/x-sl");
         server.start();
     }

--- a/truffle/com.oracle.truffle.sl.tools/src/com/oracle/truffle/sl/tools/debug/SLREPL.java
+++ b/truffle/com.oracle.truffle.sl.tools/src/com/oracle/truffle/sl/tools/debug/SLREPL.java
@@ -49,8 +49,6 @@ public final class SLREPL {
 
     public static void main(String[] args) {
 
-        System.setProperty("truffle.debug.trace", "false");
-        System.setProperty("truffle.instrumentation.trace", "false");
         final REPLServer server = new REPLServer("application/x-sl");
         server.start();
     }

--- a/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/server/InstrumentationUtils.java
+++ b/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/server/InstrumentationUtils.java
@@ -255,7 +255,7 @@ final class InstrumentationUtils {
                 estimated = true;
             }
             if (section == null) {
-                return "<error: source location>";
+                return "<unknown source location>";
             }
             return section.getShortDescription() + (estimated ? "~" : "");
         }


### PR DESCRIPTION
Remove an ad hoc mechanism for hiding selected frames in stack tracing that also contained an NPE vulnerability (which @mickjordan reported hitting in FastR).