### PR TITLE
Update Javadoc of getExecutionContext()

### DIFF
--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/RootNode.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/nodes/RootNode.java
@@ -145,14 +145,6 @@ public abstract class RootNode extends Node {
      * so also for a {@link RootCallTarget} and a {@link FrameInstance} obtained from the call
      * stack) without prior knowledge of the language it has come from.
      *
-     * Used for instance to determine the language of a <code>RootNode<code>:
-     * 
-     * <code>
-     * <pre>
-     * rootNode.getExecutionContext().getLanguageShortName();
-     * </pre>
-     * </code>
-     *
      * Returns <code>null</code> by default.
      * 
      * @since 0.8 or earlier


### PR DESCRIPTION
The ExecutionContext does not contain getLanguageShortName() method, therefore it's reference should be removed from Javadoc.