### PR TITLE
Feature Request: `run` command for REPL/debugger and `PolyglotEngine.start()` 

### DIFF
--- a/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/REPLMessage.java
+++ b/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/REPLMessage.java
@@ -158,6 +158,8 @@ public final class REPLMessage {
     public static final String QUIT = "quit";
     /** @since 0.8 or earlier */
     public static final String REPEAT = "repeat";
+    /** @since 0.12 */
+    public static final String RUN = "run";
     /** @since 0.8 or earlier */
     public static final String SET = "set";
     /** @since 0.8 or earlier */

--- a/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/client/REPLRemoteCommand.java
+++ b/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/client/REPLRemoteCommand.java
@@ -146,6 +146,23 @@ public abstract class REPLRemoteCommand extends REPLCommand {
         }
     };
 
+    public static final REPLRemoteCommand RUN_CMD = new REPLRemoteCommand("run", null, "execute program based on command-line arguments") {
+
+        private final String[] help = {"run: executes program based on command-line arguments"};
+
+        @Override
+        public String[] getHelp() {
+            return help;
+        }
+
+        @Override
+        protected com.oracle.truffle.tools.debug.shell.REPLMessage createRequest(REPLClientContext context, String[] args) {
+            com.oracle.truffle.tools.debug.shell.REPLMessage request = new com.oracle.truffle.tools.debug.shell.REPLMessage();
+            request.put(com.oracle.truffle.tools.debug.shell.REPLMessage.OP, com.oracle.truffle.tools.debug.shell.REPLMessage.RUN);
+            return request;
+        }
+    };
+
     public static final REPLRemoteCommand CALL_CMD = new REPLRemoteCommand("call", null, "call a method/function") {
 
         private final String[] help = {"call <name> <args>: calls a function by name"};

--- a/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/client/SimpleREPLClient.java
+++ b/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/client/SimpleREPLClient.java
@@ -179,6 +179,7 @@ public class SimpleREPLClient implements com.oracle.truffle.tools.debug.shell.RE
         addCommand(REPLRemoteCommand.LOAD_CMD);
         addCommand(REPLRemoteCommand.LOAD_STEP_INTO_CMD);
         addCommand(quitCommand);
+        addCommand(REPLRemoteCommand.RUN_CMD);
         addCommand(setCommand);
         addCommand(REPLRemoteCommand.SET_LANG_CMD);
         addCommand(REPLRemoteCommand.STEP_INTO_CMD);

--- a/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/server/REPLHandler.java
+++ b/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/server/REPLHandler.java
@@ -281,6 +281,16 @@ public abstract class REPLHandler {
         }
     };
 
+    public static final REPLHandler RUN_HANDLER = new REPLHandler(com.oracle.truffle.tools.debug.shell.REPLMessage.RUN) {
+
+        @Override
+        com.oracle.truffle.tools.debug.shell.REPLMessage[] receive(com.oracle.truffle.tools.debug.shell.REPLMessage request, REPLServer replServer) {
+            replServer.run();
+            com.oracle.truffle.tools.debug.shell.REPLMessage reply = createReply();
+            return finishReplySucceeded(reply, "run completed");
+        }
+    };
+
     public static final REPLHandler CALL_HANDLER = new REPLHandler(com.oracle.truffle.tools.debug.shell.REPLMessage.CALL) {
 
         @Override

--- a/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/server/REPLServer.java
+++ b/truffle/com.oracle.truffle.tools.debug.shell/src/com/oracle/truffle/tools/debug/shell/server/REPLServer.java
@@ -55,6 +55,7 @@ import com.oracle.truffle.api.source.Source;
 import com.oracle.truffle.api.source.SourceSection;
 import com.oracle.truffle.api.vm.EventConsumer;
 import com.oracle.truffle.api.vm.PolyglotEngine;
+import com.oracle.truffle.api.vm.PolyglotEngine.Builder;
 import com.oracle.truffle.api.vm.PolyglotEngine.Language;
 import com.oracle.truffle.api.vm.PolyglotEngine.Value;
 import com.oracle.truffle.tools.debug.shell.client.SimpleREPLClient;
@@ -111,10 +112,14 @@ public final class REPLServer {
     private final Map<Integer, BreakpointInfo> breakpoints = new WeakHashMap<>();
 
     public REPLServer(SimpleREPLClient client) {
-        this.replClient = client;
-        this.engine = PolyglotEngine.newBuilder().onEvent(onHalted).onEvent(onExec).build();
-        this.engine.getInstruments().get(REPL_SERVER_INSTRUMENT).setEnabled(true);
+        this(client, PolyglotEngine.newBuilder());
+    }
 
+    public REPLServer(SimpleREPLClient client, Builder builder) {
+        this.replClient = client;
+        this.engine = builder.onEvent(onHalted).onEvent(onExec).build();
+        assert this.engine.getInstruments().get(REPL_SERVER_INSTRUMENT) != null : "No " + REPL_SERVER_INSTRUMENT + " instrument found";
+        this.engine.getInstruments().get(REPL_SERVER_INSTRUMENT).setEnabled(true);
         this.db = Debugger.find(this.engine);
         engineLanguages.addAll(engine.getLanguages().values());
 
@@ -178,6 +183,7 @@ public final class REPLServer {
         add(REPLHandler.INFO_HANDLER);
         add(REPLHandler.KILL_HANDLER);
         add(REPLHandler.LOAD_HANDLER);
+        add(REPLHandler.RUN_HANDLER);
         add(REPLHandler.SET_BREAK_CONDITION_HANDLER);
         add(REPLHandler.SET_LANGUAGE_HANDLER);
         add(REPLHandler.STEP_INTO_HANDLER);
@@ -201,6 +207,17 @@ public final class REPLServer {
 
     public LocationPrinter getLocationPrinter() {
         return locationPrinter;
+    }
+
+    void run() {
+        try {
+            Source source = Source.fromNamedText("", "START");
+            source = source.withMimeType(getLanguages().iterator().next().getMimeTypes().iterator().next());
+            engine.eval(source);
+        } catch (IOException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
     }
 
     void haltedAt(SuspendedEvent event) {


### PR DESCRIPTION
This is more of a feature request than an actual pull request. So, please consider the attached code merely as a sketch.

I would like to discuss two features:
 - a `run` command for the REPL/debugger
 - `PolyglotEngine.start()` to initialize execution based on the given engine configuration

### run

For users of GDB this might be familiar as `gdb --args foo bar baz` and then using `run` in GDB.

The idea is to execute a program as if it was started normally from the command line.

My main reason for this is to avoid having to revamp my whole language implementation to be compatible with the repl/debugger. I just want to use the debugger features.

What's currently missing to make this work is a way to initialize execution from the REPL.

### start

The Polyglot engine only offers an `eval()` but no `start()` method, which would be very helpful to trigger standard execution based on the configuration provided to the engine.
This means, it is not the polyglot engine anymore that needs to determine an initial file for evaluation. Instead, it is up to the language implementation to decide how to run code.
I wonder whether other languages also currently work around polyglot to realize that (/cc @lukasstadler @chrisseaton).

The way I currently work around this is by having a magic "START" source.

Ping: @mlvdv @jtulach 