### PR TITLE
Add merging of instrument files to building of truffle-debug.jar

### DIFF
--- a/mx.truffle/mx_truffle.py
+++ b/mx.truffle/mx_truffle.py
@@ -153,3 +153,5 @@ class TruffleArchiveParticipant:
 def mx_post_parse_cmd_line(opts):
     dist = mx.distribution('TRUFFLE_TEST')
     dist.set_archiveparticipant(TruffleArchiveParticipant())
+    dist = mx.distribution('TRUFFLE_DEBUG')
+    dist.set_archiveparticipant(TruffleArchiveParticipant())


### PR DESCRIPTION
The TruffleArchiveParticipant takes care of the merging but was not yet activated for the truffle-debug.jar

This fixes problems with instruments not being available.