### PR TITLE
Document guideline to design TruffleLanguage with language-agnostic initialization.

### DIFF
--- a/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotEngine.java
+++ b/truffle/com.oracle.truffle.api.vm/src/com/oracle/truffle/api/vm/PolyglotEngine.java
@@ -64,8 +64,8 @@ import com.oracle.truffle.api.source.Source;
 
 /**
  * Gate way into the world of {@link TruffleLanguage Truffle languages}. {@link #buildNew()
- * Instantiate} your own portal into the isolated, multi language system with all the registered
- * languages ready for your use. A {@link PolyglotEngine} runs inside of a <em>JVM</em>, there can
+ * Instantiate} your own portal into the isolated, multi-language system with all the registered
+ * languages ready for your use. A {@link PolyglotEngine} runs inside of a <em>JVM</em>. There can
  * however be multiple instances (some would say tenants) of {@link PolyglotEngine} running next to
  * each other in a single <em>JVM</em> with a complete mutual isolation. There is 1:N mapping
  * between <em>JVM</em> and {@link PolyglotEngine}.
@@ -79,10 +79,13 @@ import com.oracle.truffle.api.source.Source;
  * {@link PolyglotEngine} is in inter-operability between all Truffle languages. There is 1:N
  * mapping between {@link PolyglotEngine} and {@link TruffleLanguage Truffle language
  * implementations}.
+ *
+ * <h2>Usage</h2>
+ *
  * <p>
- * Use {@link #buildNew()} to create new isolated portal ready for execution of various languages.
- * All the languages in a single portal see each other exported global symbols and can cooperate.
- * Use {@link #buildNew()} multiple times to create different, isolated portal environment
+ * Use {@link #buildNew()} to create a new isolated portal ready for execution of various languages.
+ * All the languages in a single portal see each others exported global symbols and can cooperate.
+ * Use {@link #buildNew()} multiple times to create different, isolated environments that are
  * completely separated from each other.
  * <p>
  * Once instantiated use {@link #eval(com.oracle.truffle.api.source.Source)} with a reference to a
@@ -90,7 +93,15 @@ import com.oracle.truffle.api.source.Source;
  * {@link #eval(com.oracle.truffle.api.source.Source)}. Support for individual languages is
  * initialized on demand - e.g. once a file of certain MIME type is about to be processed, its
  * appropriate engine (if found), is initialized. Once an engine gets initialized, it remains so,
- * until the virtual machine isn't garbage collected.
+ * until the virtual machine is garbage collected.
+ * <p>
+ * For using a {@link TruffleLanguage language} with a custom setup or configuration, the necessary
+ * parameters should be communicated to the {@link PolyglotEngine} - either via
+ * {@link PolyglotEngine.Builder#config} as exposed by the language implementation or by evaluating
+ * appropriate "prelude" scripts via {@link PolyglotEngine.Language#eval}. Another possibility is to
+ * pre-register various {@link PolyglotEngine.Builder#globalSymbol global objects} and make them
+ * available to the {@link PolyglotEngine}. Configuration parameters are obtained for instance by
+ * parsing command line arguments.
  * <p>
  * The engine is single-threaded and tries to enforce that. It records the thread it has been
  * {@link Builder#build() created} by and checks that all subsequent calls are coming from the same
@@ -695,7 +706,7 @@ public class PolyglotEngine {
 
     /**
      * just to make javac happy.
-     * 
+     *
      * @param event
      */
     void dispatchSuspendedEvent(Object event) {
@@ -703,7 +714,7 @@ public class PolyglotEngine {
 
     /**
      * just to make javac happy.
-     * 
+     *
      * @param event
      */
     void dispatchExecutionEvent(Object event) {

--- a/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
+++ b/truffle/com.oracle.truffle.api/src/com/oracle/truffle/api/TruffleLanguage.java
@@ -43,12 +43,21 @@ import com.oracle.truffle.api.source.Source;
 import java.util.LinkedHashSet;
 
 /**
- * An entry point for everyone who wants to implement a Truffle based language. By providing an
+ * <p>
+ * An entry point for everyone who wants to implement a Truffle-based language. By providing an
  * implementation of this type and registering it using {@link Registration} annotation, your
  * language becomes accessible to users of the {@link com.oracle.truffle.api.vm.PolyglotEngine
  * polyglot execution engine} - all they will need to do is to include your JAR into their
  * application and all the Truffle goodies (multi-language support, multitenant hosting, debugging,
  * etc.) will be made available to them.
+ *
+ * <p>
+ * To ensure that a Truffle language can be used in a language-agnostic way, the implementation
+ * should be designed to decouple its configuration and initialization from language specifics as
+ * much as possible. One aspect of this is the initialization and start of execution via the
+ * {@link com.oracle.truffle.api.vm.PolyglotEngine}, which should be designed in a generic way.
+ * Language-specific entry points, for instance to emulate the command-line interface of an existing
+ * implementation, should be handled externally.
  *
  * @param <C> internal state of the language associated with every thread that is executing program
  *            {@link #parse(com.oracle.truffle.api.source.Source, com.oracle.truffle.api.nodes.Node, java.lang.String...)


### PR DESCRIPTION
A TruffleLanguage should provide a language-agnostic interface to be able to be usable in multi-language environments. Language-specific front-ends or launchers, for instance, emulating existing implementations, should be realized externally to the PolyglotEngine.

This change fixes also minor issues in existing comments.

The tests on Travis still fail, because it seems to use the Eclipse 4.5 formatter.
Locally, it passes with using Eclipse 4.4 and making sure `ECLIPSE_EXE` is set.

Recreated the PR. Seems like force-push to a branch after the original PR is closed is problematic.