### PR TITLE
Added source-section-based breakpoints

### DIFF
--- a/truffle/com.oracle.truffle.api.debug.test/src/com/oracle/truffle/api/debug/test/BreakpointTest.java
+++ b/truffle/com.oracle.truffle.api.debug.test/src/com/oracle/truffle/api/debug/test/BreakpointTest.java
@@ -36,6 +36,8 @@ import org.junit.Test;
 import com.oracle.truffle.api.debug.Breakpoint;
 import com.oracle.truffle.api.debug.Debugger;
 import com.oracle.truffle.api.source.Source;
+import com.oracle.truffle.api.source.SourceSection;
+
 import java.io.File;
 
 public class BreakpointTest extends AbstractDebugTest {
@@ -82,6 +84,28 @@ public class BreakpointTest extends AbstractDebugTest {
         }).resume();
         expectSuspendedEvent().checkState(3, true, "STATEMENT\n  ").resume();   // FIXME-SourceSection
         getEngine().eval(test2);
+        assertExecutedOK();
+    }
+
+    @Test
+    public void testBreakpointOnSourceSection() throws Throwable {
+        Source test = TestSource.createCall("testBreakOnSourceSection");
+        final SourceSection section = test.createSection(null, 3, 5, 12);
+        final Debugger debugger = getDebugger();
+        expectExecutionEvent().stepInto();
+        expectSuspendedEvent().checkState(5, true, "STATEMENT").run(new Runnable() {
+
+            public void run() {
+                try {
+                    debugger.setSourceSectionBreakpoint(0, section, false);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+
+            }
+        }).resume();
+        expectSuspendedEvent().checkState(3, true, "STATEMENT\n  ").resume();   // FIXME-SourceSection
+        getEngine().eval(test);
         assertExecutedOK();
     }
 

--- a/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/Debugger.java
+++ b/truffle/com.oracle.truffle.api.debug/src/com/oracle/truffle/api/debug/Debugger.java
@@ -230,6 +230,25 @@ public final class Debugger {
     private DebugExecutionContext currentDebugContext;
 
     /**
+     * Sets a breakpoint to halt at a source section.
+     * <p>
+     * If a breakpoint <em>condition</em> is applied to the breakpoint, then the condition will be
+     * assumed to be in the same language as the code location where attached.
+     *
+     *
+     * @param ignoreCount number of hits to ignore before halting
+     * @param sourceSection where to set the breakpoint
+     * @param oneShot breakpoint disposes itself after fist hit, if {@code true}
+     * @return a new breakpoint, initially enabled
+     * @throws IOException if the breakpoint can not be set.
+     * @since TBD
+     */
+    @TruffleBoundary
+    public Breakpoint setSourceSectionBreakpoint(int ignoreCount, SourceSection sourceSection, boolean oneShot) throws IOException {
+        return breakpoints.create(ignoreCount, sourceSection, oneShot);
+    }
+
+    /**
      * Sets a breakpoint to halt at a source line.
      * <p>
      * If a breakpoint <em>condition</em> is applied to the breakpoint, then the condition will be


### PR DESCRIPTION
This complements line-based breakpoints by allowing a more precise selection of where to interrupt execution.

The implementation uses source section equality (with the unchanged filter mechanism) to identify where the breakpoint applies.

TODO: update `@since` for corresponding release

NOTE: I'm also thinking about adding another filter option by tags so that the source section and the tag needs to match.

/cc @jtulach @mlvdv 