### PR TITLE
Fix double-checked locking patterns

### DIFF
--- a/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/InstrumentationHandler.java
+++ b/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/InstrumentationHandler.java
@@ -72,7 +72,7 @@ final class InstrumentationHandler {
      */
     private final Map<Object, AbstractInstrumenter> instrumentations = new HashMap<>();
 
-    private boolean initialized;
+    private volatile boolean initialized;
 
     private final OutputStream out;
     private final OutputStream err;
@@ -216,7 +216,6 @@ final class InstrumentationHandler {
     private void initialize() {
         synchronized (this) {
             if (!initialized) {
-                initialized = true;
                 if (TRACE) {
                     trace("Initialize instrumentation%n");
                 }
@@ -226,6 +225,7 @@ final class InstrumentationHandler {
                 if (TRACE) {
                     trace("Initialized instrumentation%n");
                 }
+                initialized = true;
             }
         }
     }

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/DefaultCallTarget.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/DefaultCallTarget.java
@@ -37,7 +37,7 @@ import com.oracle.truffle.api.nodes.RootNode;
 public final class DefaultCallTarget implements RootCallTarget {
 
     private final RootNode rootNode;
-    private boolean initialized;
+    private volatile boolean initialized;
 
     DefaultCallTarget(RootNode function) {
         this.rootNode = function;
@@ -88,11 +88,11 @@ public final class DefaultCallTarget implements RootCallTarget {
     private void initialize() {
         synchronized (this) {
             if (!this.initialized) {
-                this.initialized = true;
                 Accessor accessor = Accessor.INSTRUMENTHANDLER;
                 if (accessor != null) {
                     accessor.initializeCallTarget(this);
                 }
+                this.initialized = true;
             }
         }
     }


### PR DESCRIPTION
* Only publish the DefaultCallTarget as initialized when it is.
* Only publish the InstrumentationHandler as initialized when it is.
* `intialized` needs to be volatile or the store to it might move above the actual initialization (compiler or CPU reordering).