### PR TITLE
Make generated Interop classes public

### DIFF
--- a/truffle/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/interop/ForeignAccessFactoryGenerator.java
+++ b/truffle/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/interop/ForeignAccessFactoryGenerator.java
@@ -70,7 +70,7 @@ public final class ForeignAccessFactoryGenerator {
         Writer w = factoryFile.openWriter();
         w.append("package ").append(packageName).append(";\n");
         appendImports(w);
-        w.append("final class ").append(simpleClassName);
+        w.append("public final class ").append(simpleClassName);
         w.append(" implements Factory10, Factory {\n");
 
         appendSingletonAndGetter(w);


### PR DESCRIPTION
The classes generated by the other DSL processors are public.
This change makes the Interop DSL consistent with that and avoids requiring strange workarounds or putting undesirable restrictions on how to divide code into packages.
