### PR TITLE
Fixes incorrect argument index in createNode(..)

### DIFF
--- a/truffle/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/generator/NodeFactoryFactory.java
+++ b/truffle/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/generator/NodeFactoryFactory.java
@@ -137,6 +137,7 @@ class NodeFactoryFactory {
             int index = 0;
             for (VariableElement param : element.getParameters()) {
                 if (ElementUtils.isObject(param.asType())) {
+                    index++;
                     continue;
                 }
                 builder.string(" && ");


### PR DESCRIPTION
This fixes issue #205.

The problem was that when there is an `Object` argument, the `index` would not be properly increased.

I didn't see any tests related to the annotation processor, so, not sure how that is supposed to be verified.
