### PR TITLE
OM-DSL: make the generated ObjectType public

### DIFF
--- a/truffle/com.oracle.truffle.api.object.dsl.test/src/com/oracle/truffle/api/object/dsl/test/ObjectTypePublicTest.java
+++ b/truffle/com.oracle.truffle.api.object.dsl.test/src/com/oracle/truffle/api/object/dsl/test/ObjectTypePublicTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.truffle.api.object.dsl.test;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.oracle.truffle.api.object.DynamicObject;
+import com.oracle.truffle.api.object.dsl.test.alternate_package.ObjectTypePublicTest.ObjectTypePublicTestLayout;
+import com.oracle.truffle.api.object.dsl.test.alternate_package.ObjectTypePublicTestLayoutImpl;
+
+public class ObjectTypePublicTest {
+
+    private static final ObjectTypePublicTestLayout LAYOUT = ObjectTypePublicTestLayoutImpl.INSTANCE;
+
+    @Test
+    public void testIsPublic() {
+        final DynamicObject instance = LAYOUT.createObjectTypePublicTest(14);
+        assertTrue(ObjectTypePublicTestLayoutImpl.ObjectTypePublicTestType.class.isAssignableFrom(instance.getShape().getObjectType().getClass()));
+    }
+
+}

--- a/truffle/com.oracle.truffle.api.object.dsl.test/src/com/oracle/truffle/api/object/dsl/test/alternate_package/ObjectTypePublicTest.java
+++ b/truffle/com.oracle.truffle.api.object.dsl.test/src/com/oracle/truffle/api/object/dsl/test/alternate_package/ObjectTypePublicTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.truffle.api.object.dsl.test.alternate_package;
+
+import com.oracle.truffle.api.object.DynamicObject;
+import com.oracle.truffle.api.object.dsl.Layout;
+
+public class ObjectTypePublicTest {
+
+    @Layout
+    public interface ObjectTypePublicTestLayout {
+
+        DynamicObject createObjectTypePublicTest(int value);
+
+        int getValue(DynamicObject object);
+
+        void setValue(DynamicObject object, int value);
+
+    }
+
+}

--- a/truffle/com.oracle.truffle.object.dsl.processor/src/com/oracle/truffle/object/dsl/processor/LayoutGenerator.java
+++ b/truffle/com.oracle.truffle.object.dsl.processor/src/com/oracle/truffle/object/dsl/processor/LayoutGenerator.java
@@ -196,7 +196,7 @@ public class LayoutGenerator {
             typeSuperclass = layout.getSuperLayout().getName() + "LayoutImpl." + layout.getSuperLayout().getName() + "Type";
         }
 
-        stream.printf("    protected static class %sType extends %s {%n", layout.getName(), typeSuperclass);
+        stream.printf("    public static class %sType extends %s {%n", layout.getName(), typeSuperclass);
 
         if (layout.hasShapeProperties()) {
             stream.println("        ");


### PR DESCRIPTION
The `ObjectType` subclass we generate as part of the OM DSL is currently hidden as an implementation detail. But now I've found out that it would be useful to have it for the foreign access DSL, which needs it in the required `receiverType` parameter of the  `AcceptMessage` annotation.

This doesn't change any signatures but I guess it counts as an API change on the as-yet unreleased OM-DSL as the generated code is different, but backwards compatible.