### PR TITLE
Debugging support:  TruffleLanguage.evalInContext() reports when unsupported

### DIFF
--- a/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/Debugger.java
+++ b/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/Debugger.java
@@ -62,7 +62,7 @@ import com.oracle.truffle.api.vm.PolyglotEngine;
  * Instance of this class is delivered via {@link SuspendedEvent#getDebugger()} and
  * {@link ExecutionEvent#getDebugger()} events, once {@link com.oracle.truffle.api.debug debugging
  * is turned on}.
- * 
+ *
  * @since 0.9
  */
 public final class Debugger {
@@ -71,7 +71,7 @@ public final class Debugger {
      * A {@link SourceSection#withTags(java.lang.String...) tag} used to mark program locations
      * where ordinary stepping should halt. The debugger will halt just <em>before</em> a code
      * location is executed that is marked with this tag.
-     * 
+     *
      * @since 0.9
      */
     public static final String HALT_TAG = "debug-HALT";
@@ -232,7 +232,7 @@ public final class Debugger {
     /**
      * Gets all existing breakpoints, whatever their status, in natural sorted order. Modification
      * save.
-     * 
+     *
      * @since 0.9
      */
     @TruffleBoundary
@@ -1067,11 +1067,12 @@ public final class Debugger {
     /**
      * Evaluates a snippet of code in a halted execution context.
      *
-     * @param ev
-     * @param code
-     * @param frameInstance
-     * @return
-     * @throws IOException
+     * @param ev description of the halted execution context
+     * @param code the code to be evaluated in the context
+     * @param frameInstance frame in the context
+     * @return any result provided by the language evaluation
+     * @throws IOException if the evaluation fails
+     * @throws UnsupportedOperationException if not supported by the language implementation
      */
     Object evalInContext(SuspendedEvent ev, String code, FrameInstance frameInstance) throws IOException {
         if (frameInstance == null) {

--- a/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/SuspendedEvent.java
+++ b/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/SuspendedEvent.java
@@ -44,7 +44,7 @@ import com.oracle.truffle.api.nodes.Node;
  * used while the handlers process the event. Then the state of the event becomes invalid and
  * subsequent calls to the event methods yield {@link IllegalStateException}. One can call
  * {@link #getDebugger()} and keep reference to it for as long as necessary.
- * 
+ *
  * @since 0.9
  */
 @SuppressWarnings("javadoc")
@@ -129,7 +129,7 @@ public final class SuspendedEvent {
      * <li>execution completes.</li>
      * </ol>
      * </ul>
-     * 
+     *
      * @since 0.9
      */
     public void prepareContinue() {
@@ -172,7 +172,7 @@ public final class SuspendedEvent {
      * <li>StepOut mode persists only through one resumption, and reverts by default to Continue
      * mode.</li>
      * </ul>
-     * 
+     *
      * @since 0.9
      */
     public void prepareStepOut() {
@@ -211,6 +211,7 @@ public final class SuspendedEvent {
      *            location.
      * @return the computed value
      * @throws IOException in case an evaluation goes wrong
+     * @throws UnsupportedOperationException if not supported by the language implementation
      * @since 0.9
      */
     public Object eval(String code, FrameInstance frame) throws IOException {

--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/TestingLanguage.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/TestingLanguage.java
@@ -77,7 +77,7 @@ public final class TestingLanguage extends TruffleLanguage<Object> {
 
     @Override
     protected Object evalInContext(Source source, Node node, MaterializedFrame mFrame) throws IOException {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/processor/LanguageRegistrationTest.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/processor/LanguageRegistrationTest.java
@@ -95,7 +95,7 @@ public class LanguageRegistrationTest {
 
         @Override
         protected Object evalInContext(Source source, Node node, MaterializedFrame mFrame) throws IOException {
-            return null;
+            throw new UnsupportedOperationException();
         }
 
         @Override
@@ -150,7 +150,7 @@ public class LanguageRegistrationTest {
 
         @Override
         protected Object evalInContext(Source source, Node node, MaterializedFrame mFrame) throws IOException {
-            return null;
+            throw new UnsupportedOperationException();
         }
 
         @Override
@@ -201,7 +201,7 @@ public class LanguageRegistrationTest {
 
         @Override
         protected Object evalInContext(Source source, Node node, MaterializedFrame mFrame) throws IOException {
-            return null;
+            throw new UnsupportedOperationException();
         }
 
         @Override

--- a/truffle/com.oracle.truffle.api.instrumentation.test/src/com/oracle/truffle/api/instrumentation/InstrumentationTest.java
+++ b/truffle/com.oracle.truffle.api.instrumentation.test/src/com/oracle/truffle/api/instrumentation/InstrumentationTest.java
@@ -269,7 +269,7 @@ public class InstrumentationTest extends AbstractInstrumentationTest {
 
         @Override
         protected Object evalInContext(Source source, Node node, MaterializedFrame mFrame) throws IOException {
-            return null;
+            throw new UnsupportedOperationException();
         }
 
     }

--- a/truffle/com.oracle.truffle.api.instrumentation.test/src/com/oracle/truffle/api/instrumentation/InstrumentationTestLanguage.java
+++ b/truffle/com.oracle.truffle.api.instrumentation.test/src/com/oracle/truffle/api/instrumentation/InstrumentationTestLanguage.java
@@ -445,7 +445,7 @@ public class InstrumentationTestLanguage extends TruffleLanguage<Map<String, Cal
 
     @Override
     protected Object evalInContext(Source source, Node node, MaterializedFrame mFrame) throws IOException {
-        return null;
+        throw new UnsupportedOperationException("InstrumentationTestLanguage does not support eval()");
     }
 
     @Override

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/TestingLanguage.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/TestingLanguage.java
@@ -74,7 +74,7 @@ public final class TestingLanguage extends TruffleLanguage<Object> {
 
     @Override
     protected Object evalInContext(Source source, Node node, MaterializedFrame mFrame) throws IOException {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/instrument/InstrumentationTestingLanguage.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/instrument/InstrumentationTestingLanguage.java
@@ -140,7 +140,7 @@ public final class InstrumentationTestingLanguage extends TruffleLanguage<Object
 
     @Override
     protected Object evalInContext(Source source, Node node, MaterializedFrame mFrame) throws IOException {
-        return null;
+        throw new UnsupportedOperationException("InstrumentationTestingLanguage does not support eval()");
     }
 
     @Override

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/ImplicitExplicitExportTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/ImplicitExplicitExportTest.java
@@ -213,7 +213,7 @@ public class ImplicitExplicitExportTest {
 
         @Override
         protected Object evalInContext(Source source, Node node, MaterializedFrame mFrame) throws IOException {
-            return null;
+            throw new UnsupportedOperationException();
         }
 
         private Object importExport(Source code) {

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
@@ -45,6 +45,7 @@ import com.oracle.truffle.api.instrument.WrapperNode;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.source.Source;
+
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -72,7 +73,7 @@ import java.util.Set;
 public abstract class TruffleLanguage<C> {
     /**
      * Constructor to be called by subclasses.
-     * 
+     *
      * @since 0.8 or earlier
      */
     protected TruffleLanguage() {
@@ -85,7 +86,7 @@ public abstract class TruffleLanguage<C> {
      * <em>one JAR drop to the class path</em> away from your users. Once they include your JAR in
      * their application, your language will be available to the
      * {@link com.oracle.truffle.api.vm.PolyglotEngine Truffle virtual machine}.
-     * 
+     *
      * @since 0.8 or earlier
      */
     @Retention(RetentionPolicy.SOURCE)
@@ -237,7 +238,7 @@ public abstract class TruffleLanguage<C> {
 
     /**
      * Gets visualization services for language-specific information.
-     * 
+     *
      * @since 0.8 or earlier
      */
     @Deprecated
@@ -250,7 +251,7 @@ public abstract class TruffleLanguage<C> {
      * {@linkplain Instrumenter#probe(Node) probing}.
      * <p>
      * <b>Note:</b> instrumentation requires a appropriate {@link WrapperNode}
-     * 
+     *
      * @see WrapperNode
      * @since 0.8 or earlier
      */
@@ -275,16 +276,18 @@ public abstract class TruffleLanguage<C> {
     }
 
     /**
-     * Runs source code in a halted execution context, or at top level.
+     * Runs source code in a halted execution context, or at top level. Language implementations
+     * that do no support this should return an {@link UnsupportedOperationException}.
      *
      * @param source the code to run
      * @param node node where execution halted, {@code null} if no execution context
-     * @param mFrame frame where execution halted, {@code null} if no execution context
+     * @param frame frame where execution halted, {@code null} if no execution context
      * @return result of running the code in the context, or at top level if no execution context.
      * @throws IOException if the evaluation cannot be performed
+     * @throws UnsupportedOperationException if not supported by the language implementation
      * @since 0.8 or earlier
      */
-    protected abstract Object evalInContext(Source source, Node node, MaterializedFrame mFrame) throws IOException;
+    protected abstract Object evalInContext(Source source, Node node, MaterializedFrame frame) throws IOException;
 
     /**
      * Generates language specific textual representation of a value. Each language may have special
@@ -376,7 +379,7 @@ public abstract class TruffleLanguage<C> {
      * {@link TruffleLanguage} receives instance of the environment before any code is executed upon
      * it. The environment has knowledge of all active languages and can exchange symbols between
      * them.
-     * 
+     *
      * @since 0.8 or earlier
      */
     public static final class Env {
@@ -589,6 +592,7 @@ public abstract class TruffleLanguage<C> {
             }
         }
 
+        // TODO (mlvdv) this does not support evaluation in null context (i.e.top level)
         @Override
         protected Object evalInContext(Object vm, Object ev, String code, Node node, MaterializedFrame frame) throws IOException {
             RootNode rootNode = node.getRootNode();

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/Accessor.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/Accessor.java
@@ -102,7 +102,7 @@ public abstract class Accessor {
 
             @Override
             protected Object evalInContext(Source source, Node node, MaterializedFrame mFrame) throws IOException {
-                return null;
+                throw new UnsupportedOperationException();
             }
         };
         lng.hashCode();
@@ -163,6 +163,16 @@ public abstract class Accessor {
         return API.eval(l, s, cache);
     }
 
+    /**
+     * @param vm
+     * @param ev
+     * @param code text to evaluate
+     * @param node node in halted context
+     * @param frame frame in halted context
+     * @return result of language evaluation
+     * @throws IOException
+     * @throws UnsupportedOperationException if not supported by the language implementation
+     */
     protected Object evalInContext(Object vm, Object ev, String code, Node node, MaterializedFrame frame) throws IOException {
         return API.evalInContext(vm, ev, code, node, frame);
     }

--- a/truffle/com.oracle.truffle.sl/src/com/oracle/truffle/sl/SLLanguage.java
+++ b/truffle/com.oracle.truffle.sl/src/com/oracle/truffle/sl/SLLanguage.java
@@ -510,7 +510,7 @@ public final class SLLanguage extends TruffleLanguage<SLContext> {
 
     @Override
     protected Object evalInContext(Source source, Node node, MaterializedFrame mFrame) throws IOException {
-        throw new IllegalStateException("evalInContext not supported in SL");
+        throw new UnsupportedOperationException("SL only evaluates complete programs");
     }
 
     public Node createFindContextNode0() {

--- a/truffle/com.oracle.truffle.tck/src/com/oracle/truffle/tck/impl/TckLanguage.java
+++ b/truffle/com.oracle.truffle.tck/src/com/oracle/truffle/tck/impl/TckLanguage.java
@@ -101,7 +101,7 @@ public final class TckLanguage extends TruffleLanguage<Env> {
 
     @Override
     protected Object evalInContext(Source source, Node node, MaterializedFrame mFrame) throws IOException {
-        throw new IOException();
+        throw new UnsupportedOperationException();
     }
 
     private static final class MultiplyNode extends RootNode implements TruffleObject, ForeignAccess.Factory {

--- a/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/server/REPLHandler.java
+++ b/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/server/REPLHandler.java
@@ -404,6 +404,8 @@ public abstract class REPLHandler {
             try {
                 Object returnValue = serverContext.eval(source, frameNumber, stepInto);
                 return finishReplySucceeded(reply, visualizer.displayValue(returnValue, 0));
+            } catch (UnsupportedOperationException ex) {
+                return finishReplyFailed(reply, "eval not supported by language: " + ex.getMessage());
             } catch (QuitException ex) {
                 throw ex;
             } catch (KillException ex) {

--- a/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/server/REPLServer.java
+++ b/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/server/REPLServer.java
@@ -365,6 +365,7 @@ public final class REPLServer {
          *            halted, null = top level eval
          * @return result of the evaluation
          * @throws IOException if something goes wrong
+         * @throws UnsupportedOperationException if not supported by the language implementation
          */
         Object eval(String code, Integer frameNumber, boolean stepInto) throws IOException {
             if (event == null) {


### PR DESCRIPTION
Usability improvement:  Languages not supporting eval() return an UnsupportedOperationException so that the debugger can distinguish between this and an ordinary failure to avoid user confusion.