### PR TITLE
Fix ecj and eclipse jdk URL for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ before_install:
   - pylint --version
 install:
   - git clone https://github.com/graalvm/mx.git
-  - wget http://ftp.halifax.rwth-aachen.de/eclipse//eclipse/downloads/drops4/R-4.5.1-201509040015/ecj-4.5.1.jar
-  - mv ecj-4.5.1.jar mx/ecj.jar
+  - wget http://archive.eclipse.org/eclipse/downloads/drops4/R-4.5.2-201602121500/ecj-4.5.2.jar
+  - mv ecj-4.5.2.jar mx/ecj.jar
   - export JDT=mx/ecj.jar
-  - wget https://lafo.ssw.uni-linz.ac.at/slavefiles/gate/eclipse-jdk8-linux-x86_64.tar.gz
+  - wget http://lafo.ssw.uni-linz.ac.at/sulong-deps/eclipse-jdk8-linux-x86_64.tar.gz
   - tar -xvzf eclipse-jdk8-linux-x86_64.tar.gz
   - export ECLIPSE_EXE=eclipse/eclipse
 script:


### PR DESCRIPTION
This also updates from 4.5.1 to 4.5.2
