### PR TITLE
Feature Request: Allow 1:n mapping of PolyglotEngines to threads

### DIFF
--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/Accessor.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/impl/Accessor.java
@@ -269,6 +269,12 @@ public abstract class Accessor {
     private static Reference<Object> previousVM = new WeakReference<>(null);
     private static Assumption oneVM = Truffle.getRuntime().createAssumption();
 
+    public static void initializeThreadForUseWithPolglotEngine(Object /* because types are evil */ polyglotEngine) {
+        assert polyglotEngine != null;
+        assert CURRENT_VM.get() == null;
+        CURRENT_VM.set(polyglotEngine);
+    }
+
     @TruffleBoundary
     protected Closeable executionStart(Object vm, @SuppressWarnings("unused") int currentDepth, boolean debugger, Source s) {
         CompilerAsserts.neverPartOfCompilation("do not call Accessor.executionStart from compiled code");


### PR DESCRIPTION
This PR is mostly to document the need to support using a single polyglot engine with multiple threads.
Specifically, the requirement is to access 'services' like the instrumentation API correctly from other threads. My use case is an actor-based language that runs on a fork/join pool. Without the ability to either initialize/prepare threads for the use in the polyglot engine, for instance instrumentation is not properly initializing.

I currently do not have any requirement to use other polyglot engine services such as the language interop. But, it would be natural future work to have that working, too.

This might be superseded by other work: https://github.com/jtulach/truffle/commits/FasterExecute
But since I am not entirely sure about the intent and progress of that branch, I'd like to request 1:n support this way.

My hack provides an API that is called in a threads `run()` method after it starts, and allows me to initialize the thread for use with a know polyglot engine. However, this of course requires to keep the engine somewhere where I can access it globally. So it is certainly not a desirable general solution.

/cc @jtulach @chumer 