### PR TITLE
Add lineStartsIn and lineEndsIn to source section filters.

### DIFF
--- a/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/BreakpointFactory.java
+++ b/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/BreakpointFactory.java
@@ -57,6 +57,7 @@ import com.oracle.truffle.api.instrumentation.ExecutionEventNode;
 import com.oracle.truffle.api.instrumentation.ExecutionEventNodeFactory;
 import com.oracle.truffle.api.instrumentation.Instrumenter;
 import com.oracle.truffle.api.instrumentation.SourceSectionFilter;
+import com.oracle.truffle.api.instrumentation.SourceSectionFilter.IndexRange;
 import com.oracle.truffle.api.nodes.DirectCallNode;
 import com.oracle.truffle.api.nodes.InvalidAssumptionException;
 import com.oracle.truffle.api.nodes.Node;
@@ -153,7 +154,8 @@ final class BreakpointFactory {
     Breakpoint create(int ignoreCount, LineLocation lineLocation, boolean oneShot) throws IOException {
         BreakpointImpl breakpoint = breakpoints.get(lineLocation);
         if (breakpoint == null) {
-            final SourceSectionFilter query = SourceSectionFilter.newBuilder().sourceIs(lineLocation.getSource()).lineIs(lineLocation.getLineNumber()).tagIs(Debugger.HALT_TAG).build();
+            final SourceSectionFilter query = SourceSectionFilter.newBuilder().sourceIs(lineLocation.getSource()).lineStartsIn(IndexRange.byLength(lineLocation.getLineNumber(), 1)).tagIs(
+                            Debugger.HALT_TAG).build();
             breakpoint = new BreakpointImpl(lineLocation, query, ignoreCount, oneShot);
             if (TRACE) {
                 trace("NEW " + breakpoint.getShortDescription());

--- a/truffle/com.oracle.truffle.api.instrumentation.test/src/com/oracle/truffle/api/instrumentation/SourceSectionFilterTest.java
+++ b/truffle/com.oracle.truffle.api.instrumentation.test/src/com/oracle/truffle/api/instrumentation/SourceSectionFilterTest.java
@@ -592,10 +592,10 @@ public class SourceSectionFilterTest {
         SourceSection root = sampleSource1.createSection(null, 0, 23);
 
         SourceSectionFilter filter = SourceSectionFilter.newBuilder().tagIs(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.DEFINE).//
-                        tagIsNot(InstrumentationTestLanguage.DEFINE, InstrumentationTestLanguage.ROOT).//
-                        indexIn(0, 3).//
-                        sourceIs(sampleSource1).sourceSectionEquals(sampleSource1.createSection(null, 0, 5)).//
-                        lineIn(1, 1).lineIs(1).mimeTypeIs("mime1", "mime2").build();
+        tagIsNot(InstrumentationTestLanguage.DEFINE, InstrumentationTestLanguage.ROOT).//
+        indexIn(0, 3).//
+        sourceIs(sampleSource1).sourceSectionEquals(sampleSource1.createSection(null, 0, 5)).//
+        lineIn(1, 1).lineIs(1).mimeTypeIs("mime1", "mime2").build();
 
         Assert.assertFalse(isInstrumented(filter, root, source()));
         Assert.assertTrue(isInstrumentedRoot(filter, null));

--- a/truffle/com.oracle.truffle.api.instrumentation.test/src/com/oracle/truffle/api/instrumentation/SourceSectionFilterTest.java
+++ b/truffle/com.oracle.truffle.api.instrumentation.test/src/com/oracle/truffle/api/instrumentation/SourceSectionFilterTest.java
@@ -151,6 +151,54 @@ public class SourceSectionFilterTest {
     }
 
     @Test
+    public void testLineStartIn() {
+        Source sampleSource = Source.fromText("line1\nline2\nline3\nline4", null);
+        SourceSection root = sampleSource.createSection(null, 0, 23);
+
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().lineStartsIn(IndexRange.byLength(2, 1)).build(),
+                        root, sampleSource.createSection(null, 6, 15, tags())));
+
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().lineStartsIn(IndexRange.byLength(2, 1)).build(),
+                        root, sampleSource.createSection(null, 0, 15, tags())));
+
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().lineStartsIn(IndexRange.byLength(2, 2)).build(),
+                        root, sampleSource.createSection(null, 0, 15, tags())));
+
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().lineStartsIn(IndexRange.byLength(1, 2)).build(),
+                        root, sampleSource.createSection(null, 0, 15, tags())));
+
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().lineStartsIn(IndexRange.byLength(1, 2)).build(),
+                        root, sampleSource.createSection(null, 6, 15, tags())));
+
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().lineStartsIn(IndexRange.byLength(1, 2)).build(),
+                        root, sampleSource.createSection(null, 12, 6, tags())));
+    }
+
+    @Test
+    public void testLineEndsIn() {
+        Source sampleSource = Source.fromText("line1\nline2\nline3\nline4", null);
+        SourceSection root = sampleSource.createSection(null, 0, 23);
+
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().lineEndsIn(IndexRange.byLength(2, 1)).build(),
+                        root, sampleSource.createSection(null, 6, 6, tags())));
+
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().lineEndsIn(IndexRange.byLength(2, 1)).build(),
+                        root, sampleSource.createSection(null, 0, 6, tags())));
+
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().lineEndsIn(IndexRange.byLength(2, 2)).build(),
+                        root, sampleSource.createSection(null, 0, 6, tags())));
+
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().lineEndsIn(IndexRange.byLength(1, 2)).build(),
+                        root, sampleSource.createSection(null, 0, 6, tags())));
+
+        Assert.assertTrue(isInstrumented(SourceSectionFilter.newBuilder().lineEndsIn(IndexRange.byLength(1, 2)).build(),
+                        root, sampleSource.createSection(null, 6, 6, tags())));
+
+        Assert.assertFalse(isInstrumented(SourceSectionFilter.newBuilder().lineEndsIn(IndexRange.byLength(1, 2)).build(),
+                        root, sampleSource.createSection(null, 12, 6, tags())));
+    }
+
+    @Test
     public void testLineNotIn() {
         Source sampleSource = Source.fromText("line1\nline2\nline3\nline4", null);
         SourceSection root = sampleSource.createSection(null, 0, 23);
@@ -544,10 +592,10 @@ public class SourceSectionFilterTest {
         SourceSection root = sampleSource1.createSection(null, 0, 23);
 
         SourceSectionFilter filter = SourceSectionFilter.newBuilder().tagIs(InstrumentationTestLanguage.EXPRESSION, InstrumentationTestLanguage.DEFINE).//
-        tagIsNot(InstrumentationTestLanguage.DEFINE, InstrumentationTestLanguage.ROOT).//
-        indexIn(0, 3).//
-        sourceIs(sampleSource1).sourceSectionEquals(sampleSource1.createSection(null, 0, 5)).//
-        lineIn(1, 1).lineIs(1).mimeTypeIs("mime1", "mime2").build();
+                        tagIsNot(InstrumentationTestLanguage.DEFINE, InstrumentationTestLanguage.ROOT).//
+                        indexIn(0, 3).//
+                        sourceIs(sampleSource1).sourceSectionEquals(sampleSource1.createSection(null, 0, 5)).//
+                        lineIn(1, 1).lineIs(1).mimeTypeIs("mime1", "mime2").build();
 
         Assert.assertFalse(isInstrumented(filter, root, source()));
         Assert.assertTrue(isInstrumentedRoot(filter, null));

--- a/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/SourceSectionFilter.java
+++ b/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/SourceSectionFilter.java
@@ -262,12 +262,7 @@ public final class SourceSectionFilter {
          * @since 0.12
          */
         public Builder lineIn(IndexRange... ranges) {
-            verifyNotNull(ranges);
-            for (IndexRange indexRange : ranges) {
-                if (indexRange.startIndex < 1) {
-                    throw new IllegalArgumentException(String.format("Start line indices must be >= 1 but were %s.", indexRange.startIndex));
-                }
-            }
+            verifyLineIndices(ranges);
             expressions.add(new EventFilterExpression.LineIn(ranges));
             return this;
         }
@@ -281,12 +276,7 @@ public final class SourceSectionFilter {
          * @since 0.12
          */
         public Builder lineNotIn(IndexRange... ranges) {
-            verifyNotNull(ranges);
-            for (IndexRange indexRange : ranges) {
-                if (indexRange.startIndex < 1) {
-                    throw new IllegalArgumentException(String.format("Start line indices must be >= 1 but were %s.", indexRange.startIndex));
-                }
-            }
+            verifyLineIndices(ranges);
             expressions.add(new Not(new EventFilterExpression.LineIn(ranges)));
             return this;
         }
@@ -302,6 +292,43 @@ public final class SourceSectionFilter {
          */
         public Builder lineIn(int startLine, int length) {
             return lineIn(IndexRange.byLength(startLine, length));
+        }
+
+        /**
+         * Add a filter for all sources sections start in one of the given index ranges. Line
+         * indices must be greater or equal to <code>1</code>.
+         *
+         * @param ranges matches lines that start in one of the given index ranges
+         * @return the builder to chain calls
+         * @since 0.12
+         */
+        public Builder lineStartsIn(IndexRange... ranges) {
+            verifyLineIndices(ranges);
+            expressions.add(new EventFilterExpression.LineStartsIn(ranges));
+            return this;
+        }
+
+        /**
+         * Add a filter for all sources sections end in one of the given index ranges. Line indices
+         * must be greater or equal to <code>1</code>.
+         *
+         * @param ranges matches lines that end in one of the given index ranges
+         * @return the builder to chain calls
+         * @since 0.12
+         */
+        public Builder lineEndsIn(IndexRange... ranges) {
+            verifyLineIndices(ranges);
+            expressions.add(new EventFilterExpression.LineEndsIn(ranges));
+            return this;
+        }
+
+        private void verifyLineIndices(IndexRange... ranges) {
+            verifyNotNull(ranges);
+            for (IndexRange indexRange : ranges) {
+                if (indexRange.startIndex < 1) {
+                    throw new IllegalArgumentException(String.format("Start line indices must be >= 1 but were %s.", indexRange.startIndex));
+                }
+            }
         }
 
         /**
@@ -681,6 +708,88 @@ public final class SourceSectionFilter {
             }
         }
 
+        private static final class LineStartsIn extends EventFilterExpression {
+
+            private final IndexRange[] ranges;
+
+            LineStartsIn(IndexRange[] ranges) {
+                this.ranges = ranges;
+            }
+
+            @Override
+            boolean isRootIncluded(SourceSection rootSourceSection) {
+                return LineIn.isLineIn(rootSourceSection, ranges);
+            }
+
+            @Override
+            boolean isIncluded(SourceSection sourceSection) {
+                int otherStart = sourceSection.getStartLine();
+                for (IndexRange indexRange : ranges) {
+                    if (indexRange.contains(otherStart, otherStart)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            @Override
+            protected int getOrder() {
+                return 10;
+            }
+
+            @Override
+            public String toString() {
+                StringBuilder builder = new StringBuilder("(line-starts-between ");
+                appendRanges(builder, ranges);
+                builder.append(")");
+                return builder.toString();
+            }
+        }
+
+        private static final class LineEndsIn extends EventFilterExpression {
+
+            private final IndexRange[] ranges;
+
+            LineEndsIn(IndexRange[] ranges) {
+                this.ranges = ranges;
+            }
+
+            @Override
+            boolean isRootIncluded(SourceSection rootSourceSection) {
+                return LineIn.isLineIn(rootSourceSection, ranges);
+            }
+
+            @Override
+            boolean isIncluded(SourceSection sourceSection) {
+                int otherStart = sourceSection.getStartLine();
+                int otherEnd;
+                if (sourceSection.getSource() == null) {
+                    otherEnd = otherStart;
+                } else {
+                    otherEnd = sourceSection.getEndLine();
+                }
+                for (IndexRange indexRange : ranges) {
+                    if (indexRange.contains(otherEnd, otherEnd)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            @Override
+            protected int getOrder() {
+                return 10;
+            }
+
+            @Override
+            public String toString() {
+                StringBuilder builder = new StringBuilder("(line-ends-between ");
+                appendRanges(builder, ranges);
+                builder.append(")");
+                return builder.toString();
+            }
+        }
+
         private static final class LineIn extends EventFilterExpression {
 
             private final IndexRange[] ranges;
@@ -696,6 +805,10 @@ public final class SourceSectionFilter {
 
             @Override
             boolean isIncluded(SourceSection sourceSection) {
+                return isLineIn(sourceSection, ranges);
+            }
+
+            static boolean isLineIn(SourceSection sourceSection, IndexRange[] ranges) {
                 int otherStart = sourceSection.getStartLine();
                 int otherEnd;
                 if (sourceSection.getSource() == null) {


### PR DESCRIPTION
This makes sense for when there are ambiguous source section definitions like a breakpoint in an if condition.

Also changed the debugger to use the new lineStartsIn.