### PR TITLE
Rename SuspendedEvent.kill() to prepareKill() and do kill lazily.

### DIFF
--- a/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/Debugger.java
+++ b/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/Debugger.java
@@ -973,13 +973,15 @@ public final class Debugger {
 
             try {
                 // Pass control to the debug client with current execution suspended
-                ACCESSOR.dispatchEvent(engine, new SuspendedEvent(Debugger.this, haltedNode, haltedFrame, contextStack, recentWarnings));
+                SuspendedEvent event = new SuspendedEvent(Debugger.this, haltedNode, haltedFrame, contextStack, recentWarnings);
+                ACCESSOR.dispatchEvent(engine, event);
+                if (event.isKillPrepared()) {
+                    contextTrace("KILL");
+                    throw new KillException();
+                }
                 // Debug client finished normally, execution resumes
                 // Presume that the client has set a new strategy (or default to Continue)
                 running = true;
-            } catch (KillException e) {
-                contextTrace("KILL");
-                throw e;
             } finally {
                 haltedNode = null;
                 haltedFrame = null;
@@ -1059,10 +1061,14 @@ public final class Debugger {
      * @throws IOException
      */
     Object evalInContext(SuspendedEvent ev, String code, FrameInstance frameInstance) throws IOException {
-        if (frameInstance == null) {
-            return ACCESSOR.evalInContext(engine, ev, code, debugContext.haltedNode, debugContext.haltedFrame);
-        } else {
-            return ACCESSOR.evalInContext(engine, ev, code, frameInstance.getCallNode(), frameInstance.getFrame(FrameAccess.MATERIALIZE, true).materialize());
+        try {
+            if (frameInstance == null) {
+                return ACCESSOR.evalInContext(engine, ev, code, debugContext.haltedNode, debugContext.haltedFrame);
+            } else {
+                return ACCESSOR.evalInContext(engine, ev, code, frameInstance.getCallNode(), frameInstance.getFrame(FrameAccess.MATERIALIZE, true).materialize());
+            }
+        } catch (KillException kex) {
+            throw new IOException("Killed");
         }
     }
 

--- a/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/SuspendedEvent.java
+++ b/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/SuspendedEvent.java
@@ -66,6 +66,7 @@ public final class SuspendedEvent {
     private final MaterializedFrame haltedFrame;
     private final List<FrameInstance> stack;
     private final List<String> warnings;
+    private volatile boolean kill;
 
     SuspendedEvent(Debugger debugger, Node haltedNode, MaterializedFrame haltedFrame, List<FrameInstance> stack, List<String> warnings) {
         this.debugger = debugger;
@@ -220,12 +221,15 @@ public final class SuspendedEvent {
     }
 
     /**
-     * Terminates the halted execution represented by this event.
+     * Prepare to terminate the suspended execution represented by this event.
      *
      * @since 0.12
      */
-    @SuppressWarnings("static-method")
-    public void kill() {
-        throw new KillException();
+    public void prepareKill() {
+        kill = true;
+    }
+
+    boolean isKillPrepared() {
+        return kill;
     }
 }

--- a/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/client/REPLRemoteCommand.java
+++ b/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/client/REPLRemoteCommand.java
@@ -579,6 +579,7 @@ public abstract class REPLRemoteCommand extends REPLCommand {
             } else {
                 context.displayFailReply(replies[0].get(REPLMessage.DISPLAY_MSG));
             }
+            throw new REPLContinueException();
         }
     };
 

--- a/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/server/REPLServer.java
+++ b/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/server/REPLServer.java
@@ -486,7 +486,7 @@ public final class REPLServer {
         }
 
         void kill() {
-            event.kill();
+            event.prepareKill();
         }
 
     }


### PR DESCRIPTION
`SuspendedEvent.kill()` directly throw the `KillException`, which has unpleasant consequences:

- Any code that follows `SuspendedEvent.kill()` call will not be processed, which may not be expected.
- We can not prevent users from accidentally calling `SuspendedEvent.kill()` in a possible asynchronous code handling the events. In this case it unexpectedly blows up.

To achieve the same effect, which was intended by the original code, but to be more polite to the caller of this method, I suggest to have just a `kill` marker on the `SuspendedEvent` and throw the `KillException` in the infrastructure. As the method is not killing right away now, I'm changing the name from `kill()` to `prepareKill()`, which corresponds with other `prepare*()` methods.