### PR TITLE
SourceSectionFilter should also error on empty array of tags

### DIFF
--- a/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/SourceSectionFilter.java
+++ b/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/SourceSectionFilter.java
@@ -362,7 +362,7 @@ public final class SourceSectionFilter {
         }
 
         private void verifyNotNull(Object[] values) {
-            if (values == null) {
+            if (values == null || values.length == 0) {
                 throw new IllegalArgumentException("Given arguments must not be null.");
             }
             for (int i = 0; i < values.length; i++) {


### PR DESCRIPTION
In the `SourceSectionFilter`, `verifyNotNull(arr)` is used to make sure that not illegal arguments are used for filtering.

Currently, it checks for `null` values only, but ignores empty arrays. My understanding is that empty arrays are problematic here, because the `Not` filter merely negates the matching filter, which does not have any matches for empty arrays. So, I'd assume that empty arrays here are usually bugs, similar to passing `null`.

Ping: @chumer