### PR TITLE
Debug: Ability to attach EventConsumers on demand and initialize Debu…

### DIFF
--- a/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotEngine.java
+++ b/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotEngine.java
@@ -102,7 +102,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * {@link Builder#build() created} by and checks that all subsequent calls are coming from the same
  * thread. There is 1:1 mapping between {@link PolyglotEngine} and a thread that can tell it what to
  * do.
- * 
+ *
  * @since 0.9
  */
 @SuppressWarnings("rawtypes")
@@ -273,7 +273,7 @@ public class PolyglotEngine {
      *     .{@link Builder#setIn(java.io.InputStream) setIn}({@link InputStream yourInput})
      *     .{@link Builder#build() build()};
      * </pre>
-     * 
+     *
      * @since 0.9
      */
     public class Builder {
@@ -498,7 +498,7 @@ public class PolyglotEngine {
      * <p>
      * Calling any other method of this class after the dispose has been done yields an
      * {@link IllegalStateException}.
-     * 
+     *
      * @since 0.9
      */
     public void dispose() {
@@ -733,7 +733,7 @@ public class PolyglotEngine {
      * {@link Builder#executor(java.util.concurrent.Executor) asynchronous execution}, the
      * {@link Value} represents a future - i.e., it is returned immediately, leaving the execution
      * running on behind.
-     * 
+     *
      * @since 0.9
      */
     public class Value {
@@ -1015,7 +1015,7 @@ public class PolyglotEngine {
      * of supported {@link #getMimeTypes() MIME types} for each language. The actual language
      * implementation is not initialized until
      * {@link PolyglotEngine#eval(com.oracle.truffle.api.source.Source) a code is evaluated} in it.
-     * 
+     *
      * @since 0.9
      */
     public class Language {


### PR DESCRIPTION
After the changes associated with instrumentation rewrite, NetBeans Truffle debugging does not work at all. We get no calls to `PolyglotEngine.dispatch*Event()`.
The reason is, that when there's no `EventConsumer` registered, there are no events. But debugger has no control of `PolyglotEngine.Builder`, because it's not creating the `PolyglotEngine`. It's the application code that creates the `PolyglotEngine`, not debugger.
For flexibility reasons, I believe that we need the ability to add/remove the `EventConsumer` on demand. Therefore I propose to introduce two methods:
```
PolyglotEngine.addEventConsumer(EventConsumer<?> handler)
PolyglotEngine.removeEventConsumer(EventConsumer<?> handler)
```
I'm also introducing an entry access point, which replaces `dispatch*Event()` methods that are non-functional as described above. The new access point is `PolyglotEngine.initJPDADebugger()`. Having a breakpoint in this method, JPDA debugger is notified about a new `PolyglotEngine` instance (unfortunately, JPDA debugger does not have a notification mechanism for new instances created, we'd not need this access point if it has one) and can add event consumers to that new instance.

Currently, registering an `EventConsumer` does not initialize the `Debugger` (`Accessor.DEBUG` is null), therefore we need to force the Debugger initialization. I did not find another suitable place than when an event consumer is registered, force to load the `Debugger` class and it's accessor.
This looks hacky, if there are better ideas how to accomplish this, I'll gladly change it.