### PR TITLE
Feature Request: Enable debugging of multithreaded programs in a single PolyglotEngine

### DIFF
--- a/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/Debugger.java
+++ b/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/Debugger.java
@@ -274,8 +274,8 @@ public final class Debugger {
      * </ul>
      */
     @TruffleBoundary
-    void prepareContinue(int depth) {
-        getCurrentDebugContext().setAction(depth, new Continue());
+    void prepareContinue(DebugExecutionContext context, int depth) {
+        context.setAction(depth, new Continue());
     }
 
     /**
@@ -295,11 +295,11 @@ public final class Debugger {
      * @throws IllegalArgumentException if the specified number is {@code <= 0}
      */
     @TruffleBoundary
-    void prepareStepInto(int stepCount) {
+    void prepareStepInto(DebugExecutionContext context, int stepCount) {
         if (stepCount <= 0) {
             throw new IllegalArgumentException();
         }
-        getCurrentDebugContext().setAction(new StepInto(stepCount));
+        context.setAction(new StepInto(stepCount));
     }
 
     /**
@@ -308,7 +308,8 @@ public final class Debugger {
      * <li>User breakpoints are enabled.</li>
      * <li>Execution will continue until either:
      * <ol>
-     * <li>execution arrives at the nearest enclosing call site on the stack, <strong>or</strong></li>
+     * <li>execution arrives at the nearest enclosing call site on the stack, <strong>or</strong>
+     * </li>
      * <li>execution completes.</li>
      * </ol>
      * <li>StepOut mode persists only through one resumption, and reverts by default to Continue
@@ -316,8 +317,8 @@ public final class Debugger {
      * </ul>
      */
     @TruffleBoundary
-    void prepareStepOut() {
-        getCurrentDebugContext().setAction(new StepOut());
+    void prepareStepOut(DebugExecutionContext context) {
+        context.setAction(new StepOut());
     }
 
     /**
@@ -339,11 +340,11 @@ public final class Debugger {
      * @throws IllegalArgumentException if the specified number is {@code <= 0}
      */
     @TruffleBoundary
-    void prepareStepOver(int stepCount) {
+    void prepareStepOver(DebugExecutionContext context, int stepCount) {
         if (stepCount <= 0) {
             throw new IllegalArgumentException();
         }
-        getCurrentDebugContext().setAction(new StepOver(stepCount));
+        context.setAction(new StepOver(stepCount));
     }
 
     Instrumenter getInstrumenter() {
@@ -753,7 +754,7 @@ public final class Debugger {
      * <p>
      * Each instance is single-use.
      */
-    private final class DebugExecutionContext {
+    final class DebugExecutionContext {
 
         // Previous halted context in stack
         private final DebugExecutionContext predecessor;
@@ -797,6 +798,10 @@ public final class Debugger {
             if (TRACE) {
                 trace("NEW DEBUG CONTEXT level=" + level);
             }
+        }
+
+        public Debugger getDebugger() {
+            return Debugger.this;
         }
 
         /**
@@ -890,7 +895,7 @@ public final class Debugger {
 
             try {
                 // Pass control to the debug client with current execution suspended
-                SuspendedEvent event = new SuspendedEvent(Debugger.this, haltedEventContext.getInstrumentedNode(), haltedFrame, contextStack, recentWarnings);
+                SuspendedEvent event = new SuspendedEvent(getCurrentDebugContext(), haltedEventContext.getInstrumentedNode(), haltedFrame, contextStack, recentWarnings);
                 AccessorDebug.engineAccess().dispatchEvent(engine, event);
                 if (event.isKillPrepared()) {
                     trace("KILL");
@@ -967,7 +972,7 @@ public final class Debugger {
         // Push a new execution context onto stack
         DebugExecutionContext context = new DebugExecutionContext(execSource, getCurrentDebugContext(), depth);
         setCurrentDebugContext(context);
-        prepareContinue(depth);
+        prepareContinue(context, depth);
         context.trace("BEGIN EXECUTION");
     }
 
@@ -988,10 +993,10 @@ public final class Debugger {
      * @return
      * @throws IOException
      */
-    Object evalInContext(SuspendedEvent ev, String code, FrameInstance frameInstance) throws IOException {
+    Object evalInContext(DebugExecutionContext context, SuspendedEvent ev,
+                    String code, FrameInstance frameInstance) throws IOException {
         try {
             if (frameInstance == null) {
-                DebugExecutionContext context = getCurrentDebugContext();
                 return AccessorDebug.langs().evalInContext(engine, ev, code, context.haltedEventContext.getInstrumentedNode(), context.haltedFrame);
             } else {
                 return AccessorDebug.langs().evalInContext(engine, ev, code, frameInstance.getCallNode(), frameInstance.getFrame(FrameAccess.MATERIALIZE, true).materialize());

--- a/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/ExecutionEvent.java
+++ b/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/ExecutionEvent.java
@@ -38,13 +38,14 @@ import java.util.concurrent.Callable;
  * {@link IllegalStateException}. One can however obtain reference to {@link Debugger} instance and
  * keep it to further manipulate with debugging capabilities of the
  * {@link com.oracle.truffle.api.vm.PolyglotEngine} when it is running.
- * 
+ *
  * @since 0.9
  */
 @SuppressWarnings("javadoc")
 public final class ExecutionEvent {
     private Object debugger;
 
+    // TODO: this needs the execution context
     ExecutionEvent(Debugger debugger) {
         this.debugger = debugger;
     }
@@ -85,11 +86,13 @@ public final class ExecutionEvent {
      * <li>execution completes.</li>
      * </ol>
      * </ul>
-     * 
+     *
      * @since 0.9
      */
+    // TODO: this needs the execution context
     public void prepareContinue() {
-        getDebugger().prepareContinue(-1);
+        throw new RuntimeException("Not Yet Implemented. Needs execution context.");
+// getDebugger().prepareContinue(-1);
     }
 
     /**
@@ -109,7 +112,9 @@ public final class ExecutionEvent {
      * @throws IllegalArgumentException if the specified number is {@code <= 0}
      * @since 0.9
      */
+    // TODO: this needs the execution context
     public void prepareStepInto() {
-        getDebugger().prepareStepInto(1);
+        throw new RuntimeException("Not Yet Implemented. Needs execution context.");
+// getDebugger().prepareStepInto(1);
     }
 }

--- a/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/SuspendedEvent.java
+++ b/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/SuspendedEvent.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.List;
 
 import com.oracle.truffle.api.CompilerDirectives;
+import com.oracle.truffle.api.debug.Debugger.DebugExecutionContext;
 import com.oracle.truffle.api.frame.FrameInstance;
 import com.oracle.truffle.api.frame.MaterializedFrame;
 import com.oracle.truffle.api.nodes.Node;
@@ -59,15 +60,15 @@ public final class SuspendedEvent {
         }
     }
 
-    private final Debugger debugger;
+    private final DebugExecutionContext context;
     private final Node haltedNode;
     private final MaterializedFrame haltedFrame;
     private final List<FrameInstance> stack;
     private final List<String> warnings;
     private volatile boolean kill;
 
-    SuspendedEvent(Debugger debugger, Node haltedNode, MaterializedFrame haltedFrame, List<FrameInstance> stack, List<String> warnings) {
-        this.debugger = debugger;
+    SuspendedEvent(DebugExecutionContext context, Node haltedNode, MaterializedFrame haltedFrame, List<FrameInstance> stack, List<String> warnings) {
+        this.context = context;
         this.haltedNode = haltedNode;
         this.haltedFrame = haltedFrame;
         this.stack = stack;
@@ -87,7 +88,7 @@ public final class SuspendedEvent {
      * @since 0.9
      */
     public Debugger getDebugger() {
-        return debugger;
+        return context.getDebugger();
     }
 
     /** @since 0.9 */
@@ -133,7 +134,7 @@ public final class SuspendedEvent {
      * @since 0.9
      */
     public void prepareContinue() {
-        debugger.prepareContinue(-1);
+        context.getDebugger().prepareContinue(context, -1);
     }
 
     /**
@@ -143,7 +144,8 @@ public final class SuspendedEvent {
      * <li>User breakpoints are disabled.</li>
      * <li>Execution will continue until either:
      * <ol>
-     * <li>execution arrives at a node with the tag {@link Debugger#HALT_TAG}, <strong>or:</strong></li>
+     * <li>execution arrives at a node with the tag {@link Debugger#HALT_TAG}, <strong>or:</strong>
+     * </li>
      * <li>execution completes.</li>
      * </ol>
      * <li>StepInto mode persists only through one resumption (i.e. {@code stepIntoCount} steps),
@@ -155,7 +157,7 @@ public final class SuspendedEvent {
      * @since 0.9
      */
     public void prepareStepInto(int stepCount) {
-        debugger.prepareStepInto(stepCount);
+        context.getDebugger().prepareStepInto(context, stepCount);
     }
 
     /**
@@ -165,7 +167,8 @@ public final class SuspendedEvent {
      * <li>User breakpoints are enabled.</li>
      * <li>Execution will continue until either:
      * <ol>
-     * <li>execution arrives at the nearest enclosing call site on the stack, <strong>or</strong></li>
+     * <li>execution arrives at the nearest enclosing call site on the stack, <strong>or</strong>
+     * </li>
      * <li>execution completes.</li>
      * </ol>
      * <li>StepOut mode persists only through one resumption, and reverts by default to Continue
@@ -175,7 +178,7 @@ public final class SuspendedEvent {
      * @since 0.9
      */
     public void prepareStepOut() {
-        debugger.prepareStepOut();
+        context.getDebugger().prepareStepOut(context);
     }
 
     /**
@@ -199,7 +202,7 @@ public final class SuspendedEvent {
      * @since 0.9
      */
     public void prepareStepOver(int stepCount) {
-        debugger.prepareStepOver(stepCount);
+        context.getDebugger().prepareStepOver(context, stepCount);
     }
 
     /**
@@ -214,7 +217,7 @@ public final class SuspendedEvent {
      * @since 0.9
      */
     public Object eval(String code, FrameInstance frame) throws IOException {
-        return debugger.evalInContext(this, code, frame);
+        return context.getDebugger().evalInContext(context, this, code, frame);
     }
 
     /**


### PR DESCRIPTION
To support debugging in scenarios with 1 polyglot engine with n threads, we need separate DebugExecutionContext for each thread. This is a first step however. The REPL would need further features to properly support this. Furthermore, the other elements of the debugger infrastructure are likely to have thread-safety issues, to. So, this is only a very first step and should provide a foundation for further work.

Furthermore, this should be considered a hack. Each additional thread beside the main thread needs to call `executionStarted()` and `executionEnded()` appropriately, manually. This might not be desirable in the long run. However, in my case, the relevant code is highly performance sensitive: I need to initialize the debugger properly for each and every asynchronous message processed. This should be considered when designing an API. Messages are processed in separation, which means they likely need separate `DebugExecutionContexts` making `executionStarted()` and `executionEnded()` highly performance critical.

This is likely related to changes in https://github.com/jtulach/truffle/tree/FasterExecute

Next steps?
This should probably be discussed to figure out all things that need to be considered to make it work for real.

Ping: @mlvdv @chumer @jtulach 