### PR TITLE
Consistently dispose PolyglotEngine after being used in tests

### DIFF
--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/utilities/InstrumentationTestMode.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/utilities/InstrumentationTestMode.java
@@ -33,8 +33,8 @@ public class InstrumentationTestMode {
 
     public static void set(boolean enable) {
 
+        final PolyglotEngine vm = PolyglotEngine.newBuilder().build();
         try {
-            final PolyglotEngine vm = PolyglotEngine.newBuilder().build();
             final Field instrumenterField = vm.getClass().getDeclaredField("instrumenter");
             instrumenterField.setAccessible(true);
             final Object instrumenter = instrumenterField.get(vm);
@@ -47,6 +47,8 @@ public class InstrumentationTestMode {
             }
         } catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException ex) {
             fail("Reflective access to Instrumenter for testing");
+        } finally {
+            vm.dispose();
         }
 
     }

--- a/truffle/com.oracle.truffle.api.interop.java.test/src/com/oracle/truffle/api/interop/java/test/InstrumentationTestMode.java
+++ b/truffle/com.oracle.truffle.api.interop.java.test/src/com/oracle/truffle/api/interop/java/test/InstrumentationTestMode.java
@@ -35,8 +35,8 @@ public class InstrumentationTestMode {
 
     public static void set(boolean enable) {
 
+        final PolyglotEngine vm = PolyglotEngine.newBuilder().build();
         try {
-            final PolyglotEngine vm = PolyglotEngine.newBuilder().build();
             final Field instrumenterField = vm.getClass().getDeclaredField("instrumenter");
             instrumenterField.setAccessible(true);
             final Object instrumenter = instrumenterField.get(vm);
@@ -49,6 +49,8 @@ public class InstrumentationTestMode {
             }
         } catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException ex) {
             fail("Reflective access to Instrumenter for testing");
+        } finally {
+            vm.dispose();
         }
 
     }

--- a/truffle/com.oracle.truffle.api.interop.java.test/src/com/oracle/truffle/api/interop/java/test/JavaFunctionTest.java
+++ b/truffle/com.oracle.truffle.api.interop.java.test/src/com/oracle/truffle/api/interop/java/test/JavaFunctionTest.java
@@ -27,15 +27,18 @@ package com.oracle.truffle.api.interop.java.test;
 import com.oracle.truffle.api.interop.java.JavaInterop;
 import com.oracle.truffle.api.vm.PolyglotEngine;
 import java.io.IOException;
+import org.junit.After;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 public class JavaFunctionTest {
+    private PolyglotEngine engine;
+
     @Test
     public void invokeRunnable() throws IOException {
         final boolean[] called = {false};
 
-        PolyglotEngine engine = PolyglotEngine.newBuilder().globalSymbol("test", JavaInterop.asTruffleFunction(Runnable.class, new Runnable() {
+        engine = PolyglotEngine.newBuilder().globalSymbol("test", JavaInterop.asTruffleFunction(Runnable.class, new Runnable() {
             @Override
             public void run() {
                 called[0] = true;
@@ -44,5 +47,12 @@ public class JavaFunctionTest {
         engine.findGlobalSymbol("test").execute();
 
         assertTrue("Runnable has been called", called[0]);
+    }
+
+    @After
+    public void dispose() {
+        if (engine != null) {
+            engine.dispose();
+        }
     }
 }

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/impl/AccessorTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/impl/AccessorTest.java
@@ -40,10 +40,12 @@ import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.vm.ImplicitExplicitExportTest.ExportImportLanguage1;
 import com.oracle.truffle.api.vm.PolyglotEngine;
+import org.junit.After;
 
 public class AccessorTest {
     private static Method find;
     private static Field instrumenthandler;
+    private PolyglotEngine engine;
 
     /**
      * Reflection access to package-private members.
@@ -59,17 +61,24 @@ public class AccessorTest {
         instrumenthandler.setAccessible(true);
     }
 
+    @After
+    public void dispose() {
+        if (engine != null) {
+            engine.dispose();
+        }
+    }
+
     @Test
     public void canGetAccessToOwnLanguageInstance() throws Exception {
-        PolyglotEngine vm = PolyglotEngine.newBuilder().executor(Executors.newSingleThreadExecutor()).build();
-        PolyglotEngine.Language language = vm.getLanguages().get(L1);
+        engine = PolyglotEngine.newBuilder().executor(Executors.newSingleThreadExecutor()).build();
+        PolyglotEngine.Language language = engine.getLanguages().get(L1);
         assertNotNull("L1 language is defined", language);
 
         Source s = Source.fromText("return nothing", "nothing");
         Object ret = language.eval(s).get();
         assertNull("nothing is returned", ret);
 
-        ExportImportLanguage1 afterInitialization = (ExportImportLanguage1) find.invoke(null, vm, ExportImportLanguage1.class);
+        ExportImportLanguage1 afterInitialization = (ExportImportLanguage1) find.invoke(null, engine, ExportImportLanguage1.class);
         assertNotNull("Language found", afterInitialization);
     }
 

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/instrument/InstrumentationTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/instrument/InstrumentationTest.java
@@ -45,6 +45,7 @@ import com.oracle.truffle.api.nodes.NodeVisitor;
 import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.vm.PolyglotEngine;
+import org.junit.After;
 
 /**
  * <h3>AST Instrumentation</h3>
@@ -55,10 +56,17 @@ import com.oracle.truffle.api.vm.PolyglotEngine;
  */
 public class InstrumentationTest {
 
+    private PolyglotEngine vm;
+
+    @After
+    public void dispose() {
+        vm.dispose();
+    }
+
     @Test
     @Ignore
     public void testProbing() throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException, IOException {
-        final PolyglotEngine vm = PolyglotEngine.newBuilder().build();
+        vm = PolyglotEngine.newBuilder().build();
         final Field field = PolyglotEngine.class.getDeclaredField("instrumenter");
         field.setAccessible(true);
         final Instrumenter instrumenter = (Instrumenter) field.get(vm);
@@ -101,7 +109,7 @@ public class InstrumentationTest {
     @Ignore
     public void testTagging() throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException, IOException {
 
-        final PolyglotEngine vm = PolyglotEngine.newBuilder().build();
+        vm = PolyglotEngine.newBuilder().build();
         final Field field = PolyglotEngine.class.getDeclaredField("instrumenter");
         field.setAccessible(true);
         final Instrumenter instrumenter = (Instrumenter) field.get(vm);

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/utilities/InstrumentationTestMode.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/utilities/InstrumentationTestMode.java
@@ -32,9 +32,8 @@ import com.oracle.truffle.api.vm.PolyglotEngine;
 public class InstrumentationTestMode {
 
     public static void set(boolean enable) {
-
+        final PolyglotEngine vm = PolyglotEngine.newBuilder().build();
         try {
-            final PolyglotEngine vm = PolyglotEngine.newBuilder().build();
             final Field instrumenterField = vm.getClass().getDeclaredField("instrumenter");
             instrumenterField.setAccessible(true);
             final Object instrumenter = instrumenterField.get(vm);
@@ -47,7 +46,8 @@ public class InstrumentationTestMode {
             }
         } catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException ex) {
             fail("Reflective access to Instrumenter for testing");
+        } finally {
+            vm.dispose();
         }
-
     }
 }

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/EngineTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/EngineTest.java
@@ -38,16 +38,35 @@ import static com.oracle.truffle.api.vm.ImplicitExplicitExportTest.L1_ALT;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import com.oracle.truffle.api.vm.PolyglotEngine.Builder;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import org.junit.After;
 import static org.junit.Assert.assertSame;
 
 public class EngineTest {
+    private Set<PolyglotEngine> toDispose = new HashSet<>();
+
     protected PolyglotEngine.Builder createBuilder() {
         return PolyglotEngine.newBuilder();
+    }
+
+    private PolyglotEngine register(PolyglotEngine engine) {
+        toDispose.add(engine);
+        return engine;
+    }
+
+    @After
+    public void dispose() {
+        for (PolyglotEngine engine : toDispose) {
+            engine.dispose();
+        }
     }
 
     @Test
     public void npeWhenCastingAs() throws Exception {
         PolyglotEngine tvm = createBuilder().build();
+        register(tvm);
 
         PolyglotEngine.Language language1 = tvm.getLanguages().get("application/x-test-import-export-1");
         PolyglotEngine.Language language2 = tvm.getLanguages().get("application/x-test-import-export-2");
@@ -61,7 +80,9 @@ public class EngineTest {
     @Test
     public void checkCachingOfNodes() throws IOException {
         PolyglotEngine vm1 = createBuilder().build();
-        PolyglotEngine vm2 = createBuilder().build();
+        register(vm1);
+        PolyglotEngine vm2 = createBuilder().executor(Executors.newSingleThreadExecutor()).build();
+        register(vm2);
 
         PolyglotEngine.Language language1 = vm1.getLanguages().get("application/x-test-hash");
         PolyglotEngine.Language language2 = vm2.getLanguages().get("application/x-test-hash");
@@ -109,6 +130,8 @@ public class EngineTest {
         Object[][] matrix = {{1, 2, 3}};
 
         PolyglotEngine tvm = createBuilder().globalSymbol("arr", new ArrayTruffleObject(matrix, forbiddenThread())).build();
+        register(tvm);
+
         PolyglotEngine.Language language1 = tvm.getLanguages().get("application/x-test-import-export-1");
         AccessArray access = language1.eval(Source.fromText("return=arr", "get the array")).as(AccessArray.class);
         assertNotNull("Array converted to list", access);
@@ -131,6 +154,7 @@ public class EngineTest {
         builder.config("application/x-test-import-export-1", "cmd-line-args", new String[]{"1", "2"});
         builder.config("application/x-test-import-export-2", "hello", "world");
         PolyglotEngine vm = builder.build();
+        register(vm);
 
         PolyglotEngine.Language language1 = vm.getLanguages().get("application/x-test-import-export-1");
 
@@ -159,6 +183,8 @@ public class EngineTest {
         builder.config("application/x-test-import-export-1", "cmd-line-args", new String[]{"1", "2"});
         builder.config("application/x-test-import-export-2", "hello", "world");
         PolyglotEngine vm = builder.build();
+        register(vm);
+
         PolyglotEngine.Language language1 = vm.getLanguages().get("application/x-test-import-export-1");
         Ctx ctx1 = language1.getGlobalObject().as(Ctx.class);
 
@@ -177,6 +203,7 @@ public class EngineTest {
         builder.config("application/x-test-import-export-2", "hello", "truffle");
         builder.config("application/x-test-import-export-2", "hello", "world");
         PolyglotEngine vm = builder.build();
+        register(vm);
 
         PolyglotEngine.Language language2 = vm.getLanguages().get("application/x-test-import-export-2");
         Ctx ctx2 = language2.getGlobalObject().as(Ctx.class);
@@ -189,6 +216,7 @@ public class EngineTest {
         builder.config("application/x-test-import-export-2", "hello", "world");
         builder.config("application/x-test-import-export-2", "hello", "truffle");
         PolyglotEngine vm = builder.build();
+        register(vm);
 
         PolyglotEngine.Language language2 = vm.getLanguages().get("application/x-test-import-export-2");
         Ctx ctx2 = language2.getGlobalObject().as(Ctx.class);
@@ -201,6 +229,7 @@ public class EngineTest {
         builder.config(L1, "hello", "truffle");
         builder.config(L1_ALT, "hello", "world");
         PolyglotEngine vm = builder.build();
+        register(vm);
 
         PolyglotEngine.Language language1 = vm.getLanguages().get(L1);
         Ctx ctx2 = language1.getGlobalObject().as(Ctx.class);
@@ -213,6 +242,7 @@ public class EngineTest {
         builder.config(L1_ALT, "hello", "truffle");
         builder.config(L1, "hello", "world");
         PolyglotEngine vm = builder.build();
+        register(vm);
 
         PolyglotEngine.Language language1 = vm.getLanguages().get(L1);
         Ctx ctx2 = language1.getGlobalObject().as(Ctx.class);
@@ -223,6 +253,7 @@ public class EngineTest {
     public void configIsNeverNull() throws IOException {
         Builder builder = createBuilder();
         PolyglotEngine vm = builder.build();
+        register(vm);
 
         PolyglotEngine.Language language1 = vm.getLanguages().get(L1);
         Ctx ctx2 = language1.getGlobalObject().as(Ctx.class);
@@ -242,10 +273,14 @@ public class EngineTest {
         PolyglotEngine vm = builder.build();
         // @formatter:on
 
-        PolyglotEngine.Language language1 = vm.getLanguages().get(L1);
-        Ctx ctx2 = language1.getGlobalObject().as(Ctx.class);
-        String[] read = (String[]) ctx2.env.getConfig().get("CMD_ARGS");
+        try {
+            PolyglotEngine.Language language1 = vm.getLanguages().get(L1);
+            Ctx ctx2 = language1.getGlobalObject().as(Ctx.class);
+            String[] read = (String[]) ctx2.env.getConfig().get("CMD_ARGS");
 
-        assertSame("The same array as specified is returned", args, read);
+            assertSame("The same array as specified is returned", args, read);
+        } finally {
+            vm.dispose();
+        }
     }
 }

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/GlobalSymbolTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/GlobalSymbolTest.java
@@ -41,6 +41,8 @@ import com.oracle.truffle.api.utilities.InstrumentationTestMode;
 
 public class GlobalSymbolTest {
 
+    private PolyglotEngine vm;
+
     @Before
     public void before() {
         InstrumentationTestMode.set(true);
@@ -49,11 +51,14 @@ public class GlobalSymbolTest {
     @After
     public void after() {
         InstrumentationTestMode.set(false);
+        if (vm != null) {
+            vm.dispose();
+        }
     }
 
     @Test
     public void globalSymbolFoundByLanguage() throws IOException {
-        PolyglotEngine vm = createEngineBuilder().globalSymbol("ahoj", "42").build();
+        vm = createEngineBuilder().globalSymbol("ahoj", "42").build();
         // @formatter:off
         Object ret = vm.eval(
             Source.fromText("return=ahoj", "Return").withMimeType(L3)
@@ -64,7 +69,7 @@ public class GlobalSymbolTest {
 
     @Test
     public void globalSymbolFoundByVMUser() throws IOException {
-        PolyglotEngine vm = createEngineBuilder().globalSymbol("ahoj", "42").build();
+        vm = createEngineBuilder().globalSymbol("ahoj", "42").build();
         PolyglotEngine.Value ret = vm.findGlobalSymbol("ahoj");
         assertNotNull("Symbol found", ret);
         assertEquals("42", ret.get());
@@ -76,7 +81,7 @@ public class GlobalSymbolTest {
 
     @Test
     public void passingArray() throws IOException {
-        PolyglotEngine vm = createEngineBuilder().globalSymbol("arguments", new Object[]{"one", "two", "three"}).build();
+        vm = createEngineBuilder().globalSymbol("arguments", new Object[]{"one", "two", "three"}).build();
         PolyglotEngine.Value value = vm.findGlobalSymbol("arguments");
         assertFalse("Not instance of array", value.get() instanceof Object[]);
         assertTrue("Instance of TruffleObject", value.get() instanceof TruffleObject);

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/ImplicitExplicitExportTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/ImplicitExplicitExportTest.java
@@ -70,6 +70,9 @@ public class ImplicitExplicitExportTest {
     @After
     public void cleanThread() {
         mainThread = null;
+        if (vm != null) {
+            vm.dispose();
+        }
     }
 
     @Test

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/InitializationTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/InitializationTest.java
@@ -48,6 +48,7 @@ import com.oracle.truffle.api.nodes.NodeVisitor;
 import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.source.SourceSection;
+import org.junit.After;
 
 /**
  * Bug report validating test.
@@ -61,9 +62,18 @@ import com.oracle.truffle.api.source.SourceSection;
  */
 public class InitializationTest {
 
+    private PolyglotEngine vm;
+
+    @After
+    public void dispose() {
+        if (vm != null) {
+            vm.dispose();
+        }
+    }
+
     @Test
     public void accessProbeForAbstractLanguage() throws IOException, NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
-        PolyglotEngine vm = PolyglotEngine.newBuilder().build();
+        vm = PolyglotEngine.newBuilder().build();
 
         final Field field = PolyglotEngine.class.getDeclaredField("instrumenter");
         field.setAccessible(true);
@@ -89,6 +99,7 @@ public class InitializationTest {
         assertEquals(vm.eval(source).get(), 1);
 
         vm.dispose();
+        vm = null;
     }
 
     private static final class MMRootNode extends RootNode {

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/IsMimeTypeSupportedTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/IsMimeTypeSupportedTest.java
@@ -29,14 +29,26 @@ import java.io.IOException;
 import org.junit.Test;
 
 import com.oracle.truffle.api.source.Source;
+import org.junit.After;
+import org.junit.Before;
 
 public class IsMimeTypeSupportedTest {
 
     private static final String MIME_TYPE = "application/x-test-mime-type-supported";
+    private PolyglotEngine vm;
+
+    @Before
+    public void create() {
+        vm = PolyglotEngine.newBuilder().build();
+    }
+
+    @After
+    public void dispose() {
+        vm.dispose();
+    }
 
     @Test
     public void isMimeSupported() throws IOException {
-        PolyglotEngine vm = PolyglotEngine.newBuilder().build();
         assertEquals(true, vm.eval(Source.fromText(MIME_TYPE, "supported").withMimeType(MIME_TYPE)).as(Boolean.class));
         assertEquals(false, vm.eval(Source.fromText("application/x-this-language-does-not-exist", "unsupported").withMimeType(MIME_TYPE)).as(Boolean.class));
     }

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/ToStringTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/ToStringTest.java
@@ -27,11 +27,21 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 
 import com.oracle.truffle.api.source.Source;
+import org.junit.After;
 
 public class ToStringTest {
+    private PolyglotEngine engine;
+
+    @After
+    public void dispose() {
+        if (engine != null) {
+            engine.dispose();
+        }
+    }
+
     @Test
     public void valueToStringValueWith1() throws Exception {
-        PolyglotEngine engine = PolyglotEngine.newBuilder().build();
+        engine = PolyglotEngine.newBuilder().build();
         PolyglotEngine.Language language1 = engine.getLanguages().get("application/x-test-import-export-1");
         PolyglotEngine.Language language2 = engine.getLanguages().get("application/x-test-import-export-2");
         language2.eval(Source.fromText("explicit.value=42", "define 42"));
@@ -44,7 +54,7 @@ public class ToStringTest {
 
     @Test
     public void valueToStringValueWith2() throws Exception {
-        PolyglotEngine engine = PolyglotEngine.newBuilder().build();
+        engine = PolyglotEngine.newBuilder().build();
         PolyglotEngine.Language language1 = engine.getLanguages().get("application/x-test-import-export-1");
         PolyglotEngine.Language language2 = engine.getLanguages().get("application/x-test-import-export-2");
         language1.eval(Source.fromText("explicit.value=42", "define 42"));

--- a/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/ValueTest.java
+++ b/truffle/com.oracle.truffle.api.test/src/com/oracle/truffle/api/vm/ValueTest.java
@@ -37,13 +37,22 @@ import java.util.concurrent.Executor;
 import org.junit.Test;
 
 import com.oracle.truffle.api.source.Source;
+import org.junit.After;
 
 public class ValueTest implements Executor {
-    private List<Runnable> pending = new LinkedList<>();
+    private final List<Runnable> pending = new LinkedList<>();
+    private PolyglotEngine engine;
+
+    @After
+    public void dispose() {
+        if (engine != null) {
+            engine.dispose();
+        }
+    }
 
     @Test
     public void valueToStringValue() throws Exception {
-        PolyglotEngine engine = PolyglotEngine.newBuilder().build();
+        engine = PolyglotEngine.newBuilder().build();
         PolyglotEngine.Language language1 = engine.getLanguages().get("application/x-test-import-export-1");
         PolyglotEngine.Language language2 = engine.getLanguages().get("application/x-test-import-export-2");
         language2.eval(Source.fromText("explicit.value=42", "define 42"));
@@ -58,7 +67,7 @@ public class ValueTest implements Executor {
 
     @Test
     public void valueToStringException() throws Exception {
-        PolyglotEngine engine = PolyglotEngine.newBuilder().build();
+        engine = PolyglotEngine.newBuilder().build();
         PolyglotEngine.Language language1 = engine.getLanguages().get("application/x-test-import-export-1");
         PolyglotEngine.Value value = null;
         try {
@@ -74,7 +83,7 @@ public class ValueTest implements Executor {
 
     @Test
     public void valueToStringValueAsync() throws Exception {
-        PolyglotEngine engine = PolyglotEngine.newBuilder().executor(this).build();
+        engine = PolyglotEngine.newBuilder().executor(this).build();
         PolyglotEngine.Language language1 = engine.getLanguages().get("application/x-test-import-export-1");
         PolyglotEngine.Language language2 = engine.getLanguages().get("application/x-test-import-export-2");
         language2.eval(Source.fromText("explicit.value=42", "define 42"));
@@ -98,7 +107,7 @@ public class ValueTest implements Executor {
 
     @Test
     public void valueToStringExceptionAsync() throws Exception {
-        PolyglotEngine engine = PolyglotEngine.newBuilder().executor(this).build();
+        engine = PolyglotEngine.newBuilder().executor(this).build();
         PolyglotEngine.Language language1 = engine.getLanguages().get("application/x-test-import-export-1");
         PolyglotEngine.Value value = language1.eval(Source.fromText("parse=does not work", "error.value"));
         assertNotNull("Value returned", value);

--- a/truffle/com.oracle.truffle.sl.test/src/com/oracle/truffle/sl/test/ParsingCachedTest.java
+++ b/truffle/com.oracle.truffle.sl.test/src/com/oracle/truffle/sl/test/ParsingCachedTest.java
@@ -43,17 +43,27 @@ package com.oracle.truffle.sl.test;
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.vm.PolyglotEngine;
 import com.oracle.truffle.sl.SLLanguage;
+import org.junit.After;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import org.junit.Test;
 
 public class ParsingCachedTest {
 
+    private PolyglotEngine engine;
+
+    @After
+    public void dispose() {
+        if (engine != null) {
+            engine.dispose();
+        }
+    }
+
     @Test
     public void stepInStepOver() throws Throwable {
         Source nullSrc = Source.fromText("function main() {}", "yields null").withMimeType("application/x-sl");
 
-        PolyglotEngine engine = PolyglotEngine.newBuilder().build();
+        engine = PolyglotEngine.newBuilder().build();
         int cnt = SLLanguage.parsingCount();
         Object res = engine.eval(nullSrc).get();
         assertNull("Is null", res);

--- a/truffle/com.oracle.truffle.sl.test/src/com/oracle/truffle/sl/test/SLDebugTest.java
+++ b/truffle/com.oracle.truffle.sl.test/src/com/oracle/truffle/sl/test/SLDebugTest.java
@@ -63,6 +63,7 @@ import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.vm.EventConsumer;
 import com.oracle.truffle.api.vm.PolyglotEngine;
 import com.oracle.truffle.api.vm.PolyglotEngine.Value;
+import org.junit.After;
 
 public class SLDebugTest {
     private Debugger debugger;
@@ -95,6 +96,13 @@ public class SLDebugTest {
             }
         }).build();
         run.clear();
+    }
+
+    @After
+    public void dispose() {
+        if (engine != null) {
+            engine.dispose();
+        }
     }
 
     private static Source createFactorial() {

--- a/truffle/com.oracle.truffle.sl.test/src/com/oracle/truffle/sl/test/SLJavaInteropTest.java
+++ b/truffle/com.oracle.truffle.sl.test/src/com/oracle/truffle/sl/test/SLJavaInteropTest.java
@@ -59,6 +59,9 @@ import org.junit.Test;
 
 public class SLJavaInteropTest {
 
+    private PolyglotEngine engine;
+    private ByteArrayOutputStream os;
+
     @Before
     public void before() {
         InstrumentationTestMode.set(true);
@@ -69,12 +72,21 @@ public class SLJavaInteropTest {
         InstrumentationTestMode.set(false);
     }
 
+    @Before
+    public void create() {
+        os = new ByteArrayOutputStream();
+        engine = PolyglotEngine.newBuilder().setOut(os).build();
+    }
+
+    @After
+    public void dispose() {
+        engine.dispose();
+    }
+
     @Test
     public void asFunction() throws Exception {
         String scriptText = "function main() {\n" + "    println(\"Called!\");\n" + "}\n";
         Source script = Source.fromText(scriptText, "Test").withMimeType("application/x-sl");
-        ByteArrayOutputStream os = new ByteArrayOutputStream();
-        PolyglotEngine engine = PolyglotEngine.newBuilder().setOut(os).build();
         engine.eval(script);
         PolyglotEngine.Value main = engine.findGlobalSymbol("main");
         final Object value = main.get();

--- a/truffle/com.oracle.truffle.sl.test/src/com/oracle/truffle/sl/test/SLPolyglotTest.java
+++ b/truffle/com.oracle.truffle.sl.test/src/com/oracle/truffle/sl/test/SLPolyglotTest.java
@@ -45,12 +45,22 @@ import org.junit.Test;
 import com.oracle.truffle.api.vm.PolyglotEngine;
 import com.oracle.truffle.api.vm.PolyglotEngine.Language;
 import java.io.IOException;
+import org.junit.After;
 import static org.junit.Assert.assertNotNull;
 
 public class SLPolyglotTest {
+    private PolyglotEngine vm;
+
+    @After
+    public void dispose() {
+        if (vm != null) {
+            vm.dispose();
+        }
+    }
+
     @Test
     public void accessGlobalObject() throws IOException {
-        PolyglotEngine vm = PolyglotEngine.newBuilder().build();
+        vm = PolyglotEngine.newBuilder().build();
         Language lang = vm.getLanguages().get("application/x-sl");
         PolyglotEngine.Value global = lang.getGlobalObject();
         Object globalValue = global.get();

--- a/truffle/com.oracle.truffle.sl.test/src/com/oracle/truffle/sl/test/SLTckTest.java
+++ b/truffle/com.oracle.truffle.sl.test/src/com/oracle/truffle/sl/test/SLTckTest.java
@@ -72,11 +72,12 @@ public class SLTckTest extends TruffleTCK {
     public void testVerifyPresence() {
         PolyglotEngine vm = PolyglotEngine.newBuilder().build();
         assertTrue("Our language is present", vm.getLanguages().containsKey("application/x-sl"));
+        vm.dispose();
     }
 
     @Override
-    protected PolyglotEngine prepareVM() throws Exception {
-        PolyglotEngine vm = PolyglotEngine.newBuilder().build();
+    protected PolyglotEngine prepareVM(PolyglotEngine.Builder builder) throws Exception {
+        PolyglotEngine vm = builder.build();
         // @formatter:off
         vm.eval(
             Source.fromText(

--- a/truffle/com.oracle.truffle.sl.test/src/com/oracle/truffle/sl/test/SLTestRunner.java
+++ b/truffle/com.oracle.truffle.sl.test/src/com/oracle/truffle/sl/test/SLTestRunner.java
@@ -285,9 +285,9 @@ public final class SLTestRunner extends ParentRunner<TestCase> {
         notifier.fireTestStarted(testCase.name);
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
+        PolyglotEngine vm = null;
         try {
-            PolyglotEngine vm = PolyglotEngine.newBuilder().setIn(new ByteArrayInputStream(repeat(testCase.testInput, repeats).getBytes("UTF-8"))).setOut(out).build();
-
+            vm = PolyglotEngine.newBuilder().setIn(new ByteArrayInputStream(repeat(testCase.testInput, repeats).getBytes("UTF-8"))).setOut(out).build();
             String script = readAllLines(testCase.path);
 
             PrintWriter printer = new PrintWriter(out);
@@ -299,6 +299,9 @@ public final class SLTestRunner extends ParentRunner<TestCase> {
         } catch (Throwable ex) {
             notifier.fireTestFailure(new Failure(testCase.name, new IllegalStateException("Cannot run " + testCase.sourceName, ex)));
         } finally {
+            if (vm != null) {
+                vm.dispose();
+            }
             notifier.fireTestFinished(testCase.name);
         }
     }

--- a/truffle/com.oracle.truffle.sl.test/src/com/oracle/truffle/sl/test/ToStringOfEvalTest.java
+++ b/truffle/com.oracle.truffle.sl.test/src/com/oracle/truffle/sl/test/ToStringOfEvalTest.java
@@ -43,16 +43,28 @@ package com.oracle.truffle.sl.test;
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.vm.PolyglotEngine;
 import java.io.IOException;
+import org.junit.After;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import org.junit.Before;
 import org.junit.Test;
 
 public class ToStringOfEvalTest {
+    PolyglotEngine engine;
+
+    @Before
+    public void initialize() {
+        engine = PolyglotEngine.newBuilder().build();
+    }
+
+    @After
+    public void dispose() {
+        engine.dispose();
+    }
 
     @Test
     public void checkToStringOnAFunction() throws IOException {
-        PolyglotEngine engine = PolyglotEngine.newBuilder().build();
         PolyglotEngine.Language sl = engine.getLanguages().get("application/x-sl");
         sl.eval(Source.fromText("function checkName() {}", "defineFn"));
         PolyglotEngine.Value value1 = engine.findGlobalSymbol("checkName");

--- a/truffle/com.oracle.truffle.sl.test/src/com/oracle/truffle/sl/test/instrument/InstrumentationTestMode.java
+++ b/truffle/com.oracle.truffle.sl.test/src/com/oracle/truffle/sl/test/instrument/InstrumentationTestMode.java
@@ -51,8 +51,8 @@ public class InstrumentationTestMode {
 
     public static void set(boolean enable) {
 
+        final PolyglotEngine vm = PolyglotEngine.newBuilder().build();
         try {
-            final PolyglotEngine vm = PolyglotEngine.newBuilder().build();
             final Field instrumenterField = vm.getClass().getDeclaredField("instrumenter");
             instrumenterField.setAccessible(true);
             final Object instrumenter = instrumenterField.get(vm);
@@ -65,6 +65,8 @@ public class InstrumentationTestMode {
             }
         } catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException ex) {
             fail("Reflective access to Instrumenter for testing");
+        } finally {
+            vm.dispose();
         }
 
     }

--- a/truffle/com.oracle.truffle.sl.test/src/com/oracle/truffle/sl/test/instrument/SLInstrumentTestRunner.java
+++ b/truffle/com.oracle.truffle.sl.test/src/com/oracle/truffle/sl/test/instrument/SLInstrumentTestRunner.java
@@ -236,11 +236,12 @@ public final class SLInstrumentTestRunner extends ParentRunner<InstrumentTestCas
         PrintStream ps = new PrintStream(out);
         final ASTProber prober = new SLStandardASTProber();
 
+        PolyglotEngine vm = null;
         try {
             // We use the name of the file to determine what visitor to attach to it.
             if (testCase.baseName.endsWith(ASSIGNMENT_VALUE_SUFFIX)) {
                 // Set up the execution context for Simple and register our two listeners
-                PolyglotEngine vm = PolyglotEngine.newBuilder().setIn(new ByteArrayInputStream(testCase.testInput.getBytes("UTF-8"))).setOut(out).build();
+                vm = PolyglotEngine.newBuilder().setIn(new ByteArrayInputStream(testCase.testInput.getBytes("UTF-8"))).setOut(out).build();
 
                 final Field field = PolyglotEngine.class.getDeclaredField("instrumenter");
                 field.setAccessible(true);
@@ -267,6 +268,9 @@ public final class SLInstrumentTestRunner extends ParentRunner<InstrumentTestCas
         } catch (Throwable ex) {
             notifier.fireTestFailure(new Failure(testCase.name, ex));
         } finally {
+            if (vm != null) {
+                vm.dispose();
+            }
             notifier.fireTestFinished(testCase.name);
         }
 

--- a/truffle/com.oracle.truffle.sl/src/com/oracle/truffle/sl/SLLanguage.java
+++ b/truffle/com.oracle.truffle.sl/src/com/oracle/truffle/sl/SLLanguage.java
@@ -242,6 +242,7 @@ public final class SLLanguage extends TruffleLanguage<SLContext> {
         while (repeats-- > 0) {
             main.execute();
         }
+        vm.dispose();
     }
 
     public static int parsingCount() {


### PR DESCRIPTION
Consistently dispose PolyglotEngine after being used in tests. Give TruffleTCK and its implementor a chance to co-operate on construction of new PolyglotEngine.

Yesterday Andreas @Woess noted that the change proposed in #85 is huge. I took a look and yes, it seems huge as it contains a lot of fixes in tests. These fixes are however independent of the #85 change - they just consistently dispose `PolyglotEngine` after it has been used. I believe this kind of robustness improving changes can go in without any delay. Thus I am starting this pull request.

In addition to that there is one change in `TruffleTCK` to allow the TCK and the tested language to co-operate on creation of a `PolyglotEngine` - such factory is needed not only for #85, but also to test import of symbols - the TCK needs to pre-register them into the builder which will be possible with this new method. 


