### PR TITLE
Ignore JavaInteropSpeedTest.

### DIFF
--- a/truffle/com.oracle.truffle.api.interop.java.test/src/com/oracle/truffle/api/interop/java/test/JavaInteropSpeedTest.java
+++ b/truffle/com.oracle.truffle.api.interop.java.test/src/com/oracle/truffle/api/interop/java/test/JavaInteropSpeedTest.java
@@ -31,11 +31,13 @@ import java.util.Random;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.oracle.truffle.api.interop.TruffleObject;
 import com.oracle.truffle.api.interop.java.JavaInterop;
 
+@Ignore("Convert into a microbenchmark!")
 public class JavaInteropSpeedTest {
     private static final int REPEAT = 10000;
     private static int[] arr;


### PR DESCRIPTION
The test tries to find performance regressions in the java interop implementation by comparing invocation time which is highly system dependent and fails regularly on different machines. Doing this in a unit test is sub-optimal. It should be converted into a microbenchmark.