### PR TITLE
Execution event always

### DIFF
--- a/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/Debugger.java
+++ b/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/Debugger.java
@@ -1042,7 +1042,6 @@ public final class Debugger {
         debugContext = new DebugExecutionContext(execSource, debugContext, depth);
         prepareContinue(depth);
         debugContext.contextTrace("START EXEC ");
-        ACCESSOR.dispatchEvent(engine, new ExecutionEvent(this));
     }
 
     void executionEnded() {
@@ -1074,19 +1073,18 @@ public final class Debugger {
 
         @Override
         protected Closeable executionStart(Object vm, int currentDepth, final boolean initializeDebugger, Source s) {
-            final Debugger debugger = find((PolyglotEngine) vm, initializeDebugger);
-            if (debugger == null) {
-                return new Closeable() {
-                    @Override
-                    public void close() throws IOException {
-                    }
-                };
+            final PolyglotEngine engine = (PolyglotEngine) vm;
+            final Debugger debugger = find(engine, initializeDebugger);
+            if (debugger != null) {
+                debugger.executionStarted(currentDepth, s);
             }
-            debugger.executionStarted(currentDepth, s);
+            ACCESSOR.dispatchEvent(engine, new ExecutionEvent(engine));
             return new Closeable() {
                 @Override
                 public void close() throws IOException {
-                    debugger.executionEnded();
+                    if (debugger != null) {
+                        debugger.executionEnded();
+                    }
                 }
             };
         }

--- a/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/ExecutionEvent.java
+++ b/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/ExecutionEvent.java
@@ -24,6 +24,8 @@
  */
 package com.oracle.truffle.api.debug;
 
+import com.oracle.truffle.api.vm.PolyglotEngine;
+
 /**
  * This event is delivered to all
  * {@link com.oracle.truffle.api.vm.PolyglotEngine.Builder#onEvent(com.oracle.truffle.api.vm.EventConsumer)
@@ -41,10 +43,10 @@ package com.oracle.truffle.api.debug;
  */
 @SuppressWarnings("javadoc")
 public final class ExecutionEvent {
-    private final Debugger debugger;
+    private final PolyglotEngine engine;
 
-    ExecutionEvent(Debugger prepares) {
-        this.debugger = prepares;
+    ExecutionEvent(PolyglotEngine vm) {
+        this.engine = vm;
     }
 
     /**
@@ -57,7 +59,7 @@ public final class ExecutionEvent {
      * @since 0.9
      */
     public Debugger getDebugger() {
-        return debugger;
+        return Debugger.find(engine);
     }
 
     /**
@@ -75,7 +77,7 @@ public final class ExecutionEvent {
      * @since 0.9
      */
     public void prepareContinue() {
-        debugger.prepareContinue(-1);
+        getDebugger().prepareContinue(-1);
     }
 
     /**
@@ -98,6 +100,6 @@ public final class ExecutionEvent {
      * @since 0.9
      */
     public void prepareStepInto() {
-        debugger.prepareStepInto(1);
+        getDebugger().prepareStepInto(1);
     }
 }

--- a/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotEngine.java
+++ b/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotEngine.java
@@ -190,15 +190,6 @@ public class PolyglotEngine {
         return Collections.unmodifiableMap(instr);
     }
 
-    private boolean isDebuggerOn() {
-        for (EventConsumer<?> handler : handlers) {
-            if (handler.type.getSimpleName().endsWith("ExecutionEvent")) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     /**
      * Creation of new Truffle virtual machine. Use the {@link Builder} methods to configure your
      * virtual machine and then create one using {@link Builder#build()}:
@@ -535,7 +526,7 @@ public class PolyglotEngine {
 
     @SuppressWarnings("try")
     private Object evalImpl(TruffleLanguage<?>[] fillLang, Source s, Language l) throws IOException {
-        try (Closeable d = SPI.executionStart(this, -1, isDebuggerOn(), s)) {
+        try (Closeable d = SPI.executionStart(this, -1, false, s)) {
             TruffleLanguage<?> langImpl = l.getImpl(true);
             fillLang[0] = langImpl;
             return SPI.eval(langImpl, s, l.cache);

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/Accessor.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/Accessor.java
@@ -114,6 +114,11 @@ public abstract class Accessor {
         } catch (ClassNotFoundException ex) {
             throw new IllegalStateException(ex);
         }
+        try {
+            Class.forName("com.oracle.truffle.api.debug.Debugger", true, Accessor.class.getClassLoader());
+        } catch (ClassNotFoundException ex) {
+            throw new IllegalStateException(ex);
+        }
     }
 
     protected Accessor() {

--- a/truffle/com.oracle.truffle.sl.test/src/com/oracle/truffle/sl/test/SLDebugTest.java
+++ b/truffle/com.oracle.truffle.sl.test/src/com/oracle/truffle/sl/test/SLDebugTest.java
@@ -82,6 +82,7 @@ public class SLDebugTest {
             @Override
             protected void on(ExecutionEvent event) {
                 executionEvent = event;
+                debugger = executionEvent.getDebugger();
                 performWork();
                 executionEvent = null;
             }
@@ -93,8 +94,6 @@ public class SLDebugTest {
                 suspendedEvent = null;
             }
         }).build();
-        debugger = Debugger.find(engine);
-        assertNotNull("Debugger found", debugger);
         run.clear();
     }
 


### PR DESCRIPTION
Returns the situation with respect to `ExecutionEvent` to 0.11 state - e.g. `ExecutionEvent` is always delivered and its `getDebugger` method returns initialized debugger.

Martin @Entlicher, please verify if the change works for your debugger.