### PR TITLE
Added Debugger.pause() and Debugger.isExecuting() methods.

### DIFF
--- a/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/ExecutionEvent.java
+++ b/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/ExecutionEvent.java
@@ -63,6 +63,9 @@ public final class ExecutionEvent {
      * @since 0.9
      */
     public Debugger getDebugger() {
+        if (debugger == null) {
+            throw new IllegalStateException("Event was disposed.");
+        }
         if (debugger instanceof Debugger) {
             return (Debugger) debugger;
         }
@@ -106,10 +109,13 @@ public final class ExecutionEvent {
      * and reverts by default to Continue mode.</li>
      * </ul>
      *
-     * @throws IllegalArgumentException if the specified number is {@code <= 0}
      * @since 0.9
      */
     public void prepareStepInto() {
         getDebugger().prepareStepInto(1);
+    }
+
+    void dispose() {
+        debugger = null;
     }
 }

--- a/truffle/com.oracle.truffle.sl.test/src/com/oracle/truffle/sl/test/SLDebugTest.java
+++ b/truffle/com.oracle.truffle.sl.test/src/com/oracle/truffle/sl/test/SLDebugTest.java
@@ -40,6 +40,8 @@
  */
 package com.oracle.truffle.sl.test;
 
+import com.oracle.truffle.api.CallTarget;
+import com.oracle.truffle.api.Truffle;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -58,11 +60,19 @@ import com.oracle.truffle.api.debug.ExecutionEvent;
 import com.oracle.truffle.api.debug.SuspendedEvent;
 import com.oracle.truffle.api.frame.FrameSlot;
 import com.oracle.truffle.api.frame.MaterializedFrame;
+import com.oracle.truffle.api.frame.VirtualFrame;
+import com.oracle.truffle.api.interop.ForeignAccess;
+import com.oracle.truffle.api.interop.ForeignAccess.Factory;
+import com.oracle.truffle.api.interop.ForeignAccess.Factory10;
+import com.oracle.truffle.api.interop.Message;
+import com.oracle.truffle.api.interop.TruffleObject;
+import com.oracle.truffle.api.nodes.RootNode;
 import com.oracle.truffle.api.source.LineLocation;
 import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.vm.EventConsumer;
 import com.oracle.truffle.api.vm.PolyglotEngine;
 import com.oracle.truffle.api.vm.PolyglotEngine.Value;
+import com.oracle.truffle.sl.SLLanguage;
 import org.junit.After;
 
 public class SLDebugTest {
@@ -118,6 +128,20 @@ public class SLDebugTest {
                         "  res = n * nMOFact;\n" +
                         "  return res;\n" + "}\n",
                         "factorial.sl").withMimeType(
+                        "application/x-sl");
+    }
+
+    private static Source createInteropComputation() {
+        return Source.fromText("function main() {\n" +
+                        "}\n" +
+                        "function interopFunction(notifyHandler) {\n" +
+                        "  executing = true;\n" +
+                        "  while (executing == true || executing) {\n" +
+                        "    executing = notifyHandler.isExecuting;\n" +
+                        "  }\n" +
+                        "  return executing;\n" +
+                        "}\n",
+                        "interopComputation.sl").withMimeType(
                         "application/x-sl");
     }
 
@@ -234,6 +258,66 @@ public class SLDebugTest {
         assertEquals("Factorial computed OK", 2, n.intValue());
     }
 
+    @Test
+    public void testPause() throws Throwable {
+        final Source interopComp = createInteropComputation();
+
+        run.addLast(new Runnable() {
+            @Override
+            public void run() {
+                assertNull(suspendedEvent);
+                assertNotNull(executionEvent);
+            }
+        });
+        engine.eval(interopComp);
+        assertExecutedOK();
+
+        final ExecNotifyHandler nh = new ExecNotifyHandler();
+
+        run.addLast(new Runnable() {
+            @Override
+            public void run() {
+                assertNull(suspendedEvent);
+                assertNotNull(executionEvent);
+                // Do pause after a while
+                new Thread() {
+                    @Override
+                    public void run() {
+                        nh.waitTillCanPause();
+                        debugger.pause();
+                    }
+                }.start();
+            }
+        });
+
+        run.addLast(new Runnable() {
+            @Override
+            public void run() {
+                // paused
+                assertNotNull(suspendedEvent);
+                int line = suspendedEvent.getNode().getSourceSection().getLineLocation().getLineNumber();
+                Assert.assertTrue("Unexpected line: " + line, 5 <= line && line <= 6);
+                final MaterializedFrame frame = suspendedEvent.getFrame();
+                String[] expectedIdentifiers = new String[]{"executing"};
+                for (String expectedIdentifier : expectedIdentifiers) {
+                    FrameSlot slot = frame.getFrameDescriptor().findFrameSlot(expectedIdentifier);
+                    Assert.assertNotNull(expectedIdentifier, slot);
+                }
+                Assert.assertTrue(debugger.isExecuting());
+                suspendedEvent.prepareContinue();
+                nh.pauseDone();
+            }
+        });
+
+        Value value = engine.findGlobalSymbol("interopFunction").execute(nh);
+
+        assertExecutedOK();
+        Assert.assertFalse(debugger.isExecuting());
+        Boolean n = value.as(Boolean.class);
+        assertNotNull(n);
+        assertTrue("Interop computation OK", !n.booleanValue());
+    }
+
     private void performWork() {
         try {
             if (ex == null && !run.isEmpty()) {
@@ -310,4 +394,138 @@ public class SLDebugTest {
         }
         assertTrue("Assuming all requests processed: " + run, run.isEmpty());
     }
+
+    private static class ExecNotifyHandler implements TruffleObject {
+
+        private final ExecNotifyHandlerForeign nhf = new ExecNotifyHandlerForeign(this);
+        private final ForeignAccess access = ForeignAccess.create(null, nhf);
+        private final Object pauseLock = new Object();
+        private boolean canPause;
+        private volatile boolean pauseDone;
+
+        @Override
+        public ForeignAccess getForeignAccess() {
+            return access;
+        }
+
+        private void waitTillCanPause() {
+            synchronized (pauseLock) {
+                while (!canPause) {
+                    try {
+                        pauseLock.wait();
+                    } catch (InterruptedException iex) {
+                    }
+                }
+            }
+        }
+
+        void setCanPause() {
+            synchronized (pauseLock) {
+                canPause = true;
+                pauseLock.notifyAll();
+            }
+        }
+
+        private void pauseDone() {
+            pauseDone = true;
+        }
+
+        boolean isPauseDone() {
+            return pauseDone;
+        }
+
+    }
+
+    private static class ExecNotifyHandlerForeign implements Factory10, Factory {
+
+        private final ExecNotifyHandler nh;
+
+        ExecNotifyHandlerForeign(ExecNotifyHandler nh) {
+            this.nh = nh;
+        }
+
+        @Override
+        public CallTarget accessIsNull() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public CallTarget accessIsExecutable() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public CallTarget accessIsBoxed() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public CallTarget accessHasSize() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public CallTarget accessGetSize() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public CallTarget accessUnbox() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public CallTarget accessRead() {
+            return Truffle.getRuntime().createCallTarget(new ExecNotifyReadNode(nh));
+        }
+
+        @Override
+        public CallTarget accessWrite() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public CallTarget accessExecute(int i) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public CallTarget accessInvoke(int i) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public CallTarget accessNew(int i) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public CallTarget accessMessage(Message msg) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        @Override
+        public boolean canHandle(TruffleObject to) {
+            return (to instanceof ExecNotifyHandler);
+        }
+
+    }
+
+    private static class ExecNotifyReadNode extends RootNode {
+
+        private final ExecNotifyHandler nh;
+
+        ExecNotifyReadNode(ExecNotifyHandler nh) {
+            super(SLLanguage.class, null, null);
+            this.nh = nh;
+        }
+
+        @Override
+        public Object execute(VirtualFrame vf) {
+            nh.setCanPause();
+            return !nh.isPauseDone();
+        }
+
+    }
+
 }


### PR DESCRIPTION
`ExecutionEvent` is made disposable. When outside of event handler process, all it's methods should throw `IllegalStateException`, according to javadoc. Also, I've deprecated `prepareContinue()` method, since continue is by default.
To add a "pause" functionality (which could be achieved by calling `ExecutionEvent.prepareStepInto()` any time during language execution, but this is not possible any more), `Debugger.pause()` method is introduced. Also, `Debugger.isExecuting()` is added so that we can test whether we can expect that `pause()` will actually pause anything.
Test is included.