### PR TITLE
Document guideline to design TruffleLanguage with language-agnostic initialization.

### DIFF
--- a/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotEngine.java
+++ b/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotEngine.java
@@ -65,8 +65,8 @@ import com.oracle.truffle.api.source.Source;
 
 /**
  * Gate way into the world of {@link TruffleLanguage Truffle languages}. {@link #buildNew()
- * Instantiate} your own portal into the isolated, multi language system with all the registered
- * languages ready for your use. A {@link PolyglotEngine} runs inside of a <em>JVM</em>, there can
+ * Instantiate} your own portal into the isolated, multi-language system with all the registered
+ * languages ready for your use. A {@link PolyglotEngine} runs inside of a <em>JVM</em>. There can
  * however be multiple instances (some would say tenants) of {@link PolyglotEngine} running next to
  * each other in a single <em>JVM</em> with a complete mutual isolation. There is 1:N mapping
  * between <em>JVM</em> and {@link PolyglotEngine}.
@@ -80,10 +80,13 @@ import com.oracle.truffle.api.source.Source;
  * {@link PolyglotEngine} is in inter-operability between all Truffle languages. There is 1:N
  * mapping between {@link PolyglotEngine} and {@link TruffleLanguage Truffle language
  * implementations}.
+ *
+ * <h2>Usage</h2>
+ *
  * <p>
- * Use {@link #buildNew()} to create new isolated portal ready for execution of various languages.
- * All the languages in a single portal see each other exported global symbols and can cooperate.
- * Use {@link #buildNew()} multiple times to create different, isolated portal environment
+ * Use {@link #buildNew()} to create a new isolated portal ready for execution of various languages.
+ * All the languages in a single portal see each others exported global symbols and can cooperate.
+ * Use {@link #buildNew()} multiple times to create different, isolated environments that are
  * completely separated from each other.
  * <p>
  * Once instantiated use {@link #eval(com.oracle.truffle.api.source.Source)} with a reference to a
@@ -91,7 +94,12 @@ import com.oracle.truffle.api.source.Source;
  * {@link #eval(com.oracle.truffle.api.source.Source)}. Support for individual languages is
  * initialized on demand - e.g. once a file of certain MIME type is about to be processed, its
  * appropriate engine (if found), is initialized. Once an engine gets initialized, it remains so,
- * until the virtual machine isn't garbage collected.
+ * until the virtual machine is garbage collected.
+ * <p>
+ * A {@link com.oracle.truffle.api.TruffleLanguage} should be designed to be initializable and
+ * configurable in a generic way. Language-specific execution front-ends, for instance to emulate
+ * existing language implementations, should be realized externally to maintain a consistent and
+ * language-agnostic way of initializing {@link PolyglotEngine}.
  * <p>
  * The engine is single-threaded and tries to enforce that. It records the thread it has been
  * {@link Builder#build() created} by and checks that all subsequent calls are coming from the same
@@ -664,7 +672,7 @@ public class PolyglotEngine {
 
     /**
      * just to make javac happy.
-     * 
+     *
      * @param event
      */
     void dispatchSuspendedEvent(Object event) {
@@ -672,7 +680,7 @@ public class PolyglotEngine {
 
     /**
      * just to make javac happy.
-     * 
+     *
      * @param event
      */
     void dispatchExecutionEvent(Object event) {

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
@@ -43,12 +43,21 @@ import com.oracle.truffle.api.source.Source;
 import java.util.LinkedHashSet;
 
 /**
- * An entry point for everyone who wants to implement a Truffle based language. By providing an
+ * <p>
+ * An entry point for everyone who wants to implement a Truffle-based language. By providing an
  * implementation of this type and registering it using {@link Registration} annotation, your
  * language becomes accessible to users of the {@link com.oracle.truffle.api.vm.PolyglotEngine
  * polyglot execution engine} - all they will need to do is to include your JAR into their
  * application and all the Truffle goodies (multi-language support, multitenant hosting, debugging,
  * etc.) will be made available to them.
+ *
+ * <p>
+ * To ensure that a Truffle language can be used in a language-agnostic way, the implementation
+ * should be designed to decouple its configuration and initialization from language specifics as
+ * much as possible. One aspect of this is the initialization and start of execution via the
+ * {@link com.oracle.truffle.api.vm.PolyglotEngine}, which should be designed in a generic way.
+ * Language-specific entry points, for instance to emulate the command-line interface of an existing
+ * implementation, should be handled externally.
  *
  * @param <C> internal state of the language associated with every thread that is executing program
  *            {@link #parse(com.oracle.truffle.api.source.Source, com.oracle.truffle.api.nodes.Node, java.lang.String...)
@@ -271,8 +280,7 @@ public abstract class TruffleLanguage<C> {
     /**
      * Generates language specific textual representation of a value. Each language may have special
      * formating conventions - even primitive values may not follow the traditional Java formating
-     * rules. As such when
-     * {@link com.oracle.truffle.api.vm.PolyglotEngine.Value#as(java.lang.Class)
+     * rules. As such when {@link com.oracle.truffle.api.vm.PolyglotEngine.Value#as(java.lang.Class)
      * value.as(String.class)} is requested, it consults the language that produced the value by
      * calling this method. By default this method calls {@link Objects#toString(java.lang.Object)}.
      *


### PR DESCRIPTION
A TruffleLanguage should provide a language-agnostic interface to be able to be usable in multi-language environments. Language-specific front-ends or launchers, for instance, emulating existing implementations, should be realized externally to the PolyglotEngine.

This change fixes also minor issues in existing comments.