### PR TITLE
Remove incorrect cast on method calls (fixes #210)

### DIFF
--- a/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/ExecuteMethodTest.java
+++ b/truffle/com.oracle.truffle.api.dsl.test/src/com/oracle/truffle/api/dsl/test/ExecuteMethodTest.java
@@ -436,4 +436,24 @@ public class ExecuteMethodTest {
         }
     }
 
+    @TypeSystem
+    @DSLOptions(defaultGenerator = DSLOptions.DSLGenerator.FLAT)
+    static class ObjectArrayTypes {
+    }
+
+    @TypeSystemReference(ObjectArrayTypes.class)
+    abstract static class ObjectArrayAsArg extends Node {
+        @Children protected final ObjectArrayAsArg[] args;
+
+        ObjectArrayAsArg() {
+            args = new ObjectArrayAsArg[0];
+        }
+
+        abstract Object execute(VirtualFrame frame, Object[] a);
+
+        @Specialization
+        Object test(Object[] a) {
+            return a;
+        }
+    }
 }

--- a/truffle/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/generator/FlatNodeGenFactory.java
+++ b/truffle/com.oracle.truffle.dsl.processor/src/com/oracle/truffle/dsl/processor/generator/FlatNodeGenFactory.java
@@ -3643,10 +3643,6 @@ public class FlatNodeGenFactory {
                 LocalVariable var = getValue(execution);
                 if (var != null) {
                     builder.startGroup();
-                    if (executions.size() == 1 && ElementUtils.typeEquals(var.getTypeMirror(), factory.getType(Object[].class))) {
-                        // if the current type is Object[] do not use varargs for a single argument
-                        builder.string("(Object) ");
-                    }
                     builder.tree(var.createReference());
                     builder.end();
                 }


### PR DESCRIPTION
This adds a test and fix for a problem with having `Object[]` arguments to execute methods reported in #210.

The cast to `Object` that was inserted does not seem necessary anymore.