### PR TITLE
Feature Request: Added isTaggedWith(Node,Class<?>) to Instrumenter

### DIFF
--- a/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/InstrumentationHandler.java
+++ b/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/InstrumentationHandler.java
@@ -616,6 +616,11 @@ final class InstrumentationHandler {
         }
 
         @Override
+        public boolean isTaggedWith(Node node, Class<?> tag) {
+            return ACCESSOR.isTaggedWith(node, tag);
+        }
+
+        @Override
         void verifyFilter(SourceSectionFilter filter) {
         }
 
@@ -713,6 +718,11 @@ final class InstrumentationHandler {
         @Override
         public Set<Class<?>> queryTags(Node node) {
             return queryTagsImpl(node, language.getClass());
+        }
+
+        @Override
+        public boolean isTaggedWith(Node node, Class<?> tag) {
+            return ACCESSOR.isTaggedWith(node, tag);
         }
 
         @Override

--- a/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/Instrumenter.java
+++ b/truffle/com.oracle.truffle.api.instrumentation/src/com/oracle/truffle/api/instrumentation/Instrumenter.java
@@ -75,4 +75,5 @@ public abstract class Instrumenter {
      */
     public abstract Set<Class<?>> queryTags(Node node);
 
+    public abstract boolean isTaggedWith(Node node, Class<?> tag);
 }


### PR DESCRIPTION
I would like to have `isTaggedWith()` on `Instrumenter`, similar to the already available `queryTags(Node)`.

For my dynamic metric tool, I am hooking up profiling objects on a group of related AST nodes.
I use `isTaggedWith()` during the setup to identify the child nodes tagged with the `Argument` tag so that I can hook them up with the profile object and record the values of the arguments separately from each other.

Note, I didn't add any tests/docs yet. First, I wanted to know whether this would be acceptable/useful.

Ping: @chumer @jtulach.