### PR TITLE
REPL debugger:  Deprecate public classes for removal from Truffle API

### DIFF
--- a/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/REPLClient.java
+++ b/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/REPLClient.java
@@ -27,16 +27,18 @@ package com.oracle.truffle.tools.debug.shell;
 /**
  * The client side of a simple message-based protocol for a possibly remote language
  * Read-Eval-Print-Loop.
- * 
+ *
  * @since 0.8 or earlier
  */
+@Deprecated
 public interface REPLClient {
 
     /**
      * Accepts a reply from the server; there may be more than one reply in response to a request.
-     * 
+     *
      * @since 0.8 or earlier
      */
+    @SuppressWarnings("deprecation")
     REPLMessage receive(REPLMessage reply);
 
 }

--- a/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/REPLMessage.java
+++ b/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/REPLMessage.java
@@ -36,7 +36,6 @@ import com.oracle.truffle.tools.debug.shell.server.REPLServer;
  * A message for communication between a Read-Eval-Print-Loop server associated with a language
  * implementation and a possibly remote client.
  *
- * @see REPLClient
  * @see REPLServer
  * @since 0.8 or earlier
  */

--- a/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/REPLMessage.java
+++ b/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/REPLMessage.java
@@ -40,6 +40,7 @@ import com.oracle.truffle.tools.debug.shell.server.REPLServer;
  * @see REPLServer
  * @since 0.8 or earlier
  */
+@Deprecated
 public final class REPLMessage {
     /** @since 0.8 or earlier */
     // Some standard keys and values
@@ -224,7 +225,7 @@ public final class REPLMessage {
 
     /**
      * Creates an empty REPL message.
-     * 
+     *
      * @since 0.8 or earlier
      */
     public REPLMessage() {
@@ -233,7 +234,7 @@ public final class REPLMessage {
 
     /**
      * Creates a REPL message with an initial entry.
-     * 
+     *
      * @since 0.8 or earlier
      */
     public REPLMessage(String key, String value) {
@@ -253,7 +254,7 @@ public final class REPLMessage {
 
     /**
      * Returns the specified key value as an integer; {@code null} if missing or non-numeric.
-     * 
+     *
      * @since 0.8 or earlier
      */
     public Integer getIntValue(String key) {

--- a/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/client/REPLRemoteCommand.java
+++ b/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/client/REPLRemoteCommand.java
@@ -29,7 +29,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import com.oracle.truffle.api.source.Source;
-import com.oracle.truffle.tools.debug.shell.REPLMessage;
 
 @SuppressWarnings("deprecation")
 public abstract class REPLRemoteCommand extends REPLCommand {
@@ -38,22 +37,22 @@ public abstract class REPLRemoteCommand extends REPLCommand {
         super(command, abbreviation, description);
     }
 
-    protected abstract REPLMessage createRequest(REPLClientContext context, String[] args);
+    protected abstract com.oracle.truffle.tools.debug.shell.REPLMessage createRequest(REPLClientContext context, String[] args);
 
-    void processReply(REPLClientContext context, REPLMessage[] replies) {
-        REPLMessage firstReply = replies[0];
+    void processReply(REPLClientContext context, com.oracle.truffle.tools.debug.shell.REPLMessage[] replies) {
+        com.oracle.truffle.tools.debug.shell.REPLMessage firstReply = replies[0];
 
-        if (firstReply.get(REPLMessage.STATUS).equals(REPLMessage.FAILED)) {
-            final String result = firstReply.get(REPLMessage.DISPLAY_MSG);
+        if (firstReply.get(com.oracle.truffle.tools.debug.shell.REPLMessage.STATUS).equals(com.oracle.truffle.tools.debug.shell.REPLMessage.FAILED)) {
+            final String result = firstReply.get(com.oracle.truffle.tools.debug.shell.REPLMessage.DISPLAY_MSG);
             context.displayFailReply(result != null ? result : firstReply.toString());
         } else {
-            final String result = firstReply.get(REPLMessage.DISPLAY_MSG);
+            final String result = firstReply.get(com.oracle.truffle.tools.debug.shell.REPLMessage.DISPLAY_MSG);
             context.displayReply(result != null ? result : firstReply.toString());
         }
 
         for (int i = 1; i < replies.length; i++) {
-            REPLMessage reply = replies[i];
-            final String result = reply.get(REPLMessage.DISPLAY_MSG);
+            com.oracle.truffle.tools.debug.shell.REPLMessage reply = replies[i];
+            final String result = reply.get(com.oracle.truffle.tools.debug.shell.REPLMessage.DISPLAY_MSG);
             context.displayInfo(result != null ? result : reply.toString());
         }
     }
@@ -69,10 +68,10 @@ public abstract class REPLRemoteCommand extends REPLCommand {
         }
 
         @Override
-        public REPLMessage createRequest(REPLClientContext context, String[] args) {
+        public com.oracle.truffle.tools.debug.shell.REPLMessage createRequest(REPLClientContext context, String[] args) {
             try {
                 final REPLineLocation lineLocation = REPLineLocation.parse(context, args);
-                final REPLMessage requestMessage = lineLocation.createMessage(REPLMessage.BREAK_AT_LINE);
+                final com.oracle.truffle.tools.debug.shell.REPLMessage requestMessage = lineLocation.createMessage(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAK_AT_LINE);
                 int ignoreCount = 0;
                 if (args.length > 2) {
                     final String ignoreText = args[2];
@@ -93,7 +92,7 @@ public abstract class REPLRemoteCommand extends REPLCommand {
                         throw new IllegalArgumentException("Unrecognized argument \"" + ignoreText + "\"");
                     }
                 }
-                requestMessage.put(REPLMessage.BREAKPOINT_IGNORE_COUNT, Integer.toString(ignoreCount));
+                requestMessage.put(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_IGNORE_COUNT, Integer.toString(ignoreCount));
                 return requestMessage;
             } catch (IllegalArgumentException ex) {
                 context.displayFailReply(ex.getMessage());
@@ -102,14 +101,14 @@ public abstract class REPLRemoteCommand extends REPLCommand {
         }
 
         @Override
-        void processReply(REPLClientContext context, REPLMessage[] replies) {
-            REPLMessage firstReply = replies[0];
+        void processReply(REPLClientContext context, com.oracle.truffle.tools.debug.shell.REPLMessage[] replies) {
+            com.oracle.truffle.tools.debug.shell.REPLMessage firstReply = replies[0];
 
-            if (firstReply.get(REPLMessage.STATUS).equals(REPLMessage.SUCCEEDED)) {
-                final String number = firstReply.get(REPLMessage.BREAKPOINT_ID);
-                final String fileName = firstReply.get(REPLMessage.SOURCE_NAME);
-                final String lineNumber = firstReply.get(REPLMessage.LINE_NUMBER);
-                firstReply.put(REPLMessage.DISPLAY_MSG, "breakpoint " + number + " set at " + fileName + ":" + lineNumber);
+            if (firstReply.get(com.oracle.truffle.tools.debug.shell.REPLMessage.STATUS).equals(com.oracle.truffle.tools.debug.shell.REPLMessage.SUCCEEDED)) {
+                final String number = firstReply.get(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_ID);
+                final String fileName = firstReply.get(com.oracle.truffle.tools.debug.shell.REPLMessage.SOURCE_NAME);
+                final String lineNumber = firstReply.get(com.oracle.truffle.tools.debug.shell.REPLMessage.LINE_NUMBER);
+                firstReply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.DISPLAY_MSG, "breakpoint " + number + " set at " + fileName + ":" + lineNumber);
             }
             super.processReply(context, replies);
         }
@@ -125,9 +124,9 @@ public abstract class REPLRemoteCommand extends REPLCommand {
         }
 
         @Override
-        public REPLMessage createRequest(REPLClientContext context, String[] args) {
+        public com.oracle.truffle.tools.debug.shell.REPLMessage createRequest(REPLClientContext context, String[] args) {
             try {
-                return REPLineLocation.parse(context, args).createMessage(REPLMessage.BREAK_AT_LINE_ONCE);
+                return REPLineLocation.parse(context, args).createMessage(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAK_AT_LINE_ONCE);
             } catch (IllegalArgumentException ex) {
                 context.displayFailReply(ex.getMessage());
             }
@@ -135,13 +134,13 @@ public abstract class REPLRemoteCommand extends REPLCommand {
         }
 
         @Override
-        void processReply(REPLClientContext context, REPLMessage[] replies) {
-            REPLMessage firstReply = replies[0];
+        void processReply(REPLClientContext context, com.oracle.truffle.tools.debug.shell.REPLMessage[] replies) {
+            com.oracle.truffle.tools.debug.shell.REPLMessage firstReply = replies[0];
 
-            if (firstReply.get(REPLMessage.STATUS).equals(REPLMessage.SUCCEEDED)) {
-                final String fileName = firstReply.get(REPLMessage.SOURCE_NAME);
-                final String lineNumber = firstReply.get(REPLMessage.LINE_NUMBER);
-                firstReply.put(REPLMessage.DISPLAY_MSG, "one-shot breakpoint set at " + fileName + ":" + lineNumber);
+            if (firstReply.get(com.oracle.truffle.tools.debug.shell.REPLMessage.STATUS).equals(com.oracle.truffle.tools.debug.shell.REPLMessage.SUCCEEDED)) {
+                final String fileName = firstReply.get(com.oracle.truffle.tools.debug.shell.REPLMessage.SOURCE_NAME);
+                final String lineNumber = firstReply.get(com.oracle.truffle.tools.debug.shell.REPLMessage.LINE_NUMBER);
+                firstReply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.DISPLAY_MSG, "one-shot breakpoint set at " + fileName + ":" + lineNumber);
             }
             super.processReply(context, replies);
         }
@@ -157,33 +156,33 @@ public abstract class REPLRemoteCommand extends REPLCommand {
         }
 
         @Override
-        public REPLMessage createRequest(REPLClientContext context, String[] args) {
+        public com.oracle.truffle.tools.debug.shell.REPLMessage createRequest(REPLClientContext context, String[] args) {
             if (args.length == 1) {
                 context.displayFailReply("name to call not speciified");
                 return null;
             }
-            final int maxArgs = REPLMessage.ARG_NAMES.length;
+            final int maxArgs = com.oracle.truffle.tools.debug.shell.REPLMessage.ARG_NAMES.length;
             if (args.length > maxArgs + 2) {
                 context.displayFailReply("too many call arguments; no more than " + maxArgs + " supported");
                 return null;
             }
-            final REPLMessage request = new REPLMessage();
-            request.put(REPLMessage.OP, REPLMessage.CALL);
-            request.put(REPLMessage.CALL_NAME, args[1]);
+            final com.oracle.truffle.tools.debug.shell.REPLMessage request = new com.oracle.truffle.tools.debug.shell.REPLMessage();
+            request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.OP, com.oracle.truffle.tools.debug.shell.REPLMessage.CALL);
+            request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.CALL_NAME, args[1]);
             for (int argIn = 2, argOut = 0; argIn < args.length; argIn++, argOut++) {
-                request.put(REPLMessage.ARG_NAMES[argOut], args[argIn]);
+                request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.ARG_NAMES[argOut], args[argIn]);
             }
             return request;
         }
 
         @Override
-        void processReply(REPLClientContext context, REPLMessage[] replies) {
-            REPLMessage firstReply = replies[0];
-            if (firstReply.get(REPLMessage.STATUS).equals(REPLMessage.FAILED)) {
-                final String result = firstReply.get(REPLMessage.DISPLAY_MSG);
+        void processReply(REPLClientContext context, com.oracle.truffle.tools.debug.shell.REPLMessage[] replies) {
+            com.oracle.truffle.tools.debug.shell.REPLMessage firstReply = replies[0];
+            if (firstReply.get(com.oracle.truffle.tools.debug.shell.REPLMessage.STATUS).equals(com.oracle.truffle.tools.debug.shell.REPLMessage.FAILED)) {
+                final String result = firstReply.get(com.oracle.truffle.tools.debug.shell.REPLMessage.DISPLAY_MSG);
                 context.displayFailReply(result != null ? result : firstReply.toString());
             } else {
-                context.displayReply(firstReply.get(REPLMessage.VALUE));
+                context.displayReply(firstReply.get(com.oracle.truffle.tools.debug.shell.REPLMessage.VALUE));
             }
         }
     };
@@ -198,16 +197,16 @@ public abstract class REPLRemoteCommand extends REPLCommand {
         }
 
         @Override
-        public REPLMessage createRequest(REPLClientContext context, String[] args) {
-            final REPLMessage request = CALL_CMD.createRequest(context, args);
+        public com.oracle.truffle.tools.debug.shell.REPLMessage createRequest(REPLClientContext context, String[] args) {
+            final com.oracle.truffle.tools.debug.shell.REPLMessage request = CALL_CMD.createRequest(context, args);
             if (request != null) {
-                request.put(REPLMessage.STEP_INTO, REPLMessage.TRUE);
+                request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.STEP_INTO, com.oracle.truffle.tools.debug.shell.REPLMessage.TRUE);
             }
             return request;
         }
 
         @Override
-        void processReply(REPLClientContext context, REPLMessage[] replies) {
+        void processReply(REPLClientContext context, com.oracle.truffle.tools.debug.shell.REPLMessage[] replies) {
             CALL_CMD.processReply(context, replies);
         }
     };
@@ -222,7 +221,7 @@ public abstract class REPLRemoteCommand extends REPLCommand {
         }
 
         @Override
-        public REPLMessage createRequest(REPLClientContext context, String[] args) {
+        public com.oracle.truffle.tools.debug.shell.REPLMessage createRequest(REPLClientContext context, String[] args) {
             if (args.length == 1) {
                 context.displayFailReply("breakpoint number not speciified:  \"break <n>\"");
             } else if (args.length > 2) {
@@ -230,9 +229,9 @@ public abstract class REPLRemoteCommand extends REPLCommand {
             } else {
                 try {
                     final int breakpointNumber = Integer.parseInt(args[1]);
-                    final REPLMessage request = new REPLMessage();
-                    request.put(REPLMessage.OP, REPLMessage.CLEAR_BREAK);
-                    request.put(REPLMessage.BREAKPOINT_ID, Integer.toString(breakpointNumber));
+                    final com.oracle.truffle.tools.debug.shell.REPLMessage request = new com.oracle.truffle.tools.debug.shell.REPLMessage();
+                    request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.OP, com.oracle.truffle.tools.debug.shell.REPLMessage.CLEAR_BREAK);
+                    request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_ID, Integer.toString(breakpointNumber));
                     return request;
                 } catch (IllegalArgumentException ex) {
                     context.displayFailReply(ex.getMessage());
@@ -242,12 +241,12 @@ public abstract class REPLRemoteCommand extends REPLCommand {
         }
 
         @Override
-        void processReply(REPLClientContext context, REPLMessage[] replies) {
-            REPLMessage firstReply = replies[0];
+        void processReply(REPLClientContext context, com.oracle.truffle.tools.debug.shell.REPLMessage[] replies) {
+            com.oracle.truffle.tools.debug.shell.REPLMessage firstReply = replies[0];
 
-            if (firstReply.get(REPLMessage.STATUS).equals(REPLMessage.SUCCEEDED)) {
-                final int breakpointNumber = firstReply.getIntValue(REPLMessage.BREAKPOINT_ID);
-                firstReply.put(REPLMessage.DISPLAY_MSG, "breakpoint " + breakpointNumber + " cleared");
+            if (firstReply.get(com.oracle.truffle.tools.debug.shell.REPLMessage.STATUS).equals(com.oracle.truffle.tools.debug.shell.REPLMessage.SUCCEEDED)) {
+                final int breakpointNumber = firstReply.getIntValue(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_ID);
+                firstReply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.DISPLAY_MSG, "breakpoint " + breakpointNumber + " cleared");
             }
             super.processReply(context, replies);
         }
@@ -263,23 +262,23 @@ public abstract class REPLRemoteCommand extends REPLCommand {
         }
 
         @Override
-        public REPLMessage createRequest(REPLClientContext context, String[] args) {
+        public com.oracle.truffle.tools.debug.shell.REPLMessage createRequest(REPLClientContext context, String[] args) {
             if (args.length == 1) {
                 context.displayFailReply("breakpoint number not speciified:  \"cond <n>\"");
             } else {
                 try {
                     final int breakpointNumber = Integer.parseInt(args[1]);
-                    final REPLMessage request = new REPLMessage();
-                    request.put(REPLMessage.BREAKPOINT_ID, Integer.toString(breakpointNumber));
+                    final com.oracle.truffle.tools.debug.shell.REPLMessage request = new com.oracle.truffle.tools.debug.shell.REPLMessage();
+                    request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_ID, Integer.toString(breakpointNumber));
                     if (args.length == 2) {
-                        request.put(REPLMessage.OP, REPLMessage.UNSET_BREAK_CONDITION);
+                        request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.OP, com.oracle.truffle.tools.debug.shell.REPLMessage.UNSET_BREAK_CONDITION);
                     } else {
                         final StringBuilder exprBuilder = new StringBuilder();
                         for (int i = 2; i < args.length; i++) {
                             exprBuilder.append(args[i]).append(" ");
                         }
-                        request.put(REPLMessage.BREAKPOINT_CONDITION, exprBuilder.toString().trim());
-                        request.put(REPLMessage.OP, REPLMessage.SET_BREAK_CONDITION);
+                        request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_CONDITION, exprBuilder.toString().trim());
+                        request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.OP, com.oracle.truffle.tools.debug.shell.REPLMessage.SET_BREAK_CONDITION);
                     }
                     return request;
                 } catch (IllegalArgumentException ex) {
@@ -290,15 +289,15 @@ public abstract class REPLRemoteCommand extends REPLCommand {
         }
 
         @Override
-        void processReply(REPLClientContext context, REPLMessage[] replies) {
-            REPLMessage firstReply = replies[0];
-            if (firstReply.get(REPLMessage.STATUS).equals(REPLMessage.SUCCEEDED)) {
-                final int breakpointNumber = firstReply.getIntValue(REPLMessage.BREAKPOINT_ID);
-                final String condition = firstReply.get(REPLMessage.BREAKPOINT_CONDITION);
+        void processReply(REPLClientContext context, com.oracle.truffle.tools.debug.shell.REPLMessage[] replies) {
+            com.oracle.truffle.tools.debug.shell.REPLMessage firstReply = replies[0];
+            if (firstReply.get(com.oracle.truffle.tools.debug.shell.REPLMessage.STATUS).equals(com.oracle.truffle.tools.debug.shell.REPLMessage.SUCCEEDED)) {
+                final int breakpointNumber = firstReply.getIntValue(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_ID);
+                final String condition = firstReply.get(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_CONDITION);
                 if (condition == null) {
-                    firstReply.put(REPLMessage.DISPLAY_MSG, "breakpoint " + breakpointNumber + " condition cleared");
+                    firstReply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.DISPLAY_MSG, "breakpoint " + breakpointNumber + " condition cleared");
                 } else {
-                    firstReply.put(REPLMessage.DISPLAY_MSG, "breakpoint " + breakpointNumber + " condition=\"" + condition + "\"");
+                    firstReply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.DISPLAY_MSG, "breakpoint " + breakpointNumber + " condition=\"" + condition + "\"");
                 }
             }
             super.processReply(context, replies);
@@ -308,18 +307,18 @@ public abstract class REPLRemoteCommand extends REPLCommand {
     public static final REPLRemoteCommand CONTINUE_CMD = new REPLRemoteCommand("continue", "c", "Continue execution") {
 
         @Override
-        public REPLMessage createRequest(REPLClientContext context, String[] args) {
+        public com.oracle.truffle.tools.debug.shell.REPLMessage createRequest(REPLClientContext context, String[] args) {
             if (context.level() == 0) {
                 context.displayFailReply("no active execution");
                 return null;
             }
-            final REPLMessage request = new REPLMessage();
-            request.put(REPLMessage.OP, REPLMessage.CONTINUE);
+            final com.oracle.truffle.tools.debug.shell.REPLMessage request = new com.oracle.truffle.tools.debug.shell.REPLMessage();
+            request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.OP, com.oracle.truffle.tools.debug.shell.REPLMessage.CONTINUE);
             return request;
         }
 
         @Override
-        void processReply(REPLClientContext context, REPLMessage[] replies) {
+        void processReply(REPLClientContext context, com.oracle.truffle.tools.debug.shell.REPLMessage[] replies) {
 
             throw new REPLContinueException();
 
@@ -329,9 +328,9 @@ public abstract class REPLRemoteCommand extends REPLCommand {
     public static final REPLRemoteCommand DELETE_CMD = new REPLRemoteCommand("delete", "d", "Delete all breakpoints") {
 
         @Override
-        public REPLMessage createRequest(REPLClientContext context, String[] args) {
-            final REPLMessage request = new REPLMessage();
-            request.put(REPLMessage.OP, REPLMessage.DELETE_BREAK);
+        public com.oracle.truffle.tools.debug.shell.REPLMessage createRequest(REPLClientContext context, String[] args) {
+            final com.oracle.truffle.tools.debug.shell.REPLMessage request = new com.oracle.truffle.tools.debug.shell.REPLMessage();
+            request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.OP, com.oracle.truffle.tools.debug.shell.REPLMessage.DELETE_BREAK);
             return request;
         }
     };
@@ -346,7 +345,7 @@ public abstract class REPLRemoteCommand extends REPLCommand {
         }
 
         @Override
-        public REPLMessage createRequest(REPLClientContext context, String[] args) {
+        public com.oracle.truffle.tools.debug.shell.REPLMessage createRequest(REPLClientContext context, String[] args) {
             if (args.length == 1) {
                 context.displayFailReply("breakpoint number not speciified:  \"disable <n>\"");
             } else if (args.length > 2) {
@@ -354,9 +353,9 @@ public abstract class REPLRemoteCommand extends REPLCommand {
             } else {
                 try {
                     final int breakpointNumber = Integer.parseInt(args[1]);
-                    final REPLMessage request = new REPLMessage();
-                    request.put(REPLMessage.OP, REPLMessage.DISABLE_BREAK);
-                    request.put(REPLMessage.BREAKPOINT_ID, Integer.toString(breakpointNumber));
+                    final com.oracle.truffle.tools.debug.shell.REPLMessage request = new com.oracle.truffle.tools.debug.shell.REPLMessage();
+                    request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.OP, com.oracle.truffle.tools.debug.shell.REPLMessage.DISABLE_BREAK);
+                    request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_ID, Integer.toString(breakpointNumber));
                     return request;
                 } catch (IllegalArgumentException ex) {
                     context.displayFailReply(ex.getMessage());
@@ -366,11 +365,11 @@ public abstract class REPLRemoteCommand extends REPLCommand {
         }
 
         @Override
-        void processReply(REPLClientContext context, REPLMessage[] replies) {
-            REPLMessage firstReply = replies[0];
-            if (firstReply.get(REPLMessage.STATUS).equals(REPLMessage.SUCCEEDED)) {
-                final int breakpointNumber = firstReply.getIntValue(REPLMessage.BREAKPOINT_ID);
-                firstReply.put(REPLMessage.DISPLAY_MSG, "breakpoint " + breakpointNumber + " disabled");
+        void processReply(REPLClientContext context, com.oracle.truffle.tools.debug.shell.REPLMessage[] replies) {
+            com.oracle.truffle.tools.debug.shell.REPLMessage firstReply = replies[0];
+            if (firstReply.get(com.oracle.truffle.tools.debug.shell.REPLMessage.STATUS).equals(com.oracle.truffle.tools.debug.shell.REPLMessage.SUCCEEDED)) {
+                final int breakpointNumber = firstReply.getIntValue(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_ID);
+                firstReply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.DISPLAY_MSG, "breakpoint " + breakpointNumber + " disabled");
             }
             super.processReply(context, replies);
         }
@@ -379,7 +378,7 @@ public abstract class REPLRemoteCommand extends REPLCommand {
     public static final REPLRemoteCommand DOWN_CMD = new REPLRemoteCommand("down", null, "Move down a stack frame") {
 
         @Override
-        public REPLMessage createRequest(REPLClientContext context, String[] args) {
+        public com.oracle.truffle.tools.debug.shell.REPLMessage createRequest(REPLClientContext context, String[] args) {
             if (context.level() == 0) {
                 context.displayFailReply("no active execution");
                 return null;
@@ -395,11 +394,11 @@ public abstract class REPLRemoteCommand extends REPLCommand {
         }
 
         @Override
-        void processReply(REPLClientContext context, REPLMessage[] replies) {
-            REPLMessage firstReply = replies[0];
+        void processReply(REPLClientContext context, com.oracle.truffle.tools.debug.shell.REPLMessage[] replies) {
+            com.oracle.truffle.tools.debug.shell.REPLMessage firstReply = replies[0];
 
-            if (firstReply.get(REPLMessage.STATUS).equals(REPLMessage.FAILED)) {
-                final String result = firstReply.get(REPLMessage.DISPLAY_MSG);
+            if (firstReply.get(com.oracle.truffle.tools.debug.shell.REPLMessage.STATUS).equals(com.oracle.truffle.tools.debug.shell.REPLMessage.FAILED)) {
+                final String result = firstReply.get(com.oracle.truffle.tools.debug.shell.REPLMessage.DISPLAY_MSG);
                 context.displayFailReply(result != null ? result : firstReply.toString());
             } else {
                 context.displayStack();
@@ -417,7 +416,7 @@ public abstract class REPLRemoteCommand extends REPLCommand {
         }
 
         @Override
-        public REPLMessage createRequest(REPLClientContext context, String[] args) {
+        public com.oracle.truffle.tools.debug.shell.REPLMessage createRequest(REPLClientContext context, String[] args) {
             if (args.length == 1) {
                 context.displayFailReply("breakpoint number not speciified:  \"enable <n>\"");
             } else if (args.length > 2) {
@@ -425,9 +424,9 @@ public abstract class REPLRemoteCommand extends REPLCommand {
             } else {
                 try {
                     final int breakpointNumber = Integer.parseInt(args[1]);
-                    final REPLMessage request = new REPLMessage();
-                    request.put(REPLMessage.OP, REPLMessage.ENABLE_BREAK);
-                    request.put(REPLMessage.BREAKPOINT_ID, Integer.toString(breakpointNumber));
+                    final com.oracle.truffle.tools.debug.shell.REPLMessage request = new com.oracle.truffle.tools.debug.shell.REPLMessage();
+                    request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.OP, com.oracle.truffle.tools.debug.shell.REPLMessage.ENABLE_BREAK);
+                    request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_ID, Integer.toString(breakpointNumber));
                     return request;
                 } catch (IllegalArgumentException ex) {
                     context.displayFailReply(ex.getMessage());
@@ -437,12 +436,12 @@ public abstract class REPLRemoteCommand extends REPLCommand {
         }
 
         @Override
-        void processReply(REPLClientContext context, REPLMessage[] replies) {
-            REPLMessage firstReply = replies[0];
+        void processReply(REPLClientContext context, com.oracle.truffle.tools.debug.shell.REPLMessage[] replies) {
+            com.oracle.truffle.tools.debug.shell.REPLMessage firstReply = replies[0];
 
-            if (firstReply.get(REPLMessage.STATUS).equals(REPLMessage.SUCCEEDED)) {
-                final int breakpointNumber = firstReply.getIntValue(REPLMessage.BREAKPOINT_ID);
-                firstReply.put(REPLMessage.DISPLAY_MSG, "breakpoint " + breakpointNumber + " enabled");
+            if (firstReply.get(com.oracle.truffle.tools.debug.shell.REPLMessage.STATUS).equals(com.oracle.truffle.tools.debug.shell.REPLMessage.SUCCEEDED)) {
+                final int breakpointNumber = firstReply.getIntValue(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_ID);
+                firstReply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.DISPLAY_MSG, "breakpoint " + breakpointNumber + " enabled");
             }
             super.processReply(context, replies);
         }
@@ -460,20 +459,20 @@ public abstract class REPLRemoteCommand extends REPLCommand {
         }
 
         @Override
-        public REPLMessage createRequest(REPLClientContext context, String[] args) {
+        public com.oracle.truffle.tools.debug.shell.REPLMessage createRequest(REPLClientContext context, String[] args) {
             if (args.length > 1) {
                 final String code = args[1];
                 if (!code.isEmpty()) {
                     // Create a fake entry in the file maps and cache, based on this unique name
                     final String fakeFileName = "<eval" + ++evalCounter + ">";
                     Source.fromNamedText(fakeFileName, code);
-                    final REPLMessage request = new REPLMessage();
-                    request.put(REPLMessage.OP, REPLMessage.EVAL);
-                    request.put(REPLMessage.CODE, code);
-                    request.put(REPLMessage.SOURCE_NAME, fakeFileName);
+                    final com.oracle.truffle.tools.debug.shell.REPLMessage request = new com.oracle.truffle.tools.debug.shell.REPLMessage();
+                    request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.OP, com.oracle.truffle.tools.debug.shell.REPLMessage.EVAL);
+                    request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.CODE, code);
+                    request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.SOURCE_NAME, fakeFileName);
                     if (context.level() > 0) {
                         // Specify a requested execution context, if one exists; otherwise top level
-                        request.put(REPLMessage.FRAME_NUMBER, Integer.toString(context.getSelectedFrameNumber()));
+                        request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.FRAME_NUMBER, Integer.toString(context.getSelectedFrameNumber()));
                     }
                     return request;
                 }
@@ -492,10 +491,10 @@ public abstract class REPLRemoteCommand extends REPLCommand {
         }
 
         @Override
-        public REPLMessage createRequest(REPLClientContext context, String[] args) {
-            final REPLMessage request = EVAL_CMD.createRequest(context, args);
+        public com.oracle.truffle.tools.debug.shell.REPLMessage createRequest(REPLClientContext context, String[] args) {
+            final com.oracle.truffle.tools.debug.shell.REPLMessage request = EVAL_CMD.createRequest(context, args);
             if (request != null) {
-                request.put(REPLMessage.STEP_INTO, REPLMessage.TRUE);
+                request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.STEP_INTO, com.oracle.truffle.tools.debug.shell.REPLMessage.TRUE);
             }
             return request;
         }
@@ -511,13 +510,13 @@ public abstract class REPLRemoteCommand extends REPLCommand {
         }
 
         @Override
-        public REPLMessage createRequest(REPLClientContext context, String[] args) {
+        public com.oracle.truffle.tools.debug.shell.REPLMessage createRequest(REPLClientContext context, String[] args) {
             if (context.level() == 0) {
                 context.displayFailReply("no active execution");
                 return null;
             }
-            final REPLMessage request = new REPLMessage();
-            request.put(REPLMessage.OP, REPLMessage.FRAME);
+            final com.oracle.truffle.tools.debug.shell.REPLMessage request = new com.oracle.truffle.tools.debug.shell.REPLMessage();
+            request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.OP, com.oracle.truffle.tools.debug.shell.REPLMessage.FRAME);
 
             int frameNumber = context.getSelectedFrameNumber();
             if (args.length > 1) {
@@ -531,26 +530,26 @@ public abstract class REPLRemoteCommand extends REPLCommand {
                     throw new IllegalArgumentException("Unrecognized argument \"" + args[2] + "\"");
                 }
             }
-            request.put(REPLMessage.FRAME_NUMBER, Integer.toString(frameNumber));
+            request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.FRAME_NUMBER, Integer.toString(frameNumber));
             return request;
         }
 
         @Override
-        void processReply(REPLClientContext context, REPLMessage[] replies) {
-            if (replies[0].get(REPLMessage.STATUS).equals(REPLMessage.FAILED)) {
-                context.displayFailReply(replies[0].get(REPLMessage.DISPLAY_MSG));
+        void processReply(REPLClientContext context, com.oracle.truffle.tools.debug.shell.REPLMessage[] replies) {
+            if (replies[0].get(com.oracle.truffle.tools.debug.shell.REPLMessage.STATUS).equals(com.oracle.truffle.tools.debug.shell.REPLMessage.FAILED)) {
+                context.displayFailReply(replies[0].get(com.oracle.truffle.tools.debug.shell.REPLMessage.DISPLAY_MSG));
             } else {
-                Integer frameNumber = replies[0].getIntValue(REPLMessage.FRAME_NUMBER);
+                Integer frameNumber = replies[0].getIntValue(com.oracle.truffle.tools.debug.shell.REPLMessage.FRAME_NUMBER);
                 context.selectFrameNumber(frameNumber);
-                if (replies[0].get(REPLMessage.SLOT_INDEX) == null) {
+                if (replies[0].get(com.oracle.truffle.tools.debug.shell.REPLMessage.SLOT_INDEX) == null) {
                     context.displayReply("Frame " + frameNumber + ": <empty");
                 } else {
                     context.displayReply("Frame " + frameNumber + ":");
-                    for (REPLMessage message : replies) {
+                    for (com.oracle.truffle.tools.debug.shell.REPLMessage message : replies) {
                         final StringBuilder sb = new StringBuilder();
-                        sb.append("#" + message.get(REPLMessage.SLOT_INDEX) + ": ");
-                        sb.append(message.get(REPLMessage.SLOT_ID) + " = ");
-                        sb.append(message.get(REPLMessage.SLOT_VALUE));
+                        sb.append("#" + message.get(com.oracle.truffle.tools.debug.shell.REPLMessage.SLOT_INDEX) + ": ");
+                        sb.append(message.get(com.oracle.truffle.tools.debug.shell.REPLMessage.SLOT_ID) + " = ");
+                        sb.append(message.get(com.oracle.truffle.tools.debug.shell.REPLMessage.SLOT_VALUE));
                         context.displayInfo(sb.toString());
                     }
                 }
@@ -561,23 +560,23 @@ public abstract class REPLRemoteCommand extends REPLCommand {
     public static final REPLRemoteCommand KILL_CMD = new REPLRemoteCommand("kill", null, "Stop program execution") {
 
         @Override
-        public REPLMessage createRequest(REPLClientContext context, String[] args) {
+        public com.oracle.truffle.tools.debug.shell.REPLMessage createRequest(REPLClientContext context, String[] args) {
             if (context.level() == 0) {
                 context.displayFailReply("no active execution");
                 return null;
             }
-            final REPLMessage request = new REPLMessage();
-            request.put(REPLMessage.OP, "kill");
+            final com.oracle.truffle.tools.debug.shell.REPLMessage request = new com.oracle.truffle.tools.debug.shell.REPLMessage();
+            request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.OP, "kill");
             context.displayKillMessage(null);
             return request;
         }
 
         @Override
-        void processReply(REPLClientContext context, REPLMessage[] replies) {
-            if (replies[0].get(REPLMessage.STATUS).equals(REPLMessage.SUCCEEDED)) {
-                context.displayReply(replies[0].get(REPLMessage.DISPLAY_MSG));
+        void processReply(REPLClientContext context, com.oracle.truffle.tools.debug.shell.REPLMessage[] replies) {
+            if (replies[0].get(com.oracle.truffle.tools.debug.shell.REPLMessage.STATUS).equals(com.oracle.truffle.tools.debug.shell.REPLMessage.SUCCEEDED)) {
+                context.displayReply(replies[0].get(com.oracle.truffle.tools.debug.shell.REPLMessage.DISPLAY_MSG));
             } else {
-                context.displayFailReply(replies[0].get(REPLMessage.DISPLAY_MSG));
+                context.displayFailReply(replies[0].get(com.oracle.truffle.tools.debug.shell.REPLMessage.DISPLAY_MSG));
             }
             throw new REPLContinueException();
         }
@@ -593,7 +592,7 @@ public abstract class REPLRemoteCommand extends REPLCommand {
         }
 
         @Override
-        public REPLMessage createRequest(REPLClientContext context, String[] args) {
+        public com.oracle.truffle.tools.debug.shell.REPLMessage createRequest(REPLClientContext context, String[] args) {
             Source runSource = null;
             if (args.length == 1) {
                 runSource = context.getSelectedSource();
@@ -609,9 +608,9 @@ public abstract class REPLRemoteCommand extends REPLCommand {
                     return null;
                 }
             }
-            final REPLMessage request = new REPLMessage();
-            request.put(REPLMessage.OP, REPLMessage.LOAD_SOURCE);
-            request.put(REPLMessage.SOURCE_NAME, runSource.getPath());
+            final com.oracle.truffle.tools.debug.shell.REPLMessage request = new com.oracle.truffle.tools.debug.shell.REPLMessage();
+            request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.OP, com.oracle.truffle.tools.debug.shell.REPLMessage.LOAD_SOURCE);
+            request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.SOURCE_NAME, runSource.getPath());
             return request;
         }
     };
@@ -626,10 +625,10 @@ public abstract class REPLRemoteCommand extends REPLCommand {
         }
 
         @Override
-        public REPLMessage createRequest(REPLClientContext context, String[] args) {
-            final REPLMessage request = LOAD_CMD.createRequest(context, args);
+        public com.oracle.truffle.tools.debug.shell.REPLMessage createRequest(REPLClientContext context, String[] args) {
+            final com.oracle.truffle.tools.debug.shell.REPLMessage request = LOAD_CMD.createRequest(context, args);
             if (request != null) {
-                request.put(REPLMessage.STEP_INTO, REPLMessage.TRUE);
+                request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.STEP_INTO, com.oracle.truffle.tools.debug.shell.REPLMessage.TRUE);
             }
             return request;
         }
@@ -645,18 +644,18 @@ public abstract class REPLRemoteCommand extends REPLCommand {
         }
 
         @Override
-        public REPLMessage createRequest(REPLClientContext context, String[] args) {
+        public com.oracle.truffle.tools.debug.shell.REPLMessage createRequest(REPLClientContext context, String[] args) {
 
-            final REPLMessage request = new REPLMessage();
-            request.put(REPLMessage.OP, REPLMessage.SET_LANGUAGE);
+            final com.oracle.truffle.tools.debug.shell.REPLMessage request = new com.oracle.truffle.tools.debug.shell.REPLMessage();
+            request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.OP, com.oracle.truffle.tools.debug.shell.REPLMessage.SET_LANGUAGE);
             if (args.length > 1) {
-                request.put(REPLMessage.LANG_NAME, args[1]);
+                request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.LANG_NAME, args[1]);
             }
             return request;
         }
 
         @Override
-        void processReply(REPLClientContext context, REPLMessage[] replies) {
+        void processReply(REPLClientContext context, com.oracle.truffle.tools.debug.shell.REPLMessage[] replies) {
             context.updatePrompt();
             super.processReply(context, replies);
         }
@@ -673,20 +672,20 @@ public abstract class REPLRemoteCommand extends REPLCommand {
         }
 
         @Override
-        public REPLMessage createRequest(REPLClientContext context, String[] args) {
+        public com.oracle.truffle.tools.debug.shell.REPLMessage createRequest(REPLClientContext context, String[] args) {
             if (context.level() == 0) {
                 context.displayFailReply("no active execution");
                 return null;
             }
-            final REPLMessage request = new REPLMessage();
-            request.put(REPLMessage.OP, REPLMessage.STEP_INTO);
+            final com.oracle.truffle.tools.debug.shell.REPLMessage request = new com.oracle.truffle.tools.debug.shell.REPLMessage();
+            request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.OP, com.oracle.truffle.tools.debug.shell.REPLMessage.STEP_INTO);
 
             if (args.length >= 2) {
                 final String nText = args[1];
                 try {
                     final int nSteps = Integer.parseInt(nText);
                     if (nSteps > 0) {
-                        request.put(REPLMessage.REPEAT, Integer.toString(nSteps));
+                        request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.REPEAT, Integer.toString(nSteps));
                     } else {
                         return null;
                     }
@@ -699,7 +698,7 @@ public abstract class REPLRemoteCommand extends REPLCommand {
         }
 
         @Override
-        void processReply(REPLClientContext context, REPLMessage[] replies) {
+        void processReply(REPLClientContext context, com.oracle.truffle.tools.debug.shell.REPLMessage[] replies) {
 
             throw new REPLContinueException();
         }
@@ -708,18 +707,18 @@ public abstract class REPLRemoteCommand extends REPLCommand {
     public static final REPLRemoteCommand STEP_OUT_CMD = new REPLRemoteCommand("finish", null, "(StepOut) return from function") {
 
         @Override
-        public REPLMessage createRequest(REPLClientContext context, String[] args) {
+        public com.oracle.truffle.tools.debug.shell.REPLMessage createRequest(REPLClientContext context, String[] args) {
             if (context.level() == 0) {
                 context.displayFailReply("no active execution");
                 return null;
             }
-            final REPLMessage request = new REPLMessage();
-            request.put(REPLMessage.OP, REPLMessage.STEP_OUT);
+            final com.oracle.truffle.tools.debug.shell.REPLMessage request = new com.oracle.truffle.tools.debug.shell.REPLMessage();
+            request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.OP, com.oracle.truffle.tools.debug.shell.REPLMessage.STEP_OUT);
             return request;
         }
 
         @Override
-        void processReply(REPLClientContext context, REPLMessage[] replies) {
+        void processReply(REPLClientContext context, com.oracle.truffle.tools.debug.shell.REPLMessage[] replies) {
 
             throw new REPLContinueException();
         }
@@ -736,20 +735,20 @@ public abstract class REPLRemoteCommand extends REPLCommand {
         }
 
         @Override
-        public REPLMessage createRequest(REPLClientContext context, String[] args) {
+        public com.oracle.truffle.tools.debug.shell.REPLMessage createRequest(REPLClientContext context, String[] args) {
             if (context.level() == 0) {
                 context.displayFailReply("no active execution");
                 return null;
             }
-            final REPLMessage request = new REPLMessage();
-            request.put(REPLMessage.OP, REPLMessage.STEP_OVER);
+            final com.oracle.truffle.tools.debug.shell.REPLMessage request = new com.oracle.truffle.tools.debug.shell.REPLMessage();
+            request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.OP, com.oracle.truffle.tools.debug.shell.REPLMessage.STEP_OVER);
 
             if (args.length >= 2) {
                 final String nText = args[1];
                 try {
                     final int nSteps = Integer.parseInt(nText);
                     if (nSteps > 0) {
-                        request.put(REPLMessage.REPEAT, Integer.toString(nSteps));
+                        request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.REPEAT, Integer.toString(nSteps));
                     } else {
                         return null;
                     }
@@ -762,7 +761,7 @@ public abstract class REPLRemoteCommand extends REPLCommand {
         }
 
         @Override
-        void processReply(REPLClientContext context, REPLMessage[] replies) {
+        void processReply(REPLClientContext context, com.oracle.truffle.tools.debug.shell.REPLMessage[] replies) {
 
             throw new REPLContinueException();
         }
@@ -771,7 +770,7 @@ public abstract class REPLRemoteCommand extends REPLCommand {
     public static final REPLRemoteCommand UP_CMD = new REPLRemoteCommand("up", null, "Move up a stack frame") {
 
         @Override
-        public REPLMessage createRequest(REPLClientContext context, String[] args) {
+        public com.oracle.truffle.tools.debug.shell.REPLMessage createRequest(REPLClientContext context, String[] args) {
             if (context.level() == 0) {
                 context.displayFailReply("no active execution");
                 return null;
@@ -786,11 +785,11 @@ public abstract class REPLRemoteCommand extends REPLCommand {
         }
 
         @Override
-        void processReply(REPLClientContext context, REPLMessage[] replies) {
-            REPLMessage firstReply = replies[0];
+        void processReply(REPLClientContext context, com.oracle.truffle.tools.debug.shell.REPLMessage[] replies) {
+            com.oracle.truffle.tools.debug.shell.REPLMessage firstReply = replies[0];
 
-            if (firstReply.get(REPLMessage.STATUS).equals(REPLMessage.FAILED)) {
-                final String result = firstReply.get(REPLMessage.DISPLAY_MSG);
+            if (firstReply.get(com.oracle.truffle.tools.debug.shell.REPLMessage.STATUS).equals(com.oracle.truffle.tools.debug.shell.REPLMessage.FAILED)) {
+                final String result = firstReply.get(com.oracle.truffle.tools.debug.shell.REPLMessage.DISPLAY_MSG);
                 context.displayFailReply(result != null ? result : firstReply.toString());
             } else {
                 context.displayStack();

--- a/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/client/REPLRemoteCommand.java
+++ b/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/client/REPLRemoteCommand.java
@@ -31,7 +31,7 @@ import java.util.List;
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.tools.debug.shell.REPLMessage;
 
-// TODO (mlvdv)  write a real command line parser
+@SuppressWarnings("deprecation")
 public abstract class REPLRemoteCommand extends REPLCommand {
 
     public REPLRemoteCommand(String command, String abbreviation, String description) {

--- a/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/client/REPLineLocation.java
+++ b/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/client/REPLineLocation.java
@@ -24,12 +24,10 @@
  */
 package com.oracle.truffle.tools.debug.shell.client;
 
-import com.oracle.truffle.api.source.Source;
-import com.oracle.truffle.tools.debug.shell.REPLMessage;
-
 import java.io.IOException;
 
-@SuppressWarnings("deprecation")
+import com.oracle.truffle.api.source.Source;
+
 final class REPLineLocation {
 
     private final Source source;
@@ -103,11 +101,12 @@ final class REPLineLocation {
      *
      * @param op the operation to be performed on this location
      */
-    public REPLMessage createMessage(String op) {
-        final REPLMessage msg = new REPLMessage(REPLMessage.OP, op);
-        msg.put(REPLMessage.SOURCE_NAME, source.getShortName());
-        msg.put(REPLMessage.FILE_PATH, source.getPath());
-        msg.put(REPLMessage.LINE_NUMBER, Integer.toString(lineNumber));
+    @SuppressWarnings("deprecation")
+    public com.oracle.truffle.tools.debug.shell.REPLMessage createMessage(String op) {
+        final com.oracle.truffle.tools.debug.shell.REPLMessage msg = new com.oracle.truffle.tools.debug.shell.REPLMessage(com.oracle.truffle.tools.debug.shell.REPLMessage.OP, op);
+        msg.put(com.oracle.truffle.tools.debug.shell.REPLMessage.SOURCE_NAME, source.getShortName());
+        msg.put(com.oracle.truffle.tools.debug.shell.REPLMessage.FILE_PATH, source.getPath());
+        msg.put(com.oracle.truffle.tools.debug.shell.REPLMessage.LINE_NUMBER, Integer.toString(lineNumber));
         return msg;
     }
 

--- a/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/client/REPLineLocation.java
+++ b/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/client/REPLineLocation.java
@@ -26,8 +26,10 @@ package com.oracle.truffle.tools.debug.shell.client;
 
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.tools.debug.shell.REPLMessage;
+
 import java.io.IOException;
 
+@SuppressWarnings("deprecation")
 final class REPLineLocation {
 
     private final Source source;

--- a/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/client/SimpleREPLClient.java
+++ b/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/client/SimpleREPLClient.java
@@ -79,6 +79,7 @@ import com.oracle.truffle.tools.debug.shell.server.REPLServer;
  * @see REPLServer
  * @see REPLMessage
  */
+@SuppressWarnings("deprecation")
 public class SimpleREPLClient implements REPLClient {
 
     // TODO (mlvdv) Temporarily in hybrid mode; will work either single language or multi (sort of)

--- a/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/client/SimpleREPLClient.java
+++ b/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/client/SimpleREPLClient.java
@@ -39,8 +39,6 @@ import java.util.TreeSet;
 import jline.console.ConsoleReader;
 
 import com.oracle.truffle.api.source.Source;
-import com.oracle.truffle.tools.debug.shell.REPLClient;
-import com.oracle.truffle.tools.debug.shell.REPLMessage;
 import com.oracle.truffle.tools.debug.shell.server.REPLServer;
 
 /**
@@ -77,10 +75,10 @@ import com.oracle.truffle.tools.debug.shell.server.REPLServer;
  * </ol>
  *
  * @see REPLServer
- * @see REPLMessage
+ * @see com.oracle.truffle.tools.debug.shell.com.oracle.truffle.tools.debug.shell.REPLMessage
  */
 @SuppressWarnings("deprecation")
-public class SimpleREPLClient implements REPLClient {
+public class SimpleREPLClient implements com.oracle.truffle.tools.debug.shell.REPLClient {
 
     // TODO (mlvdv) Temporarily in hybrid mode; will work either single language or multi (sort of)
 
@@ -213,13 +211,14 @@ public class SimpleREPLClient implements REPLClient {
     }
 
     private void showWelcome() {
-        final REPLMessage request = new REPLMessage(REPLMessage.OP, REPLMessage.INFO);
-        request.put(REPLMessage.TOPIC, REPLMessage.WELCOME_MESSAGE);
-        final REPLMessage[] replies = clientContext.sendToServer(request);
-        if (replies[0].get(REPLMessage.STATUS).equals(REPLMessage.FAILED)) {
+        final com.oracle.truffle.tools.debug.shell.REPLMessage request = new com.oracle.truffle.tools.debug.shell.REPLMessage(
+                        com.oracle.truffle.tools.debug.shell.REPLMessage.OP, com.oracle.truffle.tools.debug.shell.REPLMessage.INFO);
+        request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.TOPIC, com.oracle.truffle.tools.debug.shell.REPLMessage.WELCOME_MESSAGE);
+        final com.oracle.truffle.tools.debug.shell.REPLMessage[] replies = clientContext.sendToServer(request);
+        if (replies[0].get(com.oracle.truffle.tools.debug.shell.REPLMessage.STATUS).equals(com.oracle.truffle.tools.debug.shell.REPLMessage.FAILED)) {
             clientContext.displayReply("Welcome");
         } else {
-            clientContext.displayReply(replies[0].get(REPLMessage.INFO_VALUE));
+            clientContext.displayReply(replies[0].get(com.oracle.truffle.tools.debug.shell.REPLMessage.INFO_VALUE));
         }
     }
 
@@ -257,16 +256,16 @@ public class SimpleREPLClient implements REPLClient {
         /**
          * Create a new context on the occasion of an execution halting.
          */
-        ClientContextImpl(ClientContextImpl predecessor, REPLMessage message) {
+        ClientContextImpl(ClientContextImpl predecessor, com.oracle.truffle.tools.debug.shell.REPLMessage message) {
             this.predecessor = predecessor;
             this.level = predecessor == null ? 0 : predecessor.level + 1;
 
             if (message != null) {
-                final String sourceName = message.get(REPLMessage.SOURCE_NAME);
+                final String sourceName = message.get(com.oracle.truffle.tools.debug.shell.REPLMessage.SOURCE_NAME);
                 try {
                     this.haltedSource = Source.fromFileName(sourceName);
                 } catch (IOException ex) {
-                    final String code = message.get(REPLMessage.SOURCE_TEXT);
+                    final String code = message.get(com.oracle.truffle.tools.debug.shell.REPLMessage.SOURCE_TEXT);
                     if (code != null) {
                         this.haltedSource = Source.fromText(code, sourceName);
                     }
@@ -274,7 +273,7 @@ public class SimpleREPLClient implements REPLClient {
                 if (this.haltedSource != null) {
                     selectedSource = haltedSource;
                     try {
-                        haltedLineNumber = Integer.parseInt(message.get(REPLMessage.LINE_NUMBER));
+                        haltedLineNumber = Integer.parseInt(message.get(com.oracle.truffle.tools.debug.shell.REPLMessage.LINE_NUMBER));
                     } catch (NumberFormatException e) {
                         haltedLineNumber = 0;
                     }
@@ -300,12 +299,12 @@ public class SimpleREPLClient implements REPLClient {
         public void updatePrompt() {
 
             String languageName = "???";
-            final REPLMessage request = new REPLMessage();
-            request.put(REPLMessage.OP, REPLMessage.INFO);
-            request.put(REPLMessage.TOPIC, REPLMessage.INFO_CURRENT_LANGUAGE);
-            final REPLMessage[] replies = replServer.receive(request);
-            if (replies[0].get(REPLMessage.STATUS).equals(REPLMessage.SUCCEEDED)) {
-                languageName = replies[0].get(REPLMessage.LANG_NAME);
+            final com.oracle.truffle.tools.debug.shell.REPLMessage request = new com.oracle.truffle.tools.debug.shell.REPLMessage();
+            request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.OP, com.oracle.truffle.tools.debug.shell.REPLMessage.INFO);
+            request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.TOPIC, com.oracle.truffle.tools.debug.shell.REPLMessage.INFO_CURRENT_LANGUAGE);
+            final com.oracle.truffle.tools.debug.shell.REPLMessage[] replies = replServer.receive(request);
+            if (replies[0].get(com.oracle.truffle.tools.debug.shell.REPLMessage.STATUS).equals(com.oracle.truffle.tools.debug.shell.REPLMessage.SUCCEEDED)) {
+                languageName = replies[0].get(com.oracle.truffle.tools.debug.shell.REPLMessage.LANG_NAME);
             }
             final String showLang = languageName == null ? "() " : "( " + languageName + " )";
             if (level == 0) {
@@ -350,19 +349,20 @@ public class SimpleREPLClient implements REPLClient {
 
         public List<REPLFrame> frames() {
             if (frames == null) {
-                final REPLMessage request = new REPLMessage(REPLMessage.OP, REPLMessage.BACKTRACE);
-                final REPLMessage[] replies = sendToServer(request);
-                if (replies[0].get(REPLMessage.STATUS).equals(REPLMessage.FAILED)) {
+                final com.oracle.truffle.tools.debug.shell.REPLMessage request = new com.oracle.truffle.tools.debug.shell.REPLMessage(com.oracle.truffle.tools.debug.shell.REPLMessage.OP,
+                                com.oracle.truffle.tools.debug.shell.REPLMessage.BACKTRACE);
+                final com.oracle.truffle.tools.debug.shell.REPLMessage[] replies = sendToServer(request);
+                if (replies[0].get(com.oracle.truffle.tools.debug.shell.REPLMessage.STATUS).equals(com.oracle.truffle.tools.debug.shell.REPLMessage.FAILED)) {
                     return null;
                 }
                 frames = new ArrayList<>();
-                for (REPLMessage reply : replies) {
-                    final int index = reply.getIntValue(REPLMessage.FRAME_NUMBER);
-                    final String locationFilePath = reply.get(REPLMessage.FILE_PATH);
-                    final Integer locationLineNumber = reply.getIntValue(REPLMessage.LINE_NUMBER);
-                    final String locationDescription = reply.get(REPLMessage.SOURCE_LOCATION);
-                    final String name = reply.get(REPLMessage.METHOD_NAME);
-                    final String sourceLineText = reply.get(REPLMessage.SOURCE_LINE_TEXT);
+                for (com.oracle.truffle.tools.debug.shell.REPLMessage reply : replies) {
+                    final int index = reply.getIntValue(com.oracle.truffle.tools.debug.shell.REPLMessage.FRAME_NUMBER);
+                    final String locationFilePath = reply.get(com.oracle.truffle.tools.debug.shell.REPLMessage.FILE_PATH);
+                    final Integer locationLineNumber = reply.getIntValue(com.oracle.truffle.tools.debug.shell.REPLMessage.LINE_NUMBER);
+                    final String locationDescription = reply.get(com.oracle.truffle.tools.debug.shell.REPLMessage.SOURCE_LOCATION);
+                    final String name = reply.get(com.oracle.truffle.tools.debug.shell.REPLMessage.METHOD_NAME);
+                    final String sourceLineText = reply.get(com.oracle.truffle.tools.debug.shell.REPLMessage.SOURCE_LINE_TEXT);
                     frames.add(new REPLFrameImpl(index, locationFilePath, locationLineNumber, locationDescription, name, sourceLineText));
                 }
                 frames = Collections.unmodifiableList(frames);
@@ -384,26 +384,26 @@ public class SimpleREPLClient implements REPLClient {
 
         public String stringQuery(String op) {
             assert op != null;
-            REPLMessage request = null;
+            com.oracle.truffle.tools.debug.shell.REPLMessage request = null;
             switch (op) {
-                case REPLMessage.TRUFFLE_AST:
+                case com.oracle.truffle.tools.debug.shell.REPLMessage.TRUFFLE_AST:
                     request = truffleASTCommand.createRequest(clientContext, NULL_ARGS);
                     break;
-                case REPLMessage.TRUFFLE_SUBTREE:
+                case com.oracle.truffle.tools.debug.shell.REPLMessage.TRUFFLE_SUBTREE:
                     request = truffleSubtreeCommand.createRequest(clientContext, NULL_ARGS);
                     break;
                 default:
-                    request = new REPLMessage();
-                    request.put(REPLMessage.OP, op);
+                    request = new com.oracle.truffle.tools.debug.shell.REPLMessage();
+                    request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.OP, op);
             }
             if (request == null) {
                 return null;
             }
-            final REPLMessage[] replies = sendToServer(request);
-            if (replies[0].get(REPLMessage.STATUS).equals(REPLMessage.FAILED)) {
+            final com.oracle.truffle.tools.debug.shell.REPLMessage[] replies = sendToServer(request);
+            if (replies[0].get(com.oracle.truffle.tools.debug.shell.REPLMessage.STATUS).equals(com.oracle.truffle.tools.debug.shell.REPLMessage.FAILED)) {
                 return null;
             }
-            return replies[0].get(REPLMessage.DISPLAY_MSG);
+            return replies[0].get(com.oracle.truffle.tools.debug.shell.REPLMessage.DISPLAY_MSG);
         }
 
         public void selectFrameNumber(int frameNumber) {
@@ -565,15 +565,15 @@ public class SimpleREPLClient implements REPLClient {
 
                     } else if (command instanceof REPLRemoteCommand) {
                         final REPLRemoteCommand remoteCommand = (REPLRemoteCommand) command;
-                        final REPLMessage request = remoteCommand.createRequest(clientContext, args);
+                        final com.oracle.truffle.tools.debug.shell.REPLMessage request = remoteCommand.createRequest(clientContext, args);
                         if (request == null) {
                             continue;
                         }
 
-                        REPLMessage[] replies = sendToServer(request);
+                        com.oracle.truffle.tools.debug.shell.REPLMessage[] replies = sendToServer(request);
                         remoteCommand.processReply(clientContext, replies);
 
-                        final String path = replies[0].get(REPLMessage.FILE_PATH);
+                        final String path = replies[0].get(com.oracle.truffle.tools.debug.shell.REPLMessage.FILE_PATH);
                         if (path != null && !path.isEmpty()) {
                             selectSource(path);
                         }
@@ -590,20 +590,20 @@ public class SimpleREPLClient implements REPLClient {
 
         }
 
-        private REPLMessage[] sendToServer(REPLMessage request) {
+        private com.oracle.truffle.tools.debug.shell.REPLMessage[] sendToServer(com.oracle.truffle.tools.debug.shell.REPLMessage request) {
             if (traceMessagesOption.getBool()) {
                 clientContext.traceMessage("Sever request:");
                 request.print(writer, "  ");
             }
 
-            REPLMessage[] replies = replServer.receive(request);
+            com.oracle.truffle.tools.debug.shell.REPLMessage[] replies = replServer.receive(request);
 
             assert replies != null && replies.length > 0;
             if (traceMessagesOption.getBool()) {
                 if (replies.length > 1) {
                     clientContext.traceMessage("Received " + replies.length + " server replies");
                     int replyCount = 0;
-                    for (REPLMessage reply : replies) {
+                    for (com.oracle.truffle.tools.debug.shell.REPLMessage reply : replies) {
                         clientContext.traceMessage("Server Reply " + replyCount++ + ":");
                         reply.print(writer, "  ");
                     }
@@ -663,7 +663,7 @@ public class SimpleREPLClient implements REPLClient {
 
     // Cheating with synchrony: asynchronous replies should arrive here, but don't.
     @Override
-    public REPLMessage receive(REPLMessage request) {
+    public com.oracle.truffle.tools.debug.shell.REPLMessage receive(com.oracle.truffle.tools.debug.shell.REPLMessage request) {
         final String result = request.get("result");
         clientContext.displayReply(result != null ? result : request.toString());
         return null;
@@ -673,11 +673,11 @@ public class SimpleREPLClient implements REPLClient {
      * Cheating with synchrony: take a direct call from the server that execution has halted and
      * we've entered a nested debugging context.
      */
-    public void halted(REPLMessage message) {
+    public void halted(com.oracle.truffle.tools.debug.shell.REPLMessage message) {
 
         // Push a new context for where we've stopped.
         clientContext = new ClientContextImpl(clientContext, message);
-        final String warnings = message.get(REPLMessage.WARNINGS);
+        final String warnings = message.get(com.oracle.truffle.tools.debug.shell.REPLMessage.WARNINGS);
         if (warnings != null) {
             clientContext.displayWarnings(warnings);
         }
@@ -685,19 +685,19 @@ public class SimpleREPLClient implements REPLClient {
             clientContext.displayWhere();
         }
         if (autoNodeOption.getBool()) {
-            final String result = clientContext.stringQuery(REPLMessage.TRUFFLE_NODE);
+            final String result = clientContext.stringQuery(com.oracle.truffle.tools.debug.shell.REPLMessage.TRUFFLE_NODE);
             if (result != null) {
                 displayTruffleNode(result);
             }
         }
         if (autoASTOption.getBool()) {
-            final String result = clientContext.stringQuery(REPLMessage.TRUFFLE_AST);
+            final String result = clientContext.stringQuery(com.oracle.truffle.tools.debug.shell.REPLMessage.TRUFFLE_AST);
             if (result != null) {
                 displayTruffleAST(result);
             }
         }
         if (autoSubtreeOption.getBool()) {
-            final String result = clientContext.stringQuery(REPLMessage.TRUFFLE_SUBTREE);
+            final String result = clientContext.stringQuery(com.oracle.truffle.tools.debug.shell.REPLMessage.TRUFFLE_SUBTREE);
             if (result != null) {
                 displayTruffleSubtree(result);
             }
@@ -761,7 +761,7 @@ public class SimpleREPLClient implements REPLClient {
         }
 
         @Override
-        public REPLMessage createRequest(REPLClientContext context, String[] args) {
+        public com.oracle.truffle.tools.debug.shell.REPLMessage createRequest(REPLClientContext context, String[] args) {
             if (args.length == 1) {
                 final Source source = clientContext.getSelectedSource();
                 if (source == null) {
@@ -771,29 +771,29 @@ public class SimpleREPLClient implements REPLClient {
                 }
                 return null;
             }
-            final REPLMessage request = new REPLMessage();
-            request.put(REPLMessage.OP, REPLMessage.FILE);
-            request.put(REPLMessage.SOURCE_NAME, args[1]);
+            final com.oracle.truffle.tools.debug.shell.REPLMessage request = new com.oracle.truffle.tools.debug.shell.REPLMessage();
+            request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.OP, com.oracle.truffle.tools.debug.shell.REPLMessage.FILE);
+            request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.SOURCE_NAME, args[1]);
             return request;
         }
 
         @Override
-        void processReply(REPLClientContext context, REPLMessage[] replies) {
-            REPLMessage firstReply = replies[0];
+        void processReply(REPLClientContext context, com.oracle.truffle.tools.debug.shell.REPLMessage[] replies) {
+            com.oracle.truffle.tools.debug.shell.REPLMessage firstReply = replies[0];
 
-            if (firstReply.get(REPLMessage.STATUS).equals(REPLMessage.FAILED)) {
-                final String result = firstReply.get(REPLMessage.DISPLAY_MSG);
+            if (firstReply.get(com.oracle.truffle.tools.debug.shell.REPLMessage.STATUS).equals(com.oracle.truffle.tools.debug.shell.REPLMessage.FAILED)) {
+                final String result = firstReply.get(com.oracle.truffle.tools.debug.shell.REPLMessage.DISPLAY_MSG);
                 clientContext.displayFailReply(result != null ? result : firstReply.toString());
                 return;
             }
-            final String fileName = firstReply.get(REPLMessage.SOURCE_NAME);
-            final String path = firstReply.get(REPLMessage.FILE_PATH);
+            final String fileName = firstReply.get(com.oracle.truffle.tools.debug.shell.REPLMessage.SOURCE_NAME);
+            final String path = firstReply.get(com.oracle.truffle.tools.debug.shell.REPLMessage.FILE_PATH);
             clientContext.selectSource(path == null ? fileName : path);
             clientContext.displayReply(clientContext.getSelectedSource().getPath());
 
             for (int i = 1; i < replies.length; i++) {
-                REPLMessage reply = replies[i];
-                final String result = reply.get(REPLMessage.DISPLAY_MSG);
+                com.oracle.truffle.tools.debug.shell.REPLMessage reply = replies[i];
+                final String result = reply.get(com.oracle.truffle.tools.debug.shell.REPLMessage.DISPLAY_MSG);
                 clientContext.displayInfo(result != null ? result : reply.toString());
             }
         }
@@ -849,7 +849,7 @@ public class SimpleREPLClient implements REPLClient {
         }
     };
 
-    private final REPLIndirectCommand infoCommand = new REPLIndirectCommand(REPLMessage.INFO, null, "Additional information on topics") {
+    private final REPLIndirectCommand infoCommand = new REPLIndirectCommand(com.oracle.truffle.tools.debug.shell.REPLMessage.INFO, null, "Additional information on topics") {
 
         // "Info" commands
         private final Map<String, REPLCommand> infoCommandMap = new HashMap<>();
@@ -861,9 +861,9 @@ public class SimpleREPLClient implements REPLClient {
             for (String infoCommandName : infoCommandNames) {
                 final REPLCommand cmd = infoCommandMap.get(infoCommandName);
                 if (cmd == null) {
-                    lines.add("\"" + REPLMessage.INFO + " " + infoCommandName + "\" not implemented");
+                    lines.add("\"" + com.oracle.truffle.tools.debug.shell.REPLMessage.INFO + " " + infoCommandName + "\" not implemented");
                 } else {
-                    lines.add("\"" + REPLMessage.INFO + " " + infoCommandName + "\": " + cmd.getDescription());
+                    lines.add("\"" + com.oracle.truffle.tools.debug.shell.REPLMessage.INFO + " " + infoCommandName + "\": " + cmd.getDescription());
                 }
             }
             return lines.toArray(new String[0]);
@@ -902,23 +902,23 @@ public class SimpleREPLClient implements REPLClient {
     private final REPLCommand infoBreakCommand = new REPLRemoteCommand("breakpoint", "break", "info about breakpoints") {
 
         @Override
-        public REPLMessage createRequest(REPLClientContext context, String[] args) {
-            final REPLMessage request = new REPLMessage();
-            request.put(REPLMessage.OP, REPLMessage.BREAKPOINT_INFO);
+        public com.oracle.truffle.tools.debug.shell.REPLMessage createRequest(REPLClientContext context, String[] args) {
+            final com.oracle.truffle.tools.debug.shell.REPLMessage request = new com.oracle.truffle.tools.debug.shell.REPLMessage();
+            request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.OP, com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_INFO);
             return request;
         }
 
         @Override
-        void processReply(REPLClientContext context, REPLMessage[] replies) {
-            if (replies[0].get(REPLMessage.STATUS).equals(REPLMessage.FAILED)) {
-                clientContext.displayFailReply(replies[0].get(REPLMessage.DISPLAY_MSG));
+        void processReply(REPLClientContext context, com.oracle.truffle.tools.debug.shell.REPLMessage[] replies) {
+            if (replies[0].get(com.oracle.truffle.tools.debug.shell.REPLMessage.STATUS).equals(com.oracle.truffle.tools.debug.shell.REPLMessage.FAILED)) {
+                clientContext.displayFailReply(replies[0].get(com.oracle.truffle.tools.debug.shell.REPLMessage.DISPLAY_MSG));
             } else {
-                Arrays.sort(replies, new Comparator<REPLMessage>() {
+                Arrays.sort(replies, new Comparator<com.oracle.truffle.tools.debug.shell.REPLMessage>() {
 
-                    public int compare(REPLMessage o1, REPLMessage o2) {
+                    public int compare(com.oracle.truffle.tools.debug.shell.REPLMessage o1, com.oracle.truffle.tools.debug.shell.REPLMessage o2) {
                         try {
-                            final int n1 = Integer.parseInt(o1.get(REPLMessage.BREAKPOINT_ID));
-                            final int n2 = Integer.parseInt(o2.get(REPLMessage.BREAKPOINT_ID));
+                            final int n1 = Integer.parseInt(o1.get(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_ID));
+                            final int n2 = Integer.parseInt(o2.get(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_ID));
                             return Integer.compare(n1, n2);
                         } catch (Exception ex) {
                         }
@@ -927,17 +927,17 @@ public class SimpleREPLClient implements REPLClient {
 
                 });
                 clientContext.displayReply("Breakpoints set:");
-                for (REPLMessage message : replies) {
+                for (com.oracle.truffle.tools.debug.shell.REPLMessage message : replies) {
                     final StringBuilder sb = new StringBuilder();
 
-                    sb.append(Integer.parseInt(message.get(REPLMessage.BREAKPOINT_ID)) + ": ");
-                    sb.append("@" + message.get(REPLMessage.INFO_VALUE));
-                    sb.append(" (state=" + message.get(REPLMessage.BREAKPOINT_STATE));
+                    sb.append(Integer.parseInt(message.get(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_ID)) + ": ");
+                    sb.append("@" + message.get(com.oracle.truffle.tools.debug.shell.REPLMessage.INFO_VALUE));
+                    sb.append(" (state=" + message.get(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_STATE));
                     if (verboseBreakpointInfoOption.getBool()) {
-                        sb.append(", hits=" + Integer.parseInt(message.get(REPLMessage.BREAKPOINT_HIT_COUNT)));
-                        sb.append(", ignore=" + Integer.parseInt(message.get(REPLMessage.BREAKPOINT_IGNORE_COUNT)));
+                        sb.append(", hits=" + Integer.parseInt(message.get(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_HIT_COUNT)));
+                        sb.append(", ignore=" + Integer.parseInt(message.get(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_IGNORE_COUNT)));
                     }
-                    final String condition = message.get(REPLMessage.BREAKPOINT_CONDITION);
+                    final String condition = message.get(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_CONDITION);
                     if (condition != null) {
                         sb.append(", condition=\"" + condition + "\"");
                     }
@@ -958,24 +958,24 @@ public class SimpleREPLClient implements REPLClient {
         }
 
         @Override
-        public REPLMessage createRequest(REPLClientContext context, String[] args) {
-            final REPLMessage request = new REPLMessage();
-            request.put(REPLMessage.OP, REPLMessage.INFO);
-            request.put(REPLMessage.TOPIC, REPLMessage.INFO_SUPPORTED_LANGUAGES);
+        public com.oracle.truffle.tools.debug.shell.REPLMessage createRequest(REPLClientContext context, String[] args) {
+            final com.oracle.truffle.tools.debug.shell.REPLMessage request = new com.oracle.truffle.tools.debug.shell.REPLMessage();
+            request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.OP, com.oracle.truffle.tools.debug.shell.REPLMessage.INFO);
+            request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.TOPIC, com.oracle.truffle.tools.debug.shell.REPLMessage.INFO_SUPPORTED_LANGUAGES);
             return request;
         }
 
         @Override
-        void processReply(REPLClientContext context, REPLMessage[] replies) {
-            if (replies[0].get(REPLMessage.STATUS).equals(REPLMessage.FAILED)) {
-                clientContext.displayFailReply(replies[0].get(REPLMessage.DISPLAY_MSG));
+        void processReply(REPLClientContext context, com.oracle.truffle.tools.debug.shell.REPLMessage[] replies) {
+            if (replies[0].get(com.oracle.truffle.tools.debug.shell.REPLMessage.STATUS).equals(com.oracle.truffle.tools.debug.shell.REPLMessage.FAILED)) {
+                clientContext.displayFailReply(replies[0].get(com.oracle.truffle.tools.debug.shell.REPLMessage.DISPLAY_MSG));
             } else {
                 clientContext.displayReply("Languages supported:");
-                for (REPLMessage message : replies) {
+                for (com.oracle.truffle.tools.debug.shell.REPLMessage message : replies) {
                     final StringBuilder sb = new StringBuilder();
-                    sb.append(message.get(REPLMessage.LANG_NAME));
+                    sb.append(message.get(com.oracle.truffle.tools.debug.shell.REPLMessage.LANG_NAME));
                     sb.append(" ver. ");
-                    sb.append(message.get(REPLMessage.LANG_VER));
+                    sb.append(message.get(com.oracle.truffle.tools.debug.shell.REPLMessage.LANG_VER));
                     clientContext.displayInfo(sb.toString());
                 }
             }
@@ -1080,7 +1080,7 @@ public class SimpleREPLClient implements REPLClient {
     private final REPLCommand quitCommand = new REPLRemoteCommand("quit", "q", "Quit execution and REPL") {
 
         @Override
-        protected REPLMessage createRequest(REPLClientContext context, String[] args) {
+        protected com.oracle.truffle.tools.debug.shell.REPLMessage createRequest(REPLClientContext context, String[] args) {
             return null;
         }
 
@@ -1095,7 +1095,7 @@ public class SimpleREPLClient implements REPLClient {
 
         @Override
         public void execute(String[] args) {
-            REPLMessage request = null;
+            com.oracle.truffle.tools.debug.shell.REPLMessage request = null;
             if (args.length == 1) {
                 clientContext.displayFailReply("No option specified, try \"help set\"");
             } else if (args.length == 2) {
@@ -1120,10 +1120,10 @@ public class SimpleREPLClient implements REPLClient {
                         }
                         clientContext.displayInfo(localOption.name + " = " + localOption.getValue());
                     } else {
-                        request = new REPLMessage();
-                        request.put(REPLMessage.OP, REPLMessage.SET);
-                        request.put(REPLMessage.OPTION, optionName);
-                        request.put(REPLMessage.VALUE, newValue);
+                        request = new com.oracle.truffle.tools.debug.shell.REPLMessage();
+                        request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.OP, com.oracle.truffle.tools.debug.shell.REPLMessage.SET);
+                        request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.OPTION, optionName);
+                        request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.VALUE, newValue);
                     }
                 }
             } else {
@@ -1132,7 +1132,7 @@ public class SimpleREPLClient implements REPLClient {
         }
     };
 
-    private final REPLIndirectCommand truffleCommand = new REPLIndirectCommand(REPLMessage.TRUFFLE, "t", "Access to Truffle internals") {
+    private final REPLIndirectCommand truffleCommand = new REPLIndirectCommand(com.oracle.truffle.tools.debug.shell.REPLMessage.TRUFFLE, "t", "Access to Truffle internals") {
 
         // "Truffle" commands
         private final Map<String, REPLCommand> truffleCommandMap = new HashMap<>();
@@ -1144,7 +1144,7 @@ public class SimpleREPLClient implements REPLClient {
             for (String truffleCommandName : truffleCommandNames) {
                 final REPLCommand cmd = truffleCommandMap.get(truffleCommandName);
                 if (cmd == null) {
-                    lines.add("\"" + REPLMessage.TRUFFLE + " " + truffleCommandName + "\" not implemented");
+                    lines.add("\"" + com.oracle.truffle.tools.debug.shell.REPLMessage.TRUFFLE + " " + truffleCommandName + "\" not implemented");
                 } else {
                     for (String line : cmd.getHelp()) {
                         lines.add(line);
@@ -1193,15 +1193,15 @@ public class SimpleREPLClient implements REPLClient {
         }
 
         @Override
-        public REPLMessage createRequest(REPLClientContext context, String[] args) {
+        public com.oracle.truffle.tools.debug.shell.REPLMessage createRequest(REPLClientContext context, String[] args) {
             if (clientContext.level() == 0) {
                 context.displayFailReply("no active execution");
                 return null;
             }
 
-            final REPLMessage request = new REPLMessage();
-            request.put(REPLMessage.OP, REPLMessage.TRUFFLE);
-            request.put(REPLMessage.TOPIC, REPLMessage.AST);
+            final com.oracle.truffle.tools.debug.shell.REPLMessage request = new com.oracle.truffle.tools.debug.shell.REPLMessage();
+            request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.OP, com.oracle.truffle.tools.debug.shell.REPLMessage.TRUFFLE);
+            request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.TOPIC, com.oracle.truffle.tools.debug.shell.REPLMessage.AST);
 
             int astDepth = astDepthOption.getInt();
             if (args.length > 2) {
@@ -1211,18 +1211,18 @@ public class SimpleREPLClient implements REPLClient {
                 } catch (NumberFormatException e) {
                 }
             }
-            request.put(REPLMessage.AST_DEPTH, Integer.toString(astDepth));
+            request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.AST_DEPTH, Integer.toString(astDepth));
             return request;
         }
 
         @Override
-        void processReply(REPLClientContext context, REPLMessage[] replies) {
-            if (replies[0].get(REPLMessage.STATUS).equals(REPLMessage.FAILED)) {
-                clientContext.displayFailReply(replies[0].get(REPLMessage.DISPLAY_MSG));
+        void processReply(REPLClientContext context, com.oracle.truffle.tools.debug.shell.REPLMessage[] replies) {
+            if (replies[0].get(com.oracle.truffle.tools.debug.shell.REPLMessage.STATUS).equals(com.oracle.truffle.tools.debug.shell.REPLMessage.FAILED)) {
+                clientContext.displayFailReply(replies[0].get(com.oracle.truffle.tools.debug.shell.REPLMessage.DISPLAY_MSG));
             } else {
                 clientContext.displayReply("AST containing the Current Node:");
-                for (REPLMessage message : replies) {
-                    for (String line : message.get(REPLMessage.DISPLAY_MSG).split("\n")) {
+                for (com.oracle.truffle.tools.debug.shell.REPLMessage message : replies) {
+                    for (String line : message.get(com.oracle.truffle.tools.debug.shell.REPLMessage.DISPLAY_MSG).split("\n")) {
                         clientContext.displayInfo(line);
                     }
                 }
@@ -1247,22 +1247,22 @@ public class SimpleREPLClient implements REPLClient {
         }
 
         @Override
-        public REPLMessage createRequest(REPLClientContext context, String[] args) {
+        public com.oracle.truffle.tools.debug.shell.REPLMessage createRequest(REPLClientContext context, String[] args) {
             if (clientContext.level() == 0) {
                 context.displayFailReply("no active execution");
                 return null;
             }
-            final REPLMessage request = new REPLMessage();
-            request.put(REPLMessage.OP, REPLMessage.TRUFFLE_NODE);
+            final com.oracle.truffle.tools.debug.shell.REPLMessage request = new com.oracle.truffle.tools.debug.shell.REPLMessage();
+            request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.OP, com.oracle.truffle.tools.debug.shell.REPLMessage.TRUFFLE_NODE);
             return request;
         }
 
         @Override
-        void processReply(REPLClientContext context, REPLMessage[] replies) {
-            if (replies[0].get(REPLMessage.STATUS).equals(REPLMessage.FAILED)) {
-                clientContext.displayFailReply(replies[0].get(REPLMessage.DISPLAY_MSG));
+        void processReply(REPLClientContext context, com.oracle.truffle.tools.debug.shell.REPLMessage[] replies) {
+            if (replies[0].get(com.oracle.truffle.tools.debug.shell.REPLMessage.STATUS).equals(com.oracle.truffle.tools.debug.shell.REPLMessage.FAILED)) {
+                clientContext.displayFailReply(replies[0].get(com.oracle.truffle.tools.debug.shell.REPLMessage.DISPLAY_MSG));
             } else {
-                displayTruffleNode(replies[0].get(REPLMessage.DISPLAY_MSG));
+                displayTruffleNode(replies[0].get(com.oracle.truffle.tools.debug.shell.REPLMessage.DISPLAY_MSG));
             }
         }
     };
@@ -1282,15 +1282,15 @@ public class SimpleREPLClient implements REPLClient {
         }
 
         @Override
-        public REPLMessage createRequest(REPLClientContext context, String[] args) {
+        public com.oracle.truffle.tools.debug.shell.REPLMessage createRequest(REPLClientContext context, String[] args) {
             if (clientContext.level() == 0) {
                 context.displayFailReply("no active execution");
                 return null;
             }
 
-            final REPLMessage request = new REPLMessage();
-            request.put(REPLMessage.OP, REPLMessage.TRUFFLE);
-            request.put(REPLMessage.TOPIC, REPLMessage.SUBTREE);
+            final com.oracle.truffle.tools.debug.shell.REPLMessage request = new com.oracle.truffle.tools.debug.shell.REPLMessage();
+            request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.OP, com.oracle.truffle.tools.debug.shell.REPLMessage.TRUFFLE);
+            request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.TOPIC, com.oracle.truffle.tools.debug.shell.REPLMessage.SUBTREE);
 
             int astDepth = astDepthOption.getInt();
             if (args.length > 2) {
@@ -1300,18 +1300,18 @@ public class SimpleREPLClient implements REPLClient {
                 } catch (NumberFormatException e) {
                 }
             }
-            request.put(REPLMessage.AST_DEPTH, Integer.toString(astDepth));
+            request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.AST_DEPTH, Integer.toString(astDepth));
             return request;
         }
 
         @Override
-        void processReply(REPLClientContext context, REPLMessage[] replies) {
-            if (replies[0].get(REPLMessage.STATUS).equals(REPLMessage.FAILED)) {
-                clientContext.displayFailReply(replies[0].get(REPLMessage.DISPLAY_MSG));
+        void processReply(REPLClientContext context, com.oracle.truffle.tools.debug.shell.REPLMessage[] replies) {
+            if (replies[0].get(com.oracle.truffle.tools.debug.shell.REPLMessage.STATUS).equals(com.oracle.truffle.tools.debug.shell.REPLMessage.FAILED)) {
+                clientContext.displayFailReply(replies[0].get(com.oracle.truffle.tools.debug.shell.REPLMessage.DISPLAY_MSG));
             } else {
                 clientContext.displayReply("AST subtree at Current Node:");
-                for (REPLMessage message : replies) {
-                    for (String line : message.get(REPLMessage.DISPLAY_MSG).split("\n")) {
+                for (com.oracle.truffle.tools.debug.shell.REPLMessage message : replies) {
+                    for (String line : message.get(com.oracle.truffle.tools.debug.shell.REPLMessage.DISPLAY_MSG).split("\n")) {
                         clientContext.displayInfo(line);
                     }
                 }

--- a/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/package-info.java
+++ b/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,10 @@
  */
 
 /**
+ * <strong>Warning:</strong> The public classes in this package have been
+ * deprecated and will be removed from the Truffle public API in a subsequent
+ * release.
+ * <p>
  * This package contains <strong>REPL*</strong>: an experimental framework for
  * building a <em>language-agnostic</em> command-line oriented debugger that:
  * <ul>

--- a/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/server/REPLHandler.java
+++ b/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/server/REPLHandler.java
@@ -37,7 +37,6 @@ import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.source.SourceSection;
 import com.oracle.truffle.api.vm.PolyglotEngine.Language;
-import com.oracle.truffle.tools.debug.shell.REPLMessage;
 import com.oracle.truffle.tools.debug.shell.server.InstrumentationUtils.ASTPrinter;
 import com.oracle.truffle.tools.debug.shell.server.InstrumentationUtils.LocationPrinter;
 import com.oracle.truffle.tools.debug.shell.server.REPLServer.BreakpointInfo;
@@ -45,7 +44,8 @@ import com.oracle.truffle.tools.debug.shell.server.REPLServer.Context;
 import com.oracle.truffle.tools.debug.shell.server.REPLServer.REPLVisualizer;
 
 /**
- * Server-side REPL implementation of an {@linkplain REPLMessage "op"}.
+ * Server-side REPL implementation of an
+ * {@linkplain com.oracle.truffle.tools.debug.shell.REPLMessage "op"}.
  * <p>
  * The language-agnostic handlers are implemented here.
  */
@@ -71,62 +71,64 @@ public abstract class REPLHandler {
     /**
      * Passes a request to this handler.
      */
-    abstract REPLMessage[] receive(REPLMessage request, REPLServer replServer);
+    abstract com.oracle.truffle.tools.debug.shell.REPLMessage[] receive(com.oracle.truffle.tools.debug.shell.REPLMessage request, REPLServer replServer);
 
     /**
      * Creates skeleton for a reply message that identifies the operation currently being handled.
      */
-    REPLMessage createReply() {
-        return new REPLMessage(REPLMessage.OP, op);
+    com.oracle.truffle.tools.debug.shell.REPLMessage createReply() {
+        return new com.oracle.truffle.tools.debug.shell.REPLMessage(com.oracle.truffle.tools.debug.shell.REPLMessage.OP, op);
     }
 
     /**
      * Completes a reply, reporting and explaining successful handling.
      */
-    protected static final REPLMessage[] finishReplySucceeded(REPLMessage reply, String explanation) {
-        reply.put(REPLMessage.STATUS, REPLMessage.SUCCEEDED);
-        reply.put(REPLMessage.DISPLAY_MSG, explanation);
-        final REPLMessage[] replies = new REPLMessage[]{reply};
+    protected static final com.oracle.truffle.tools.debug.shell.REPLMessage[] finishReplySucceeded(com.oracle.truffle.tools.debug.shell.REPLMessage reply, String explanation) {
+        reply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.STATUS, com.oracle.truffle.tools.debug.shell.REPLMessage.SUCCEEDED);
+        reply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.DISPLAY_MSG, explanation);
+        final com.oracle.truffle.tools.debug.shell.REPLMessage[] replies = new com.oracle.truffle.tools.debug.shell.REPLMessage[]{reply};
         return replies;
     }
 
     /**
      * Completes a reply, reporting and explaining failed handling.
      */
-    protected static final REPLMessage[] finishReplyFailed(REPLMessage reply, String explanation) {
-        reply.put(REPLMessage.STATUS, REPLMessage.FAILED);
-        reply.put(REPLMessage.DISPLAY_MSG, explanation);
-        final REPLMessage[] replies = new REPLMessage[]{reply};
+    protected static final com.oracle.truffle.tools.debug.shell.REPLMessage[] finishReplyFailed(com.oracle.truffle.tools.debug.shell.REPLMessage reply, String explanation) {
+        reply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.STATUS, com.oracle.truffle.tools.debug.shell.REPLMessage.FAILED);
+        reply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.DISPLAY_MSG, explanation);
+        final com.oracle.truffle.tools.debug.shell.REPLMessage[] replies = new com.oracle.truffle.tools.debug.shell.REPLMessage[]{reply};
         return replies;
     }
 
-    protected static final REPLMessage[] finishReplyFailed(REPLMessage reply, Exception ex) {
-        reply.put(REPLMessage.STATUS, REPLMessage.FAILED);
+    protected static final com.oracle.truffle.tools.debug.shell.REPLMessage[] finishReplyFailed(com.oracle.truffle.tools.debug.shell.REPLMessage reply, Exception ex) {
+        reply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.STATUS, com.oracle.truffle.tools.debug.shell.REPLMessage.FAILED);
         String message = ex.getMessage();
-        reply.put(REPLMessage.DISPLAY_MSG, message == null ? ex.getClass().getSimpleName() : message);
-        final REPLMessage[] replies = new REPLMessage[]{reply};
+        reply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.DISPLAY_MSG, message == null ? ex.getClass().getSimpleName() : message);
+        final com.oracle.truffle.tools.debug.shell.REPLMessage[] replies = new com.oracle.truffle.tools.debug.shell.REPLMessage[]{reply};
         return replies;
     }
 
-    protected static final REPLMessage createBreakpointInfoMessage(BreakpointInfo info) {
-        final REPLMessage infoMessage = new REPLMessage(REPLMessage.OP, REPLMessage.BREAKPOINT_INFO);
-        infoMessage.put(REPLMessage.BREAKPOINT_ID, Integer.toString(info.getID()));
-        infoMessage.put(REPLMessage.BREAKPOINT_STATE, info.describeState());
-        infoMessage.put(REPLMessage.BREAKPOINT_HIT_COUNT, Integer.toString(info.getHitCount()));
-        infoMessage.put(REPLMessage.BREAKPOINT_IGNORE_COUNT, Integer.toString(info.getIgnoreCount()));
-        infoMessage.put(REPLMessage.INFO_VALUE, info.describeLocation());
+    protected static final com.oracle.truffle.tools.debug.shell.REPLMessage createBreakpointInfoMessage(BreakpointInfo info) {
+        final com.oracle.truffle.tools.debug.shell.REPLMessage infoMessage = new com.oracle.truffle.tools.debug.shell.REPLMessage(com.oracle.truffle.tools.debug.shell.REPLMessage.OP,
+                        com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_INFO);
+        infoMessage.put(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_ID, Integer.toString(info.getID()));
+        infoMessage.put(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_STATE, info.describeState());
+        infoMessage.put(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_HIT_COUNT, Integer.toString(info.getHitCount()));
+        infoMessage.put(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_IGNORE_COUNT, Integer.toString(info.getIgnoreCount()));
+        infoMessage.put(com.oracle.truffle.tools.debug.shell.REPLMessage.INFO_VALUE, info.describeLocation());
         if (info.getCondition() != null) {
-            infoMessage.put(REPLMessage.BREAKPOINT_CONDITION, info.getCondition());
+            infoMessage.put(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_CONDITION, info.getCondition());
         }
-        infoMessage.put(REPLMessage.STATUS, REPLMessage.SUCCEEDED);
+        infoMessage.put(com.oracle.truffle.tools.debug.shell.REPLMessage.STATUS, com.oracle.truffle.tools.debug.shell.REPLMessage.SUCCEEDED);
         return infoMessage;
     }
 
-    protected static final REPLMessage createFrameInfoMessage(final REPLServer replServer, int number, Node node) {
-        final REPLMessage infoMessage = new REPLMessage(REPLMessage.OP, REPLMessage.FRAME_INFO);
-        infoMessage.put(REPLMessage.FRAME_NUMBER, Integer.toString(number));
-        infoMessage.put(REPLMessage.SOURCE_LOCATION, replServer.getLocationPrinter().displaySourceLocation(node));
-        infoMessage.put(REPLMessage.METHOD_NAME, replServer.getCurrentContext().getVisualizer().displayMethodName(node));
+    protected static final com.oracle.truffle.tools.debug.shell.REPLMessage createFrameInfoMessage(final REPLServer replServer, int number, Node node) {
+        final com.oracle.truffle.tools.debug.shell.REPLMessage infoMessage = new com.oracle.truffle.tools.debug.shell.REPLMessage(com.oracle.truffle.tools.debug.shell.REPLMessage.OP,
+                        com.oracle.truffle.tools.debug.shell.REPLMessage.FRAME_INFO);
+        infoMessage.put(com.oracle.truffle.tools.debug.shell.REPLMessage.FRAME_NUMBER, Integer.toString(number));
+        infoMessage.put(com.oracle.truffle.tools.debug.shell.REPLMessage.SOURCE_LOCATION, replServer.getLocationPrinter().displaySourceLocation(node));
+        infoMessage.put(com.oracle.truffle.tools.debug.shell.REPLMessage.METHOD_NAME, replServer.getCurrentContext().getVisualizer().displayMethodName(node));
 
         if (node != null) {
             SourceSection section = node.getSourceSection();
@@ -134,21 +136,21 @@ public abstract class REPLHandler {
                 section = node.getEncapsulatingSourceSection();
             }
             if (section != null && section.getSource() != null) {
-                infoMessage.put(REPLMessage.FILE_PATH, section.getSource().getPath());
-                infoMessage.put(REPLMessage.LINE_NUMBER, Integer.toString(section.getStartLine()));
-                infoMessage.put(REPLMessage.SOURCE_LINE_TEXT, section.getSource().getCode(section.getStartLine()));
+                infoMessage.put(com.oracle.truffle.tools.debug.shell.REPLMessage.FILE_PATH, section.getSource().getPath());
+                infoMessage.put(com.oracle.truffle.tools.debug.shell.REPLMessage.LINE_NUMBER, Integer.toString(section.getStartLine()));
+                infoMessage.put(com.oracle.truffle.tools.debug.shell.REPLMessage.SOURCE_LINE_TEXT, section.getSource().getCode(section.getStartLine()));
             }
         }
-        infoMessage.put(REPLMessage.STATUS, REPLMessage.SUCCEEDED);
+        infoMessage.put(com.oracle.truffle.tools.debug.shell.REPLMessage.STATUS, com.oracle.truffle.tools.debug.shell.REPLMessage.SUCCEEDED);
         return infoMessage;
     }
 
-    public static final REPLHandler BACKTRACE_HANDLER = new REPLHandler(REPLMessage.BACKTRACE) {
+    public static final REPLHandler BACKTRACE_HANDLER = new REPLHandler(com.oracle.truffle.tools.debug.shell.REPLMessage.BACKTRACE) {
 
         @Override
-        public REPLMessage[] receive(REPLMessage request, REPLServer replServer) {
+        public com.oracle.truffle.tools.debug.shell.REPLMessage[] receive(com.oracle.truffle.tools.debug.shell.REPLMessage request, REPLServer replServer) {
             final REPLVisualizer visualizer = replServer.getCurrentContext().getVisualizer();
-            final ArrayList<REPLMessage> replies = new ArrayList<>();
+            final ArrayList<com.oracle.truffle.tools.debug.shell.REPLMessage> replies = new ArrayList<>();
             final Context currentContext = replServer.getCurrentContext();
             final List<FrameInstance> stack = currentContext.getStack();
             int frameIndex = 0; // Index into list of displayed frames
@@ -160,39 +162,41 @@ public abstract class REPLHandler {
                 }
             }
             if (replies.size() > 0) {
-                return replies.toArray(new REPLMessage[0]);
+                return replies.toArray(new com.oracle.truffle.tools.debug.shell.REPLMessage[0]);
             }
-            return finishReplyFailed(new REPLMessage(REPLMessage.OP, REPLMessage.BACKTRACE), "No stack");
+            return finishReplyFailed(new com.oracle.truffle.tools.debug.shell.REPLMessage(com.oracle.truffle.tools.debug.shell.REPLMessage.OP,
+                            com.oracle.truffle.tools.debug.shell.REPLMessage.BACKTRACE), "No stack");
         }
     };
 
-    private static REPLMessage btMessage(int index, Node node, REPLVisualizer visualizer, LocationPrinter locationPrinter) {
-        final REPLMessage btMessage = new REPLMessage(REPLMessage.OP, REPLMessage.BACKTRACE);
-        btMessage.put(REPLMessage.FRAME_NUMBER, Integer.toString(index));
+    private static com.oracle.truffle.tools.debug.shell.REPLMessage btMessage(int index, Node node, REPLVisualizer visualizer, LocationPrinter locationPrinter) {
+        final com.oracle.truffle.tools.debug.shell.REPLMessage btMessage = new com.oracle.truffle.tools.debug.shell.REPLMessage(com.oracle.truffle.tools.debug.shell.REPLMessage.OP,
+                        com.oracle.truffle.tools.debug.shell.REPLMessage.BACKTRACE);
+        btMessage.put(com.oracle.truffle.tools.debug.shell.REPLMessage.FRAME_NUMBER, Integer.toString(index));
         if (node != null) {
-            btMessage.put(REPLMessage.SOURCE_LOCATION, locationPrinter.displaySourceLocation(node));
-            btMessage.put(REPLMessage.METHOD_NAME, visualizer.displayMethodName(node));
+            btMessage.put(com.oracle.truffle.tools.debug.shell.REPLMessage.SOURCE_LOCATION, locationPrinter.displaySourceLocation(node));
+            btMessage.put(com.oracle.truffle.tools.debug.shell.REPLMessage.METHOD_NAME, visualizer.displayMethodName(node));
             SourceSection section = node.getSourceSection();
             if (section == null) {
                 section = node.getEncapsulatingSourceSection();
             }
             if (section != null && section.getSource() != null) {
-                btMessage.put(REPLMessage.FILE_PATH, section.getSource().getPath());
-                btMessage.put(REPLMessage.LINE_NUMBER, Integer.toString(section.getStartLine()));
-                btMessage.put(REPLMessage.SOURCE_LINE_TEXT, section.getSource().getCode(section.getStartLine()));
+                btMessage.put(com.oracle.truffle.tools.debug.shell.REPLMessage.FILE_PATH, section.getSource().getPath());
+                btMessage.put(com.oracle.truffle.tools.debug.shell.REPLMessage.LINE_NUMBER, Integer.toString(section.getStartLine()));
+                btMessage.put(com.oracle.truffle.tools.debug.shell.REPLMessage.SOURCE_LINE_TEXT, section.getSource().getCode(section.getStartLine()));
             }
-            btMessage.put(REPLMessage.STATUS, REPLMessage.SUCCEEDED);
+            btMessage.put(com.oracle.truffle.tools.debug.shell.REPLMessage.STATUS, com.oracle.truffle.tools.debug.shell.REPLMessage.SUCCEEDED);
         }
         return btMessage;
     }
 
-    public static final REPLHandler BREAK_AT_LINE_HANDLER = new REPLHandler(REPLMessage.BREAK_AT_LINE) {
+    public static final REPLHandler BREAK_AT_LINE_HANDLER = new REPLHandler(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAK_AT_LINE) {
 
         @Override
-        public REPLMessage[] receive(REPLMessage request, REPLServer replServer) {
-            final REPLMessage reply = createReply();
-            final String path = request.get(REPLMessage.FILE_PATH);
-            final String fileName = request.get(REPLMessage.SOURCE_NAME);
+        public com.oracle.truffle.tools.debug.shell.REPLMessage[] receive(com.oracle.truffle.tools.debug.shell.REPLMessage request, REPLServer replServer) {
+            final com.oracle.truffle.tools.debug.shell.REPLMessage reply = createReply();
+            final String path = request.get(com.oracle.truffle.tools.debug.shell.REPLMessage.FILE_PATH);
+            final String fileName = request.get(com.oracle.truffle.tools.debug.shell.REPLMessage.SOURCE_NAME);
             final String lookupFile = (path == null || path.isEmpty()) ? fileName : path;
             Source source = null;
             try {
@@ -203,11 +207,11 @@ public abstract class REPLHandler {
             if (source == null) {
                 return finishReplyFailed(reply, fileName + " not found");
             }
-            final Integer lineNumber = request.getIntValue(REPLMessage.LINE_NUMBER);
+            final Integer lineNumber = request.getIntValue(com.oracle.truffle.tools.debug.shell.REPLMessage.LINE_NUMBER);
             if (lineNumber == null) {
                 return finishReplyFailed(reply, "missing line number");
             }
-            Integer ignoreCount = request.getIntValue(REPLMessage.BREAKPOINT_IGNORE_COUNT);
+            Integer ignoreCount = request.getIntValue(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_IGNORE_COUNT);
             if (ignoreCount == null) {
                 ignoreCount = 0;
             }
@@ -217,22 +221,22 @@ public abstract class REPLHandler {
             } catch (IOException ex) {
                 return finishReplyFailed(reply, ex.getMessage());
             }
-            reply.put(REPLMessage.SOURCE_NAME, fileName);
-            reply.put(REPLMessage.FILE_PATH, source.getPath());
-            reply.put(REPLMessage.BREAKPOINT_ID, Integer.toString(breakpointInfo.getID()));
-            reply.put(REPLMessage.LINE_NUMBER, Integer.toString(lineNumber));
-            reply.put(REPLMessage.BREAKPOINT_IGNORE_COUNT, ignoreCount.toString());
+            reply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.SOURCE_NAME, fileName);
+            reply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.FILE_PATH, source.getPath());
+            reply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_ID, Integer.toString(breakpointInfo.getID()));
+            reply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.LINE_NUMBER, Integer.toString(lineNumber));
+            reply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_IGNORE_COUNT, ignoreCount.toString());
             return finishReplySucceeded(reply, "Breakpoint set");
         }
     };
 
-    public static final REPLHandler BREAK_AT_LINE_ONCE_HANDLER = new REPLHandler(REPLMessage.BREAK_AT_LINE_ONCE) {
+    public static final REPLHandler BREAK_AT_LINE_ONCE_HANDLER = new REPLHandler(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAK_AT_LINE_ONCE) {
 
         @Override
-        public REPLMessage[] receive(REPLMessage request, REPLServer replServer) {
-            final REPLMessage reply = createReply();
-            final String path = request.get(REPLMessage.FILE_PATH);
-            final String fileName = request.get(REPLMessage.SOURCE_NAME);
+        public com.oracle.truffle.tools.debug.shell.REPLMessage[] receive(com.oracle.truffle.tools.debug.shell.REPLMessage request, REPLServer replServer) {
+            final com.oracle.truffle.tools.debug.shell.REPLMessage reply = createReply();
+            final String path = request.get(com.oracle.truffle.tools.debug.shell.REPLMessage.FILE_PATH);
+            final String fileName = request.get(com.oracle.truffle.tools.debug.shell.REPLMessage.SOURCE_NAME);
             final String lookupFile = (path == null || path.isEmpty()) ? fileName : path;
             Source source = null;
             try {
@@ -243,7 +247,7 @@ public abstract class REPLHandler {
             if (source == null) {
                 return finishReplyFailed(reply, fileName + " not found");
             }
-            final Integer lineNumber = request.getIntValue(REPLMessage.LINE_NUMBER);
+            final Integer lineNumber = request.getIntValue(com.oracle.truffle.tools.debug.shell.REPLMessage.LINE_NUMBER);
             if (lineNumber == null) {
                 return finishReplyFailed(reply, "missing line number");
             }
@@ -253,51 +257,52 @@ public abstract class REPLHandler {
             } catch (IOException ex) {
                 return finishReplyFailed(reply, ex.getMessage());
             }
-            reply.put(REPLMessage.SOURCE_NAME, fileName);
-            reply.put(REPLMessage.FILE_PATH, source.getPath());
-            reply.put(REPLMessage.BREAKPOINT_ID, Integer.toString(breakpointInfo.getID()));
-            reply.put(REPLMessage.LINE_NUMBER, Integer.toString(lineNumber));
+            reply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.SOURCE_NAME, fileName);
+            reply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.FILE_PATH, source.getPath());
+            reply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_ID, Integer.toString(breakpointInfo.getID()));
+            reply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.LINE_NUMBER, Integer.toString(lineNumber));
             return finishReplySucceeded(reply, "One-shot line breakpoint set");
         }
     };
 
-    public static final REPLHandler BREAKPOINT_INFO_HANDLER = new REPLHandler(REPLMessage.BREAKPOINT_INFO) {
+    public static final REPLHandler BREAKPOINT_INFO_HANDLER = new REPLHandler(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_INFO) {
 
         @Override
-        public REPLMessage[] receive(REPLMessage request, REPLServer replServer) {
-            final REPLMessage reply = createReply();
-            final ArrayList<REPLMessage> infoMessages = new ArrayList<>();
+        public com.oracle.truffle.tools.debug.shell.REPLMessage[] receive(com.oracle.truffle.tools.debug.shell.REPLMessage request, REPLServer replServer) {
+            final com.oracle.truffle.tools.debug.shell.REPLMessage reply = createReply();
+            final ArrayList<com.oracle.truffle.tools.debug.shell.REPLMessage> infoMessages = new ArrayList<>();
             for (BreakpointInfo breakpointInfo : replServer.getBreakpoints()) {
                 infoMessages.add(createBreakpointInfoMessage(breakpointInfo));
             }
             if (infoMessages.size() > 0) {
-                return infoMessages.toArray(new REPLMessage[0]);
+                return infoMessages.toArray(new com.oracle.truffle.tools.debug.shell.REPLMessage[0]);
             }
             return finishReplyFailed(reply, "No breakpoints");
         }
     };
 
-    public static final REPLHandler CALL_HANDLER = new REPLHandler(REPLMessage.CALL) {
+    public static final REPLHandler CALL_HANDLER = new REPLHandler(com.oracle.truffle.tools.debug.shell.REPLMessage.CALL) {
 
         @Override
-        public REPLMessage[] receive(REPLMessage request, REPLServer replServer) {
-            final REPLMessage reply = new REPLMessage(REPLMessage.OP, REPLMessage.CALL);
-            final String callName = request.get(REPLMessage.CALL_NAME);
+        public com.oracle.truffle.tools.debug.shell.REPLMessage[] receive(com.oracle.truffle.tools.debug.shell.REPLMessage request, REPLServer replServer) {
+            final com.oracle.truffle.tools.debug.shell.REPLMessage reply = new com.oracle.truffle.tools.debug.shell.REPLMessage(com.oracle.truffle.tools.debug.shell.REPLMessage.OP,
+                            com.oracle.truffle.tools.debug.shell.REPLMessage.CALL);
+            final String callName = request.get(com.oracle.truffle.tools.debug.shell.REPLMessage.CALL_NAME);
             if (callName == null) {
                 return finishReplyFailed(reply, "no name specified");
             }
             final ArrayList<String> argList = new ArrayList<>();
-            for (int argCount = 0; argCount < REPLMessage.ARG_NAMES.length; argCount++) {
-                final String arg = request.get(REPLMessage.ARG_NAMES[argCount]);
+            for (int argCount = 0; argCount < com.oracle.truffle.tools.debug.shell.REPLMessage.ARG_NAMES.length; argCount++) {
+                final String arg = request.get(com.oracle.truffle.tools.debug.shell.REPLMessage.ARG_NAMES[argCount]);
                 if (arg == null) {
                     break;
                 }
                 argList.add(arg);
             }
-            final boolean stepInto = REPLMessage.TRUE.equals(request.get(REPLMessage.STEP_INTO));
+            final boolean stepInto = com.oracle.truffle.tools.debug.shell.REPLMessage.TRUE.equals(request.get(com.oracle.truffle.tools.debug.shell.REPLMessage.STEP_INTO));
             try {
                 final Object result = replServer.getCurrentContext().call(callName, stepInto, argList);
-                reply.put(REPLMessage.VALUE, result == null ? "<void>" : result.toString());
+                reply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.VALUE, result == null ? "<void>" : result.toString());
             } catch (Exception ex) {
                 return finishReplyFailed(reply, ex);
             }
@@ -305,12 +310,12 @@ public abstract class REPLHandler {
         }
     };
 
-    public static final REPLHandler CLEAR_BREAK_HANDLER = new REPLHandler(REPLMessage.CLEAR_BREAK) {
+    public static final REPLHandler CLEAR_BREAK_HANDLER = new REPLHandler(com.oracle.truffle.tools.debug.shell.REPLMessage.CLEAR_BREAK) {
 
         @Override
-        public REPLMessage[] receive(REPLMessage request, REPLServer replServer) {
-            final REPLMessage reply = createReply();
-            final Integer breakpointNumber = request.getIntValue(REPLMessage.BREAKPOINT_ID);
+        public com.oracle.truffle.tools.debug.shell.REPLMessage[] receive(com.oracle.truffle.tools.debug.shell.REPLMessage request, REPLServer replServer) {
+            final com.oracle.truffle.tools.debug.shell.REPLMessage reply = createReply();
+            final Integer breakpointNumber = request.getIntValue(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_ID);
             if (breakpointNumber == null) {
                 return finishReplyFailed(reply, "missing breakpoint number");
             }
@@ -319,26 +324,26 @@ public abstract class REPLHandler {
                 return finishReplyFailed(reply, "no breakpoint number " + breakpointNumber);
             }
             breakpointInfo.dispose();
-            reply.put(REPLMessage.BREAKPOINT_ID, Integer.toString(breakpointNumber));
+            reply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_ID, Integer.toString(breakpointNumber));
             return finishReplySucceeded(reply, "Breakpoint " + breakpointNumber + " cleared");
         }
     };
 
-    public static final REPLHandler CONTINUE_HANDLER = new REPLHandler(REPLMessage.CONTINUE) {
+    public static final REPLHandler CONTINUE_HANDLER = new REPLHandler(com.oracle.truffle.tools.debug.shell.REPLMessage.CONTINUE) {
 
         @Override
-        public REPLMessage[] receive(REPLMessage request, REPLServer replServer) {
-            final REPLMessage reply = createReply();
+        public com.oracle.truffle.tools.debug.shell.REPLMessage[] receive(com.oracle.truffle.tools.debug.shell.REPLMessage request, REPLServer replServer) {
+            final com.oracle.truffle.tools.debug.shell.REPLMessage reply = createReply();
             replServer.getCurrentContext().prepareContinue();
             return finishReplySucceeded(reply, "Continue mode entered");
         }
     };
 
-    public static final REPLHandler DELETE_HANDLER = new REPLHandler(REPLMessage.DELETE_BREAK) {
+    public static final REPLHandler DELETE_HANDLER = new REPLHandler(com.oracle.truffle.tools.debug.shell.REPLMessage.DELETE_BREAK) {
 
         @Override
-        public REPLMessage[] receive(REPLMessage request, REPLServer replServer) {
-            final REPLMessage reply = createReply();
+        public com.oracle.truffle.tools.debug.shell.REPLMessage[] receive(com.oracle.truffle.tools.debug.shell.REPLMessage request, REPLServer replServer) {
+            final com.oracle.truffle.tools.debug.shell.REPLMessage reply = createReply();
             final Collection<BreakpointInfo> breakpoints = replServer.getBreakpoints();
             if (breakpoints.isEmpty()) {
                 return finishReplyFailed(reply, "no breakpoints to delete");
@@ -350,12 +355,12 @@ public abstract class REPLHandler {
         }
     };
 
-    public static final REPLHandler DISABLE_BREAK_HANDLER = new REPLHandler(REPLMessage.DISABLE_BREAK) {
+    public static final REPLHandler DISABLE_BREAK_HANDLER = new REPLHandler(com.oracle.truffle.tools.debug.shell.REPLMessage.DISABLE_BREAK) {
 
         @Override
-        public REPLMessage[] receive(REPLMessage request, REPLServer replServer) {
-            final REPLMessage reply = createReply();
-            Integer breakpointNumber = request.getIntValue(REPLMessage.BREAKPOINT_ID);
+        public com.oracle.truffle.tools.debug.shell.REPLMessage[] receive(com.oracle.truffle.tools.debug.shell.REPLMessage request, REPLServer replServer) {
+            final com.oracle.truffle.tools.debug.shell.REPLMessage reply = createReply();
+            Integer breakpointNumber = request.getIntValue(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_ID);
             if (breakpointNumber == null) {
                 return finishReplyFailed(reply, "missing breakpoint number");
             }
@@ -364,17 +369,17 @@ public abstract class REPLHandler {
                 return finishReplyFailed(reply, "no breakpoint number " + breakpointNumber);
             }
             breakpointInfo.setEnabled(false);
-            reply.put(REPLMessage.BREAKPOINT_ID, Integer.toString(breakpointNumber));
+            reply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_ID, Integer.toString(breakpointNumber));
             return finishReplySucceeded(reply, "Breakpoint " + breakpointNumber + " disabled");
         }
     };
 
-    public static final REPLHandler ENABLE_BREAK_HANDLER = new REPLHandler(REPLMessage.ENABLE_BREAK) {
+    public static final REPLHandler ENABLE_BREAK_HANDLER = new REPLHandler(com.oracle.truffle.tools.debug.shell.REPLMessage.ENABLE_BREAK) {
 
         @Override
-        public REPLMessage[] receive(REPLMessage request, REPLServer replServer) {
-            final REPLMessage reply = createReply();
-            Integer breakpointNumber = request.getIntValue(REPLMessage.BREAKPOINT_ID);
+        public com.oracle.truffle.tools.debug.shell.REPLMessage[] receive(com.oracle.truffle.tools.debug.shell.REPLMessage request, REPLServer replServer) {
+            final com.oracle.truffle.tools.debug.shell.REPLMessage reply = createReply();
+            Integer breakpointNumber = request.getIntValue(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_ID);
             if (breakpointNumber == null) {
                 return finishReplyFailed(reply, "missing breakpoint number");
             }
@@ -383,23 +388,23 @@ public abstract class REPLHandler {
                 return finishReplyFailed(reply, "no breakpoint number " + breakpointNumber);
             }
             breakpointInfo.setEnabled(true);
-            reply.put(REPLMessage.BREAKPOINT_ID, Integer.toString(breakpointNumber));
+            reply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_ID, Integer.toString(breakpointNumber));
             return finishReplySucceeded(reply, "Breakpoint " + breakpointNumber + " enabled");
         }
     };
-    public static final REPLHandler EVAL_HANDLER = new REPLHandler(REPLMessage.EVAL) {
+    public static final REPLHandler EVAL_HANDLER = new REPLHandler(com.oracle.truffle.tools.debug.shell.REPLMessage.EVAL) {
         @Override
-        public REPLMessage[] receive(REPLMessage request, REPLServer replServer) {
-            final REPLMessage reply = createReply();
-            final String sourceName = request.get(REPLMessage.SOURCE_NAME);
-            reply.put(REPLMessage.SOURCE_NAME, sourceName);
+        public com.oracle.truffle.tools.debug.shell.REPLMessage[] receive(com.oracle.truffle.tools.debug.shell.REPLMessage request, REPLServer replServer) {
+            final com.oracle.truffle.tools.debug.shell.REPLMessage reply = createReply();
+            final String sourceName = request.get(com.oracle.truffle.tools.debug.shell.REPLMessage.SOURCE_NAME);
+            reply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.SOURCE_NAME, sourceName);
             final Context serverContext = replServer.getCurrentContext();
-            reply.put(REPLMessage.DEBUG_LEVEL, Integer.toString(serverContext.getLevel()));
+            reply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.DEBUG_LEVEL, Integer.toString(serverContext.getLevel()));
 
-            final String source = request.get(REPLMessage.CODE);
+            final String source = request.get(com.oracle.truffle.tools.debug.shell.REPLMessage.CODE);
             final REPLVisualizer visualizer = replServer.getCurrentContext().getVisualizer();
-            final Integer frameNumber = request.getIntValue(REPLMessage.FRAME_NUMBER);
-            final boolean stepInto = REPLMessage.TRUE.equals(request.get(REPLMessage.STEP_INTO));
+            final Integer frameNumber = request.getIntValue(com.oracle.truffle.tools.debug.shell.REPLMessage.FRAME_NUMBER);
+            final boolean stepInto = com.oracle.truffle.tools.debug.shell.REPLMessage.TRUE.equals(request.get(com.oracle.truffle.tools.debug.shell.REPLMessage.STEP_INTO));
             try {
                 Object returnValue = serverContext.eval(source, frameNumber, stepInto);
                 return finishReplySucceeded(reply, visualizer.displayValue(returnValue, 0));
@@ -408,22 +413,22 @@ public abstract class REPLHandler {
             }
         }
     };
-    public static final REPLHandler FILE_HANDLER = new REPLHandler(REPLMessage.FILE) {
+    public static final REPLHandler FILE_HANDLER = new REPLHandler(com.oracle.truffle.tools.debug.shell.REPLMessage.FILE) {
         @Override
-        public REPLMessage[] receive(REPLMessage request, REPLServer replServer) {
-            final REPLMessage reply = createReply();
-            final String fileName = request.get(REPLMessage.SOURCE_NAME);
+        public com.oracle.truffle.tools.debug.shell.REPLMessage[] receive(com.oracle.truffle.tools.debug.shell.REPLMessage request, REPLServer replServer) {
+            final com.oracle.truffle.tools.debug.shell.REPLMessage reply = createReply();
+            final String fileName = request.get(com.oracle.truffle.tools.debug.shell.REPLMessage.SOURCE_NAME);
             if (fileName == null) {
                 return finishReplyFailed(reply, "no file specified");
             }
-            reply.put(REPLMessage.SOURCE_NAME, fileName);
+            reply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.SOURCE_NAME, fileName);
             try {
                 Source source = Source.fromFileName(fileName);
                 if (source == null) {
                     return finishReplyFailed(reply, "file \"" + fileName + "\" not found");
                 } else {
-                    reply.put(REPLMessage.FILE_PATH, source.getPath());
-                    reply.put(REPLMessage.CODE, source.getCode());
+                    reply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.FILE_PATH, source.getPath());
+                    reply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.CODE, source.getCode());
                     return finishReplySucceeded(reply, "file found");
                 }
             } catch (IOException ex) {
@@ -439,11 +444,11 @@ public abstract class REPLHandler {
      * Returns a general description of the frame, plus a textual summary of the slot values: one
      * per line.
      */
-    public static final REPLHandler FRAME_HANDLER = new REPLHandler(REPLMessage.FRAME) {
+    public static final REPLHandler FRAME_HANDLER = new REPLHandler(com.oracle.truffle.tools.debug.shell.REPLMessage.FRAME) {
 
         @Override
-        public REPLMessage[] receive(REPLMessage request, REPLServer replServer) {
-            final Integer frameNumber = request.getIntValue(REPLMessage.FRAME_NUMBER);
+        public com.oracle.truffle.tools.debug.shell.REPLMessage[] receive(com.oracle.truffle.tools.debug.shell.REPLMessage request, REPLServer replServer) {
+            final Integer frameNumber = request.getIntValue(com.oracle.truffle.tools.debug.shell.REPLMessage.FRAME_NUMBER);
             if (frameNumber == null) {
                 return finishReplyFailed(createReply(), "no frame number specified");
             }
@@ -466,74 +471,80 @@ public abstract class REPLHandler {
             }
             List<? extends FrameSlot> slots = frame.getFrameDescriptor().getSlots();
             if (slots.size() == 0) {
-                final REPLMessage emptyFrameMessage = createFrameInfoMessage(replServer, frameNumber, node);
+                final com.oracle.truffle.tools.debug.shell.REPLMessage emptyFrameMessage = createFrameInfoMessage(replServer, frameNumber, node);
                 return finishReplySucceeded(emptyFrameMessage, "empty frame");
             }
-            final ArrayList<REPLMessage> replies = new ArrayList<>();
+            final ArrayList<com.oracle.truffle.tools.debug.shell.REPLMessage> replies = new ArrayList<>();
 
             for (FrameSlot slot : slots) {
-                final REPLMessage slotMessage = createFrameInfoMessage(replServer, frameNumber, node);
-                slotMessage.put(REPLMessage.SLOT_INDEX, Integer.toString(slot.getIndex()));
-                slotMessage.put(REPLMessage.SLOT_ID, visualizer.displayIdentifier(slot));
-                slotMessage.put(REPLMessage.SLOT_VALUE, visualizer.displayValue(frame.getValue(slot), 0));
-                slotMessage.put(REPLMessage.STATUS, REPLMessage.SUCCEEDED);
+                final com.oracle.truffle.tools.debug.shell.REPLMessage slotMessage = createFrameInfoMessage(replServer, frameNumber, node);
+                slotMessage.put(com.oracle.truffle.tools.debug.shell.REPLMessage.SLOT_INDEX, Integer.toString(slot.getIndex()));
+                slotMessage.put(com.oracle.truffle.tools.debug.shell.REPLMessage.SLOT_ID, visualizer.displayIdentifier(slot));
+                slotMessage.put(com.oracle.truffle.tools.debug.shell.REPLMessage.SLOT_VALUE, visualizer.displayValue(frame.getValue(slot), 0));
+                slotMessage.put(com.oracle.truffle.tools.debug.shell.REPLMessage.STATUS, com.oracle.truffle.tools.debug.shell.REPLMessage.SUCCEEDED);
                 replies.add(slotMessage);
             }
-            return replies.toArray(new REPLMessage[0]);
+            return replies.toArray(new com.oracle.truffle.tools.debug.shell.REPLMessage[0]);
         }
     };
 
-    public static final REPLHandler INFO_HANDLER = new REPLHandler(REPLMessage.INFO) {
+    public static final REPLHandler INFO_HANDLER = new REPLHandler(com.oracle.truffle.tools.debug.shell.REPLMessage.INFO) {
 
         @Override
-        public REPLMessage[] receive(REPLMessage request, REPLServer replServer) {
-            final String topic = request.get(REPLMessage.TOPIC);
+        public com.oracle.truffle.tools.debug.shell.REPLMessage[] receive(com.oracle.truffle.tools.debug.shell.REPLMessage request, REPLServer replServer) {
+            final String topic = request.get(com.oracle.truffle.tools.debug.shell.REPLMessage.TOPIC);
 
             if (topic == null || topic.isEmpty()) {
-                final REPLMessage message = new REPLMessage(REPLMessage.OP, REPLMessage.INFO);
+                final com.oracle.truffle.tools.debug.shell.REPLMessage message = new com.oracle.truffle.tools.debug.shell.REPLMessage(com.oracle.truffle.tools.debug.shell.REPLMessage.OP,
+                                com.oracle.truffle.tools.debug.shell.REPLMessage.INFO);
                 return finishReplyFailed(message, "No info topic specified");
             }
 
             switch (topic) {
 
-                case REPLMessage.INFO_SUPPORTED_LANGUAGES:
-                    final ArrayList<REPLMessage> langMessages = new ArrayList<>();
+                case com.oracle.truffle.tools.debug.shell.REPLMessage.INFO_SUPPORTED_LANGUAGES:
+                    final ArrayList<com.oracle.truffle.tools.debug.shell.REPLMessage> langMessages = new ArrayList<>();
 
                     for (Language language : replServer.getLanguages()) {
-                        final REPLMessage infoMessage = new REPLMessage(REPLMessage.OP, REPLMessage.INFO);
-                        infoMessage.put(REPLMessage.TOPIC, REPLMessage.INFO_SUPPORTED_LANGUAGES);
-                        infoMessage.put(REPLMessage.LANG_NAME, language.getName());
-                        infoMessage.put(REPLMessage.LANG_VER, language.getVersion());
-                        infoMessage.put(REPLMessage.STATUS, REPLMessage.SUCCEEDED);
+                        final com.oracle.truffle.tools.debug.shell.REPLMessage infoMessage = new com.oracle.truffle.tools.debug.shell.REPLMessage(com.oracle.truffle.tools.debug.shell.REPLMessage.OP,
+                                        com.oracle.truffle.tools.debug.shell.REPLMessage.INFO);
+                        infoMessage.put(com.oracle.truffle.tools.debug.shell.REPLMessage.TOPIC, com.oracle.truffle.tools.debug.shell.REPLMessage.INFO_SUPPORTED_LANGUAGES);
+                        infoMessage.put(com.oracle.truffle.tools.debug.shell.REPLMessage.LANG_NAME, language.getName());
+                        infoMessage.put(com.oracle.truffle.tools.debug.shell.REPLMessage.LANG_VER, language.getVersion());
+                        infoMessage.put(com.oracle.truffle.tools.debug.shell.REPLMessage.STATUS, com.oracle.truffle.tools.debug.shell.REPLMessage.SUCCEEDED);
                         langMessages.add(infoMessage);
                     }
-                    return langMessages.toArray(new REPLMessage[0]);
+                    return langMessages.toArray(new com.oracle.truffle.tools.debug.shell.REPLMessage[0]);
 
-                case REPLMessage.INFO_CURRENT_LANGUAGE:
-                    final REPLMessage reply = new REPLMessage(REPLMessage.OP, REPLMessage.INFO);
-                    reply.put(REPLMessage.TOPIC, REPLMessage.INFO_CURRENT_LANGUAGE);
+                case com.oracle.truffle.tools.debug.shell.REPLMessage.INFO_CURRENT_LANGUAGE:
+                    final com.oracle.truffle.tools.debug.shell.REPLMessage reply = new com.oracle.truffle.tools.debug.shell.REPLMessage(com.oracle.truffle.tools.debug.shell.REPLMessage.OP,
+                                    com.oracle.truffle.tools.debug.shell.REPLMessage.INFO);
+                    reply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.TOPIC, com.oracle.truffle.tools.debug.shell.REPLMessage.INFO_CURRENT_LANGUAGE);
                     final String languageName = replServer.getCurrentContext().getLanguageName();
-                    reply.put(REPLMessage.LANG_NAME, languageName);
+                    reply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.LANG_NAME, languageName);
                     return finishReplySucceeded(reply, languageName);
 
-                case REPLMessage.WELCOME_MESSAGE:
-                    final REPLMessage infoMessage = new REPLMessage(REPLMessage.OP, REPLMessage.INFO);
-                    infoMessage.put(REPLMessage.TOPIC, REPLMessage.WELCOME_MESSAGE);
-                    infoMessage.put(REPLMessage.INFO_VALUE, replServer.getWelcome());
-                    infoMessage.put(REPLMessage.STATUS, REPLMessage.SUCCEEDED);
+                case com.oracle.truffle.tools.debug.shell.REPLMessage.WELCOME_MESSAGE:
+                    final com.oracle.truffle.tools.debug.shell.REPLMessage infoMessage = new com.oracle.truffle.tools.debug.shell.REPLMessage(com.oracle.truffle.tools.debug.shell.REPLMessage.OP,
+                                    com.oracle.truffle.tools.debug.shell.REPLMessage.INFO);
+                    infoMessage.put(com.oracle.truffle.tools.debug.shell.REPLMessage.TOPIC, com.oracle.truffle.tools.debug.shell.REPLMessage.WELCOME_MESSAGE);
+                    infoMessage.put(com.oracle.truffle.tools.debug.shell.REPLMessage.INFO_VALUE, replServer.getWelcome());
+                    infoMessage.put(com.oracle.truffle.tools.debug.shell.REPLMessage.STATUS, com.oracle.truffle.tools.debug.shell.REPLMessage.SUCCEEDED);
                     return finishReplySucceeded(infoMessage, "welcome");
 
                 default:
-                    final REPLMessage message = new REPLMessage(REPLMessage.OP, REPLMessage.INFO);
+                    final com.oracle.truffle.tools.debug.shell.REPLMessage message = new com.oracle.truffle.tools.debug.shell.REPLMessage(com.oracle.truffle.tools.debug.shell.REPLMessage.OP,
+                                    com.oracle.truffle.tools.debug.shell.REPLMessage.INFO);
                     return finishReplyFailed(message, "No info about topic \"" + topic + "\"");
             }
         }
     };
-    public static final REPLHandler KILL_HANDLER = new REPLHandler(REPLMessage.KILL) {
+    public static final REPLHandler KILL_HANDLER = new REPLHandler(com.oracle.truffle.tools.debug.shell.REPLMessage.KILL) {
 
         @Override
-        public REPLMessage[] receive(REPLMessage request, REPLServer replServer) {
-            final REPLMessage reply = new REPLMessage(REPLMessage.OP, REPLMessage.KILL);
+        public com.oracle.truffle.tools.debug.shell.REPLMessage[] receive(com.oracle.truffle.tools.debug.shell.REPLMessage request, REPLServer replServer) {
+            final com.oracle.truffle.tools.debug.shell.REPLMessage reply = new com.oracle.truffle.tools.debug.shell.REPLMessage(com.oracle.truffle.tools.debug.shell.REPLMessage.OP,
+                            com.oracle.truffle.tools.debug.shell.REPLMessage.KILL);
             if (replServer.getCurrentContext().getLevel() == 0) {
                 return finishReplyFailed(reply, "nothing to kill");
             }
@@ -543,17 +554,18 @@ public abstract class REPLHandler {
         }
     };
 
-    public static final REPLHandler LOAD_HANDLER = new REPLHandler(REPLMessage.LOAD_SOURCE) {
+    public static final REPLHandler LOAD_HANDLER = new REPLHandler(com.oracle.truffle.tools.debug.shell.REPLMessage.LOAD_SOURCE) {
 
         @Override
-        public REPLMessage[] receive(REPLMessage request, REPLServer replServer) {
-            final REPLMessage reply = new REPLMessage(REPLMessage.OP, REPLMessage.LOAD_SOURCE);
-            final String fileName = request.get(REPLMessage.SOURCE_NAME);
-            final boolean stepInto = REPLMessage.TRUE.equals(request.get(REPLMessage.STEP_INTO));
+        public com.oracle.truffle.tools.debug.shell.REPLMessage[] receive(com.oracle.truffle.tools.debug.shell.REPLMessage request, REPLServer replServer) {
+            final com.oracle.truffle.tools.debug.shell.REPLMessage reply = new com.oracle.truffle.tools.debug.shell.REPLMessage(com.oracle.truffle.tools.debug.shell.REPLMessage.OP,
+                            com.oracle.truffle.tools.debug.shell.REPLMessage.LOAD_SOURCE);
+            final String fileName = request.get(com.oracle.truffle.tools.debug.shell.REPLMessage.SOURCE_NAME);
+            final boolean stepInto = com.oracle.truffle.tools.debug.shell.REPLMessage.TRUE.equals(request.get(com.oracle.truffle.tools.debug.shell.REPLMessage.STEP_INTO));
             try {
                 final Source fileSource = Source.fromFileName(fileName);
                 replServer.getCurrentContext().eval(fileSource, stepInto);
-                reply.put(REPLMessage.FILE_PATH, fileName);
+                reply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.FILE_PATH, fileName);
                 return finishReplySucceeded(reply, fileName + "  loaded");
             } catch (Exception ex) {
                 return finishReplyFailed(reply, ex);
@@ -561,18 +573,19 @@ public abstract class REPLHandler {
         }
     };
 
-    public static final REPLHandler SET_LANGUAGE_HANDLER = new REPLHandler(REPLMessage.SET_LANGUAGE) {
+    public static final REPLHandler SET_LANGUAGE_HANDLER = new REPLHandler(com.oracle.truffle.tools.debug.shell.REPLMessage.SET_LANGUAGE) {
 
         @Override
-        public REPLMessage[] receive(REPLMessage request, REPLServer replServer) {
-            final REPLMessage reply = new REPLMessage(REPLMessage.OP, REPLMessage.SET_LANGUAGE);
-            String languageName = request.get(REPLMessage.LANG_NAME);
+        public com.oracle.truffle.tools.debug.shell.REPLMessage[] receive(com.oracle.truffle.tools.debug.shell.REPLMessage request, REPLServer replServer) {
+            final com.oracle.truffle.tools.debug.shell.REPLMessage reply = new com.oracle.truffle.tools.debug.shell.REPLMessage(com.oracle.truffle.tools.debug.shell.REPLMessage.OP,
+                            com.oracle.truffle.tools.debug.shell.REPLMessage.SET_LANGUAGE);
+            String languageName = request.get(com.oracle.truffle.tools.debug.shell.REPLMessage.LANG_NAME);
             if (languageName == null) {
                 final String oldLanguageName = replServer.getCurrentContext().getLanguageName();
-                reply.put(REPLMessage.LANG_NAME, reply.put(REPLMessage.LANG_NAME, oldLanguageName));
+                reply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.LANG_NAME, reply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.LANG_NAME, oldLanguageName));
                 return finishReplySucceeded(reply, "Language set to " + oldLanguageName);
             }
-            reply.put(REPLMessage.LANG_NAME, languageName);
+            reply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.LANG_NAME, languageName);
             try {
                 final String newLanguageName = replServer.getCurrentContext().setLanguage(languageName);
                 if (newLanguageName != null) {
@@ -585,21 +598,22 @@ public abstract class REPLHandler {
         }
     };
 
-    public static final REPLHandler SET_BREAK_CONDITION_HANDLER = new REPLHandler(REPLMessage.SET_BREAK_CONDITION) {
+    public static final REPLHandler SET_BREAK_CONDITION_HANDLER = new REPLHandler(com.oracle.truffle.tools.debug.shell.REPLMessage.SET_BREAK_CONDITION) {
 
         @Override
-        public REPLMessage[] receive(REPLMessage request, REPLServer replServer) {
-            final REPLMessage message = new REPLMessage(REPLMessage.OP, REPLMessage.SET_BREAK_CONDITION);
-            Integer breakpointNumber = request.getIntValue(REPLMessage.BREAKPOINT_ID);
+        public com.oracle.truffle.tools.debug.shell.REPLMessage[] receive(com.oracle.truffle.tools.debug.shell.REPLMessage request, REPLServer replServer) {
+            final com.oracle.truffle.tools.debug.shell.REPLMessage message = new com.oracle.truffle.tools.debug.shell.REPLMessage(com.oracle.truffle.tools.debug.shell.REPLMessage.OP,
+                            com.oracle.truffle.tools.debug.shell.REPLMessage.SET_BREAK_CONDITION);
+            Integer breakpointNumber = request.getIntValue(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_ID);
             if (breakpointNumber == null) {
                 return finishReplyFailed(message, "missing breakpoint number");
             }
-            message.put(REPLMessage.BREAKPOINT_ID, Integer.toString(breakpointNumber));
+            message.put(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_ID, Integer.toString(breakpointNumber));
             final BreakpointInfo breakpointInfo = replServer.findBreakpoint(breakpointNumber);
             if (breakpointInfo == null) {
                 return finishReplyFailed(message, "no breakpoint number " + breakpointNumber);
             }
-            final String expr = request.get(REPLMessage.BREAKPOINT_CONDITION);
+            final String expr = request.get(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_CONDITION);
             if (expr == null || expr.isEmpty()) {
                 return finishReplyFailed(message, "missing condition for " + breakpointNumber);
             }
@@ -612,17 +626,17 @@ public abstract class REPLHandler {
             } catch (Exception ex) {
                 return finishReplyFailed(message, ex);
             }
-            message.put(REPLMessage.BREAKPOINT_CONDITION, expr);
+            message.put(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_CONDITION, expr);
             return finishReplySucceeded(message, "Breakpoint " + breakpointNumber + " condition=\"" + expr + "\"");
         }
     };
 
-    public static final REPLHandler STEP_INTO_HANDLER = new REPLHandler(REPLMessage.STEP_INTO) {
+    public static final REPLHandler STEP_INTO_HANDLER = new REPLHandler(com.oracle.truffle.tools.debug.shell.REPLMessage.STEP_INTO) {
 
         @Override
-        public REPLMessage[] receive(REPLMessage request, REPLServer replServer) {
-            final REPLMessage reply = createReply();
-            Integer repeat = request.getIntValue(REPLMessage.REPEAT);
+        public com.oracle.truffle.tools.debug.shell.REPLMessage[] receive(com.oracle.truffle.tools.debug.shell.REPLMessage request, REPLServer replServer) {
+            final com.oracle.truffle.tools.debug.shell.REPLMessage reply = createReply();
+            Integer repeat = request.getIntValue(com.oracle.truffle.tools.debug.shell.REPLMessage.REPEAT);
             if (repeat == null) {
                 repeat = 1;
             }
@@ -632,22 +646,22 @@ public abstract class REPLHandler {
         }
     };
 
-    public static final REPLHandler STEP_OUT_HANDLER = new REPLHandler(REPLMessage.STEP_OUT) {
+    public static final REPLHandler STEP_OUT_HANDLER = new REPLHandler(com.oracle.truffle.tools.debug.shell.REPLMessage.STEP_OUT) {
 
         @Override
-        public REPLMessage[] receive(REPLMessage request, REPLServer replServer) {
-            final REPLMessage reply = createReply();
+        public com.oracle.truffle.tools.debug.shell.REPLMessage[] receive(com.oracle.truffle.tools.debug.shell.REPLMessage request, REPLServer replServer) {
+            final com.oracle.truffle.tools.debug.shell.REPLMessage reply = createReply();
             replServer.getCurrentContext().prepareStepOut();
             return finishReplySucceeded(reply, "StepOut enabled");
         }
     };
 
-    public static final REPLHandler STEP_OVER_HANDLER = new REPLHandler(REPLMessage.STEP_OVER) {
+    public static final REPLHandler STEP_OVER_HANDLER = new REPLHandler(com.oracle.truffle.tools.debug.shell.REPLMessage.STEP_OVER) {
 
         @Override
-        public REPLMessage[] receive(REPLMessage request, REPLServer replServer) {
-            final REPLMessage reply = createReply();
-            Integer repeat = request.getIntValue(REPLMessage.REPEAT);
+        public com.oracle.truffle.tools.debug.shell.REPLMessage[] receive(com.oracle.truffle.tools.debug.shell.REPLMessage request, REPLServer replServer) {
+            final com.oracle.truffle.tools.debug.shell.REPLMessage reply = createReply();
+            Integer repeat = request.getIntValue(com.oracle.truffle.tools.debug.shell.REPLMessage.REPEAT);
             if (repeat == null) {
                 repeat = 1;
             }
@@ -657,36 +671,36 @@ public abstract class REPLHandler {
         }
     };
 
-    public static final REPLHandler TRUFFLE_HANDLER = new REPLHandler(REPLMessage.TRUFFLE) {
+    public static final REPLHandler TRUFFLE_HANDLER = new REPLHandler(com.oracle.truffle.tools.debug.shell.REPLMessage.TRUFFLE) {
 
         @Override
-        public REPLMessage[] receive(REPLMessage request, REPLServer replServer) {
-            final REPLMessage reply = createReply();
+        public com.oracle.truffle.tools.debug.shell.REPLMessage[] receive(com.oracle.truffle.tools.debug.shell.REPLMessage request, REPLServer replServer) {
+            final com.oracle.truffle.tools.debug.shell.REPLMessage reply = createReply();
             final ASTPrinter astPrinter = replServer.getASTPrinter();
-            final String topic = request.get(REPLMessage.TOPIC);
-            reply.put(REPLMessage.TOPIC, topic);
+            final String topic = request.get(com.oracle.truffle.tools.debug.shell.REPLMessage.TOPIC);
+            reply.put(com.oracle.truffle.tools.debug.shell.REPLMessage.TOPIC, topic);
             Node node = replServer.getCurrentContext().getNodeAtHalt();
             if (node == null) {
                 return finishReplyFailed(reply, "no current AST node");
             }
-            final Integer depth = request.getIntValue(REPLMessage.AST_DEPTH);
+            final Integer depth = request.getIntValue(com.oracle.truffle.tools.debug.shell.REPLMessage.AST_DEPTH);
             if (depth == null) {
                 return finishReplyFailed(reply, "missing AST depth");
             }
             try {
                 switch (topic) {
-                    case REPLMessage.AST:
+                    case com.oracle.truffle.tools.debug.shell.REPLMessage.AST:
                         while (node.getParent() != null) {
                             node = node.getParent();
                         }
                         final String astText = astPrinter.displayAST(node, depth, replServer.getCurrentContext().getNodeAtHalt());
                         return finishReplySucceeded(reply, astText);
-                    case REPLMessage.SUBTREE:
-                    case REPLMessage.SUB:
+                    case com.oracle.truffle.tools.debug.shell.REPLMessage.SUBTREE:
+                    case com.oracle.truffle.tools.debug.shell.REPLMessage.SUB:
                         final String subTreeText = astPrinter.displayAST(node, depth);
                         return finishReplySucceeded(reply, subTreeText);
                     default:
-                        return finishReplyFailed(reply, "Unknown \"" + REPLMessage.TRUFFLE.toString() + "\" topic");
+                        return finishReplyFailed(reply, "Unknown \"" + com.oracle.truffle.tools.debug.shell.REPLMessage.TRUFFLE.toString() + "\" topic");
                 }
 
             } catch (Exception ex) {
@@ -695,16 +709,17 @@ public abstract class REPLHandler {
         }
     };
 
-    public static final REPLHandler UNSET_BREAK_CONDITION_HANDLER = new REPLHandler(REPLMessage.UNSET_BREAK_CONDITION) {
+    public static final REPLHandler UNSET_BREAK_CONDITION_HANDLER = new REPLHandler(com.oracle.truffle.tools.debug.shell.REPLMessage.UNSET_BREAK_CONDITION) {
 
         @Override
-        public REPLMessage[] receive(REPLMessage request, REPLServer replServer) {
-            final REPLMessage message = new REPLMessage(REPLMessage.OP, REPLMessage.UNSET_BREAK_CONDITION);
-            Integer breakpointNumber = request.getIntValue(REPLMessage.BREAKPOINT_ID);
+        public com.oracle.truffle.tools.debug.shell.REPLMessage[] receive(com.oracle.truffle.tools.debug.shell.REPLMessage request, REPLServer replServer) {
+            final com.oracle.truffle.tools.debug.shell.REPLMessage message = new com.oracle.truffle.tools.debug.shell.REPLMessage(com.oracle.truffle.tools.debug.shell.REPLMessage.OP,
+                            com.oracle.truffle.tools.debug.shell.REPLMessage.UNSET_BREAK_CONDITION);
+            Integer breakpointNumber = request.getIntValue(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_ID);
             if (breakpointNumber == null) {
                 return finishReplyFailed(message, "missing breakpoint number");
             }
-            message.put(REPLMessage.BREAKPOINT_ID, Integer.toString(breakpointNumber));
+            message.put(com.oracle.truffle.tools.debug.shell.REPLMessage.BREAKPOINT_ID, Integer.toString(breakpointNumber));
             final BreakpointInfo breakpointInfo = replServer.findBreakpoint(breakpointNumber);
             if (breakpointInfo == null) {
                 return finishReplyFailed(message, "no breakpoint number " + breakpointNumber);
@@ -718,11 +733,11 @@ public abstract class REPLHandler {
         }
     };
 
-    public static final REPLHandler TRUFFLE_NODE_HANDLER = new REPLHandler(REPLMessage.TRUFFLE_NODE) {
+    public static final REPLHandler TRUFFLE_NODE_HANDLER = new REPLHandler(com.oracle.truffle.tools.debug.shell.REPLMessage.TRUFFLE_NODE) {
 
         @Override
-        public REPLMessage[] receive(REPLMessage request, REPLServer replServer) {
-            final REPLMessage reply = createReply();
+        public com.oracle.truffle.tools.debug.shell.REPLMessage[] receive(com.oracle.truffle.tools.debug.shell.REPLMessage request, REPLServer replServer) {
+            final com.oracle.truffle.tools.debug.shell.REPLMessage reply = createReply();
             final Node node = replServer.getCurrentContext().getNodeAtHalt();
             if (node == null) {
                 return finishReplyFailed(reply, "no current AST node");

--- a/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/server/REPLHandler.java
+++ b/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/server/REPLHandler.java
@@ -49,6 +49,7 @@ import com.oracle.truffle.tools.debug.shell.server.REPLServer.REPLVisualizer;
  * <p>
  * The language-agnostic handlers are implemented here.
  */
+@SuppressWarnings("deprecation")
 public abstract class REPLHandler {
 
     // TODO (mlvdv) add support for setting/using ignore count

--- a/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/server/REPLServer.java
+++ b/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/server/REPLServer.java
@@ -64,6 +64,7 @@ import com.oracle.truffle.tools.debug.shell.server.InstrumentationUtils.Location
  * The server side of a simple message-based protocol for a possibly remote language
  * Read-Eval-Print-Loop.
  */
+@SuppressWarnings("deprecation")
 public final class REPLServer {
 
     private static final boolean TRACE = Boolean.getBoolean("truffle.debug.trace");
@@ -594,7 +595,6 @@ public final class REPLServer {
         }
 
         @Override
-        @SuppressWarnings("deprecation")
         protected void activate() throws IOException {
             breakpoint = db.setTagBreakpoint(ignoreCount, tag, oneShot);
             // TODO (mlvdv) check if resolved


### PR DESCRIPTION
Add a warning to com.oracle.truffle.tools.debug.shell.package-info.java and deprecate the two public names; they will be be removed from the Truffle public API.