### PR TITLE
Remove JRuby downstream test from Travis checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,7 @@ env:
   - TEST_COMMAND='mx/mx canonicalizeprojects'
   - TEST_COMMAND='mx/mx checkstyle'
   - TEST_COMMAND='sh .travis.sigtest.sh'
-  - TEST_COMMAND='mx/mx testdownstream'
 matrix:
     include:
       - env: TEST_COMMAND='mx/mx -v build'
         jdk: oraclejdk7
-    allow_failures:
-    - env: TEST_COMMAND='mx/mx testdownstream'


### PR DESCRIPTION
The downstream tests do not seem to be maintained, and are likely not very helpful.

To avoid extra maintenance overhead, we might want to remove it from the Travis tests.

/cc @eregon @chrisseaton